### PR TITLE
chore: add developer docker compose setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+POSTGRES_DB=theagentforum
+POSTGRES_USER=theagentforum
+POSTGRES_PASSWORD=theagentforum
+POSTGRES_PORT=5432
+
+PGADMIN_PORT=5050
+PGADMIN_DEFAULT_EMAIL=dev@theagentforum.local
+PGADMIN_DEFAULT_PASSWORD=devpassword

--- a/README.md
+++ b/README.md
@@ -184,6 +184,10 @@ Right now this repo is the starting point for exploring:
 - data model
 - MVP scope
 
+## Local development
+
+For a quick local Postgres database, see [docs/DEV_SETUP.md](docs/DEV_SETUP.md).
+
 ## Name
 
 Working project name: **TheAgentForum**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,44 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: theagentforum-postgres
+    restart: unless-stopped
+    ports:
+      - "${POSTGRES_PORT:-5432}:5432"
+    environment:
+      POSTGRES_DB: "${POSTGRES_DB:-theagentforum}"
+      POSTGRES_USER: "${POSTGRES_USER:-theagentforum}"
+      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:-theagentforum}"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "pg_isready -U ${POSTGRES_USER:-theagentforum} -d ${POSTGRES_DB:-theagentforum}",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+  pgadmin:
+    image: dpage/pgadmin4:8
+    container_name: theagentforum-pgadmin
+    restart: unless-stopped
+    profiles:
+      - admin
+    depends_on:
+      postgres:
+        condition: service_healthy
+    ports:
+      - "${PGADMIN_PORT:-5050}:80"
+    environment:
+      PGADMIN_DEFAULT_EMAIL: "${PGADMIN_DEFAULT_EMAIL:-dev@theagentforum.local}"
+      PGADMIN_DEFAULT_PASSWORD: "${PGADMIN_DEFAULT_PASSWORD:-devpassword}"
+    volumes:
+      - pgadmin_data:/var/lib/pgadmin
+
+volumes:
+  postgres_data:
+  pgadmin_data:

--- a/docs/DEV_SETUP.md
+++ b/docs/DEV_SETUP.md
@@ -1,0 +1,104 @@
+# Developer Setup
+
+This repository includes a small Docker Compose setup for local development infrastructure.
+
+Today it is intentionally limited to:
+
+- Postgres for a quick local database
+- optional pgAdmin for browsing data locally
+
+It is not meant for production deployment.
+
+## Prerequisites
+
+- Docker Engine with the Compose plugin (`docker compose`)
+
+## Quick start
+
+1. Copy the example environment file if you want custom local settings:
+
+   ```bash
+   cp .env.example .env
+   ```
+
+2. Start Postgres:
+
+   ```bash
+   docker compose up -d
+   ```
+
+3. Verify the container is healthy:
+
+   ```bash
+   docker compose ps
+   ```
+
+4. Stop it when you are done:
+
+   ```bash
+   docker compose down
+   ```
+
+The database data is stored in the named `postgres_data` volume, so it survives container restarts.
+
+## Default connection settings
+
+- host: `localhost`
+- port: `5432`
+- database: `theagentforum`
+- username: `theagentforum`
+- password: `theagentforum`
+
+Example connection URL:
+
+```text
+postgresql://theagentforum:theagentforum@localhost:5432/theagentforum
+```
+
+## Environment variables
+
+The compose file uses simple local defaults and can be overridden through `.env`.
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `POSTGRES_DB` | `theagentforum` | Local database name |
+| `POSTGRES_USER` | `theagentforum` | Local database user |
+| `POSTGRES_PASSWORD` | `theagentforum` | Local database password |
+| `POSTGRES_PORT` | `5432` | Host port mapped to Postgres |
+| `PGADMIN_PORT` | `5050` | Host port for pgAdmin |
+| `PGADMIN_DEFAULT_EMAIL` | `dev@theagentforum.local` | pgAdmin login |
+| `PGADMIN_DEFAULT_PASSWORD` | `devpassword` | pgAdmin password |
+
+## Optional pgAdmin
+
+pgAdmin is kept out of the default startup path. Run it only if you want a local database UI:
+
+```bash
+docker compose --profile admin up -d
+```
+
+Then open `http://localhost:5050`.
+
+To connect pgAdmin to the bundled Postgres container, use:
+
+- host: `postgres`
+- port: `5432`
+- username: value of `POSTGRES_USER`
+- password: value of `POSTGRES_PASSWORD`
+- database: value of `POSTGRES_DB`
+
+Its state is stored in the named `pgadmin_data` volume.
+
+## Resetting local data
+
+If you want to remove the local database contents entirely:
+
+```bash
+docker compose down -v
+```
+
+Use that only when you intentionally want a fresh local database.
+
+## Future extension
+
+This setup is deliberately narrow. Later, the repo can add API or web service containers once those services are stable enough to benefit from containerized local development.


### PR DESCRIPTION
## Summary
- add a simple local developer docker compose setup
- add .env example for local database defaults
- document local DB usage in DEV_SETUP
- keep this scoped to boring developer infrastructure only

## Notes
- Postgres is the primary local service
- app containers can come later once API/web wiring is real
