### PR TITLE
feat: add passkey-first auth MVP slice

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ A realistic first MVP might support:
 - creating questions
 - posting answers
 - marking accepted answers
+- passkey-first registration sessions and pairing sessions
 - basic search
 - simple API flows
 - lightweight web browsing UI later
@@ -218,6 +219,17 @@ That means browser clients (including phones) do not need to call `localhost` di
 
 For a compose deployment, keep:
 - `VITE_API_BASE_URL=/api`
+
+## Auth slice
+
+The repo now includes an MVP auth review slice aligned with issue `#17`:
+
+- passkey-first registration session start
+- registration status polling
+- pairing code redemption
+- no third-party auth in v1
+
+See [docs/AUTH.md](docs/AUTH.md) and [docs/API.md](docs/API.md) for the current flow and the explicit TODO boundary for full WebAuthn ceremony.
 - `API_PROXY_TARGET=http://api:3001`
 
 ## Name

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,16 +1,24 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type {
   Actor,
+  CompleteRegistrationVerificationInput,
   CreateAnswerInput,
   CreateQuestionInput,
+  RedeemPairingInput,
+  StartRegistrationInput,
 } from "@theagentforum/core";
+import type { AuthStore } from "./auth-store";
 import type { QuestionStore } from "./question-store";
 
 interface CreateAppOptions {
   corsAllowOrigin?: string;
 }
 
-export function createApp(store: QuestionStore, options: CreateAppOptions = {}) {
+export function createApp(
+  questionStore: QuestionStore,
+  authStore: AuthStore,
+  options: CreateAppOptions = {},
+) {
   const corsAllowOrigin = options.corsAllowOrigin ?? "*";
   const corsHeaders = {
     "access-control-allow-origin": corsAllowOrigin,
@@ -23,7 +31,7 @@ export function createApp(store: QuestionStore, options: CreateAppOptions = {}) 
     res: ServerResponse,
   ): Promise<void> {
     try {
-      await routeRequest(store, req, res, corsHeaders);
+      await routeRequest(questionStore, authStore, req, res, corsHeaders);
     } catch (error) {
       if (isHttpError(error)) {
         sendError(res, corsHeaders, error.statusCode, error.code, error.message);
@@ -43,7 +51,8 @@ export function createApp(store: QuestionStore, options: CreateAppOptions = {}) 
 }
 
 async function routeRequest(
-  store: QuestionStore,
+  questionStore: QuestionStore,
+  authStore: AuthStore,
   req: IncomingMessage,
   res: ServerResponse,
   corsHeaders: Record<string, string>,
@@ -76,7 +85,7 @@ async function routeRequest(
   if (method === "GET" && path === "/questions") {
     sendJson(res, corsHeaders, 200, {
       ok: true,
-      data: await store.listQuestions(),
+      data: await questionStore.listQuestions(),
     });
     return;
   }
@@ -84,7 +93,7 @@ async function routeRequest(
   if (method === "POST" && path === "/questions") {
     const payload = await readJsonBody(req);
     const input = parseCreateQuestionInput(payload);
-    const question = await store.createQuestion(input);
+    const question = await questionStore.createQuestion(input);
 
     sendJson(res, corsHeaders, 201, {
       ok: true,
@@ -101,7 +110,7 @@ async function routeRequest(
   const questionMatch = matchPath(path, /^\/questions\/([^/]+)$/);
 
   if (method === "GET" && questionMatch) {
-    const thread = await store.getQuestionThread(questionMatch[1]);
+    const thread = await questionStore.getQuestionThread(questionMatch[1]);
 
     if (!thread) {
       sendError(res, corsHeaders, 404, "question_not_found", "Question not found.");
@@ -120,7 +129,7 @@ async function routeRequest(
   if (method === "POST" && answersMatch) {
     const payload = await readJsonBody(req);
     const input = parseCreateAnswerInput(payload);
-    const thread = await store.createAnswer(answersMatch[1], input);
+    const thread = await questionStore.createAnswer(answersMatch[1], input);
 
     if (!thread) {
       sendError(res, corsHeaders, 404, "question_not_found", "Question not found.");
@@ -139,10 +148,10 @@ async function routeRequest(
   if (method === "POST" && acceptMatch) {
     const questionId = acceptMatch[1];
     const answerId = acceptMatch[2];
-    const thread = await store.acceptAnswer(questionId, answerId);
+    const thread = await questionStore.acceptAnswer(questionId, answerId);
 
     if (!thread) {
-      const questionExists = await store.getQuestionThread(questionId);
+      const questionExists = await questionStore.getQuestionThread(questionId);
 
       if (!questionExists) {
         sendError(res, corsHeaders, 404, "question_not_found", "Question not found.");
@@ -167,6 +176,102 @@ async function routeRequest(
   }
 
   if (path.startsWith("/questions/")) {
+    sendError(res, corsHeaders, 405, "method_not_allowed", "Method not allowed.");
+    return;
+  }
+
+  if (method === "POST" && path === "/auth/registrations/start") {
+    const payload = await readJsonBody(req);
+    const input = parseStartRegistrationInput(payload);
+
+    sendJson(res, corsHeaders, 201, {
+      ok: true,
+      data: await authStore.startRegistration(input),
+    });
+    return;
+  }
+
+  const registrationMatch = matchPath(path, /^\/auth\/registrations\/([^/]+)$/);
+
+  if (method === "GET" && registrationMatch) {
+    const session = await authStore.getRegistrationSession(registrationMatch[1]);
+
+    if (!session) {
+      sendError(
+        res,
+        corsHeaders,
+        404,
+        "registration_session_not_found",
+        "Registration session not found.",
+      );
+      return;
+    }
+
+    sendJson(res, corsHeaders, 200, {
+      ok: true,
+      data: session,
+    });
+    return;
+  }
+
+  const verifyMatch = matchPath(path, /^\/auth\/registrations\/([^/]+)\/verify$/);
+
+  if (method === "POST" && verifyMatch) {
+    const payload = await readJsonBody(req);
+    const input = parseCompleteRegistrationVerificationInput(payload);
+    const session = await authStore.completeRegistrationVerification(verifyMatch[1], input);
+
+    if (!session) {
+      sendError(
+        res,
+        corsHeaders,
+        404,
+        "registration_session_not_found",
+        "Registration session not found.",
+      );
+      return;
+    }
+
+    sendJson(res, corsHeaders, 200, {
+      ok: true,
+      data: session,
+    });
+    return;
+  }
+
+  if (method === "POST" && path === "/auth/pairings/redeem") {
+    const payload = await readJsonBody(req);
+    const input = parseRedeemPairingInput(payload);
+    const session = await authStore.redeemPairing(input);
+
+    if (!session) {
+      sendError(res, corsHeaders, 404, "pairing_session_not_found", "Pairing session not found.");
+      return;
+    }
+
+    if (session.pairing.status !== "paired") {
+      sendError(
+        res,
+        corsHeaders,
+        409,
+        "pairing_not_ready",
+        "Pairing session is not ready to redeem.",
+        {
+          registrationStatus: session.status,
+          pairingStatus: session.pairing.status,
+        },
+      );
+      return;
+    }
+
+    sendJson(res, corsHeaders, 200, {
+      ok: true,
+      data: session,
+    });
+    return;
+  }
+
+  if (path.startsWith("/auth/")) {
     sendError(res, corsHeaders, 405, "method_not_allowed", "Method not allowed.");
     return;
   }
@@ -252,6 +357,34 @@ function parseCreateAnswerInput(payload: unknown): CreateAnswerInput {
   };
 }
 
+function parseStartRegistrationInput(payload: unknown): StartRegistrationInput {
+  const input = asRecord(payload, "Request body must be an object.");
+
+  return {
+    handle: readRequiredString(input.handle, "handle"),
+    displayName: readOptionalString(input.displayName, "displayName"),
+  };
+}
+
+function parseCompleteRegistrationVerificationInput(
+  payload: unknown,
+): CompleteRegistrationVerificationInput {
+  const input = asRecord(payload, "Request body must be an object.");
+
+  return {
+    passkeyLabel: readRequiredString(input.passkeyLabel, "passkeyLabel"),
+  };
+}
+
+function parseRedeemPairingInput(payload: unknown): RedeemPairingInput {
+  const input = asRecord(payload, "Request body must be an object.");
+
+  return {
+    pairingCode: readRequiredString(input.pairingCode, "pairingCode"),
+    deviceLabel: readRequiredString(input.deviceLabel, "deviceLabel"),
+  };
+}
+
 function parseActor(value: unknown): Actor {
   const actor = asRecord(value, "author must be an object.");
   const displayName = actor.displayName;
@@ -292,6 +425,14 @@ function readRequiredString(value: unknown, fieldName: string): string {
   }
 
   return value.trim();
+}
+
+function readOptionalString(value: unknown, fieldName: string): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  return readRequiredString(value, fieldName);
 }
 
 function asRecord(value: unknown, message: string): Record<string, unknown> {

--- a/apps/api/src/auth-store.ts
+++ b/apps/api/src/auth-store.ts
@@ -1,0 +1,16 @@
+import type {
+  CompleteRegistrationVerificationInput,
+  RedeemPairingInput,
+  RegistrationSession,
+  StartRegistrationInput,
+} from "@theagentforum/core";
+
+export interface AuthStore {
+  startRegistration(input: StartRegistrationInput): Promise<RegistrationSession>;
+  getRegistrationSession(registrationSessionId: string): Promise<RegistrationSession | null>;
+  completeRegistrationVerification(
+    registrationSessionId: string,
+    input: CompleteRegistrationVerificationInput,
+  ): Promise<RegistrationSession | null>;
+  redeemPairing(input: RedeemPairingInput): Promise<RegistrationSession | null>;
+}

--- a/apps/api/src/http.test.ts
+++ b/apps/api/src/http.test.ts
@@ -1,7 +1,8 @@
 import assert from "node:assert/strict";
-import { createServer } from "node:http";
-import { afterEach, describe, it } from "node:test";
+import { Readable } from "node:stream";
+import { describe, it } from "node:test";
 import { createApp } from "./app";
+import { createInMemoryAuthStore } from "./memory-auth-store";
 import { createInMemoryQuestionStore } from "./memory-question-store";
 
 const humanAuthor = {
@@ -16,20 +17,11 @@ const agentAuthor = {
   handle: "pixel",
 };
 
-const servers = new Set<ReturnType<typeof createServer>>();
-
-afterEach(async () => {
-  await Promise.all(
-    Array.from(servers, (server) => closeServer(server)),
-  );
-  servers.clear();
-});
-
 describe("HTTP API", () => {
   it("serves the full question -> answer -> accept flow", async () => {
-    const baseUrl = await startTestServer();
+    const app = createTestApp();
 
-    const createQuestionResponse = await requestJson(baseUrl, "/questions", {
+    const createQuestionResponse = await requestJson(app, "/questions", {
       method: "POST",
       body: {
         title: "What should the first API support?",
@@ -42,37 +34,29 @@ describe("HTTP API", () => {
     const question = createQuestionResponse.body.data;
     assert.equal(question.status, "open");
 
-    const firstAnswerResponse = await requestJson(
-      baseUrl,
-      `/questions/${question.id}/answers`,
-      {
-        method: "POST",
-        body: {
-          body: "Ship the smallest possible workflow first.",
-          author: agentAuthor,
-        },
+    const firstAnswerResponse = await requestJson(app, `/questions/${question.id}/answers`, {
+      method: "POST",
+      body: {
+        body: "Ship the smallest possible workflow first.",
+        author: agentAuthor,
       },
-    );
+    });
     assert.equal(firstAnswerResponse.status, 201);
 
     await sleep(2);
 
-    const secondAnswerResponse = await requestJson(
-      baseUrl,
-      `/questions/${question.id}/answers`,
-      {
-        method: "POST",
-        body: {
-          body: "Add acceptance before reputation.",
-          author: humanAuthor,
-        },
+    const secondAnswerResponse = await requestJson(app, `/questions/${question.id}/answers`, {
+      method: "POST",
+      body: {
+        body: "Add acceptance before reputation.",
+        author: humanAuthor,
       },
-    );
+    });
     assert.equal(secondAnswerResponse.status, 201);
 
     const answerToAccept = secondAnswerResponse.body.data.answers[1];
     const acceptResponse = await requestJson(
-      baseUrl,
+      app,
       `/questions/${question.id}/accept/${answerToAccept.id}`,
       {
         method: "POST",
@@ -88,15 +72,15 @@ describe("HTTP API", () => {
     assert.equal(acceptResponse.body.data.answers[0].id, answerToAccept.id);
     assert.ok(acceptResponse.body.data.answers[0].acceptedAt);
 
-    const threadResponse = await requestJson(baseUrl, `/questions/${question.id}`);
+    const threadResponse = await requestJson(app, `/questions/${question.id}`);
     assert.equal(threadResponse.status, 200);
     assert.equal(threadResponse.body.data.answers[0].id, answerToAccept.id);
   });
 
   it("returns validation errors for invalid question payloads", async () => {
-    const baseUrl = await startTestServer();
+    const app = createTestApp();
 
-    const response = await requestJson(baseUrl, "/questions", {
+    const response = await requestJson(app, "/questions", {
       method: "POST",
       body: {
         title: "",
@@ -112,9 +96,9 @@ describe("HTTP API", () => {
   });
 
   it("returns answer_not_found when accepting an answer outside the question", async () => {
-    const baseUrl = await startTestServer();
+    const app = createTestApp();
 
-    const createQuestionResponse = await requestJson(baseUrl, "/questions", {
+    const createQuestionResponse = await requestJson(app, "/questions", {
       method: "POST",
       body: {
         title: "Where should acceptance live?",
@@ -124,70 +108,153 @@ describe("HTTP API", () => {
     });
 
     const questionId = createQuestionResponse.body.data.id;
-    const response = await requestJson(
-      baseUrl,
-      `/questions/${questionId}/accept/a-404`,
-      {
-        method: "POST",
-      },
-    );
+    const response = await requestJson(app, `/questions/${questionId}/accept/a-404`, {
+      method: "POST",
+    });
 
     assert.equal(response.status, 404);
     assert.equal(response.body.ok, false);
     assert.equal(response.body.error.code, "answer_not_found");
   });
+
+  it("serves the passkey-first registration -> verify -> pair flow", async () => {
+    const app = createTestApp();
+
+    const started = await requestJson(app, "/auth/registrations/start", {
+      method: "POST",
+      body: {
+        handle: "felix796",
+        displayName: "Felix",
+      },
+    });
+
+    assert.equal(started.status, 201);
+    assert.equal(started.body.data.status, "awaiting_verification");
+    assert.equal(started.body.data.pairing.status, "waiting_for_verification");
+    assert.match(started.body.data.challenge, /^[A-Za-z0-9_-]+$/);
+
+    const registrationId = started.body.data.id;
+    const pairingCode = started.body.data.pairing.code;
+
+    const pendingRedeem = await requestJson(app, "/auth/pairings/redeem", {
+      method: "POST",
+      body: {
+        pairingCode,
+        deviceLabel: "pixel-bot",
+      },
+    });
+
+    assert.equal(pendingRedeem.status, 409);
+    assert.equal(pendingRedeem.body.error.code, "pairing_not_ready");
+
+    const verified = await requestJson(app, `/auth/registrations/${registrationId}/verify`, {
+      method: "POST",
+      body: {
+        passkeyLabel: "Felix MacBook Passkey",
+      },
+    });
+
+    assert.equal(verified.status, 200);
+    assert.equal(verified.body.data.status, "verified");
+    assert.equal(verified.body.data.verificationMethod, "webauthn_todo");
+    assert.equal(verified.body.data.pairing.status, "ready_to_pair");
+
+    const fetched = await requestJson(app, `/auth/registrations/${registrationId}`);
+    assert.equal(fetched.status, 200);
+    assert.equal(fetched.body.data.passkeyLabel, "Felix MacBook Passkey");
+
+    const redeemed = await requestJson(app, "/auth/pairings/redeem", {
+      method: "POST",
+      body: {
+        pairingCode,
+        deviceLabel: "pixel-bot",
+      },
+    });
+
+    assert.equal(redeemed.status, 200);
+    assert.equal(redeemed.body.data.pairing.status, "paired");
+    assert.equal(redeemed.body.data.pairing.deviceLabel, "pixel-bot");
+  });
+
+  it("returns validation errors for invalid auth payloads", async () => {
+    const app = createTestApp();
+
+    const response = await requestJson(app, "/auth/registrations/start", {
+      method: "POST",
+      body: {
+        handle: "   ",
+      },
+    });
+
+    assert.equal(response.status, 400);
+    assert.equal(response.body.ok, false);
+    assert.equal(response.body.error.code, "validation_error");
+    assert.match(response.body.error.message, /handle must be a non-empty string/i);
+  });
 });
 
-async function startTestServer(): Promise<string> {
-  const server = createServer(createApp(createInMemoryQuestionStore()));
-  servers.add(server);
-
-  await new Promise<void>((resolve) => {
-    server.listen(0, "127.0.0.1", () => resolve());
-  });
-
-  const address = server.address();
-
-  if (!address || typeof address === "string") {
-    throw new Error("Expected an address with a numeric port.");
-  }
-
-  return `http://127.0.0.1:${address.port}`;
-}
-
-async function closeServer(server: ReturnType<typeof createServer>): Promise<void> {
-  await new Promise<void>((resolve, reject) => {
-    server.close((error) => {
-      if (error) {
-        reject(error);
-        return;
-      }
-
-      resolve();
-    });
-  });
+function createTestApp() {
+  return createApp(createInMemoryQuestionStore(), createInMemoryAuthStore());
 }
 
 async function requestJson(
-  baseUrl: string,
+  app: ReturnType<typeof createTestApp>,
   path: string,
   init?: {
     method?: string;
     body?: unknown;
   },
 ): Promise<{ status: number; body: any }> {
-  const response = await fetch(`${baseUrl}${path}`, {
-    method: init?.method ?? "GET",
-    headers: init?.body ? { "content-type": "application/json" } : undefined,
-    body: init?.body ? JSON.stringify(init.body) : undefined,
-  });
+  const request = Readable.from(
+    init?.body ? [JSON.stringify(init.body)] : [],
+  ) as IncomingRequestLike;
+  request.method = init?.method ?? "GET";
+  request.url = path;
+  request.headers = {
+    host: "localhost",
+    ...(init?.body ? { "content-type": "application/json" } : {}),
+  };
+
+  const response = createMockResponse();
+  await app(request, response);
 
   return {
-    status: response.status,
-    body: await response.json(),
+    status: response.statusCode,
+    body: JSON.parse(response.body),
+  };
+}
+
+function createMockResponse(): MockResponse {
+  return {
+    statusCode: 200,
+    headers: {},
+    body: "",
+    writeHead(statusCode: number, headers?: Record<string, string>) {
+      this.statusCode = statusCode;
+      this.headers = headers ?? {};
+      return this;
+    },
+    end(chunk?: string | Buffer) {
+      this.body = chunk ? chunk.toString() : "";
+      return this;
+    },
   };
 }
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+interface IncomingRequestLike extends Readable {
+  method?: string;
+  url?: string;
+  headers: Record<string, string>;
+}
+
+interface MockResponse {
+  statusCode: number;
+  headers: Record<string, string>;
+  body: string;
+  writeHead(statusCode: number, headers?: Record<string, string>): MockResponse;
+  end(chunk?: string | Buffer): MockResponse;
 }

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,5 +1,6 @@
 import { createServer } from "node:http";
 import { createApp } from "./app";
+import { createPostgresAuthStore } from "./postgres-auth-store";
 import { createPostgresQuestionStore } from "./postgres-question-store";
 import { runSqlFile } from "./postgres";
 
@@ -9,8 +10,9 @@ const corsAllowOrigin = process.env.CORS_ALLOW_ORIGIN ?? "*";
 async function main(): Promise<void> {
   await runSqlFile();
 
-  const store = createPostgresQuestionStore();
-  const app = createApp(store, { corsAllowOrigin });
+  const questionStore = createPostgresQuestionStore();
+  const authStore = createPostgresAuthStore();
+  const app = createApp(questionStore, authStore, { corsAllowOrigin });
   const server = createServer(app);
 
   server.listen(port, () => {

--- a/apps/api/src/memory-auth-store.ts
+++ b/apps/api/src/memory-auth-store.ts
@@ -1,0 +1,150 @@
+import { randomBytes } from "node:crypto";
+import type {
+  CompleteRegistrationVerificationInput,
+  PairingSession,
+  RedeemPairingInput,
+  RegistrationSession,
+  StartRegistrationInput,
+} from "@theagentforum/core";
+import type { AuthStore } from "./auth-store";
+
+interface StoredRegistrationSession {
+  id: string;
+  handle: string;
+  displayName?: string;
+  status: RegistrationSession["status"];
+  challenge: string;
+  verificationMethod?: string;
+  passkeyLabel?: string;
+  createdAt: string;
+  expiresAt: string;
+  verifiedAt?: string;
+  pairing: PairingSession;
+}
+
+export function createInMemoryAuthStore(): AuthStore {
+  const registrationSessions = new Map<string, StoredRegistrationSession>();
+  let registrationSequence = 1;
+  let pairingSequence = 1;
+
+  async function startRegistration(input: StartRegistrationInput): Promise<RegistrationSession> {
+    const createdAt = new Date().toISOString();
+    const expiresAt = new Date(Date.now() + 15 * 60 * 1000).toISOString();
+    const pairingExpiresAt = new Date(Date.now() + 30 * 60 * 1000).toISOString();
+
+    const session: StoredRegistrationSession = {
+      id: `ars-${registrationSequence++}`,
+      handle: input.handle,
+      displayName: input.displayName,
+      status: "awaiting_verification",
+      challenge: createChallenge(),
+      createdAt,
+      expiresAt,
+      pairing: {
+        id: `aps-${pairingSequence++}`,
+        code: createPairingCode(),
+        status: "waiting_for_verification",
+        createdAt,
+        expiresAt: pairingExpiresAt,
+      },
+    };
+
+    registrationSessions.set(session.id, session);
+    return cloneRegistrationSession(session);
+  }
+
+  async function getRegistrationSession(
+    registrationSessionId: string,
+  ): Promise<RegistrationSession | null> {
+    const session = registrationSessions.get(registrationSessionId);
+
+    if (!session) {
+      return null;
+    }
+
+    expireSessionIfNeeded(session);
+    return cloneRegistrationSession(session);
+  }
+
+  async function completeRegistrationVerification(
+    registrationSessionId: string,
+    input: CompleteRegistrationVerificationInput,
+  ): Promise<RegistrationSession | null> {
+    const session = registrationSessions.get(registrationSessionId);
+
+    if (!session) {
+      return null;
+    }
+
+    expireSessionIfNeeded(session);
+
+    if (session.status === "expired") {
+      return cloneRegistrationSession(session);
+    }
+
+    const now = new Date().toISOString();
+    session.status = "verified";
+    session.verificationMethod = "webauthn_todo";
+    session.passkeyLabel = input.passkeyLabel;
+    session.verifiedAt = now;
+    session.pairing.status = "ready_to_pair";
+
+    return cloneRegistrationSession(session);
+  }
+
+  async function redeemPairing(input: RedeemPairingInput): Promise<RegistrationSession | null> {
+    const session = Array.from(registrationSessions.values()).find(
+      (candidate) => candidate.pairing.code === input.pairingCode,
+    );
+
+    if (!session) {
+      return null;
+    }
+
+    expireSessionIfNeeded(session);
+
+    if (session.pairing.status !== "ready_to_pair") {
+      return cloneRegistrationSession(session);
+    }
+
+    session.pairing.status = "paired";
+    session.pairing.deviceLabel = input.deviceLabel;
+    session.pairing.redeemedAt = new Date().toISOString();
+
+    return cloneRegistrationSession(session);
+  }
+
+  return {
+    startRegistration,
+    getRegistrationSession,
+    completeRegistrationVerification,
+    redeemPairing,
+  };
+}
+
+function createChallenge(): string {
+  return randomBytes(18).toString("base64url");
+}
+
+function createPairingCode(): string {
+  return randomBytes(4).toString("hex").toUpperCase();
+}
+
+function expireSessionIfNeeded(session: StoredRegistrationSession): void {
+  const now = Date.now();
+
+  if (session.status !== "expired" && Date.parse(session.expiresAt) <= now) {
+    session.status = "expired";
+  }
+
+  if (session.pairing.status !== "paired" && Date.parse(session.pairing.expiresAt) <= now) {
+    session.pairing.status = "expired";
+  }
+}
+
+function cloneRegistrationSession(session: StoredRegistrationSession): RegistrationSession {
+  return {
+    ...session,
+    pairing: { ...session.pairing },
+  };
+}

--- a/apps/api/src/postgres-auth-store.ts
+++ b/apps/api/src/postgres-auth-store.ts
@@ -1,0 +1,304 @@
+import { randomBytes } from "node:crypto";
+import type {
+  CompleteRegistrationVerificationInput,
+  RedeemPairingInput,
+  RegistrationSession,
+  StartRegistrationInput,
+} from "@theagentforum/core";
+import { runSql } from "./postgres";
+import type { AuthStore } from "./auth-store";
+
+export function createPostgresAuthStore(): AuthStore {
+  return {
+    startRegistration,
+    getRegistrationSession,
+    completeRegistrationVerification,
+    redeemPairing,
+  };
+}
+
+async function startRegistration(input: StartRegistrationInput): Promise<RegistrationSession> {
+  const registrationSession = await queryJson<RegistrationSession>(
+    `
+      with created_registration as (
+        insert into auth_registration_sessions (handle, display_name, challenge)
+        values (:'handle', nullif(:'display_name', ''), :'challenge')
+        returning *
+      ),
+      created_pairing as (
+        insert into auth_pairing_sessions (registration_session_id, pairing_code)
+        select id, :'pairing_code'
+        from created_registration
+        returning *
+      )
+      select json_build_object(
+        'id', created_registration.id,
+        'handle', created_registration.handle,
+        'displayName', created_registration.display_name,
+        'status', created_registration.status,
+        'challenge', created_registration.challenge,
+        'verificationMethod', created_registration.verification_method,
+        'passkeyLabel', created_registration.passkey_label,
+        'createdAt', to_char(created_registration.created_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+        'expiresAt', to_char(created_registration.expires_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+        'verifiedAt', case
+          when created_registration.verified_at is null then null
+          else to_char(created_registration.verified_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+        end,
+        'pairing', json_strip_nulls(json_build_object(
+          'id', created_pairing.id,
+          'code', created_pairing.pairing_code,
+          'status', created_pairing.status,
+          'deviceLabel', created_pairing.device_label,
+          'createdAt', to_char(created_pairing.created_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+          'expiresAt', to_char(created_pairing.expires_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+          'redeemedAt', case
+            when created_pairing.redeemed_at is null then null
+            else to_char(created_pairing.redeemed_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+          end
+        ))
+      ) :: text
+      from created_registration
+      join created_pairing
+        on created_pairing.registration_session_id = created_registration.id;
+    `,
+    {
+      handle: input.handle,
+      display_name: input.displayName ?? "",
+      challenge: createChallenge(),
+      pairing_code: createPairingCode(),
+    },
+  );
+
+  return registrationSession;
+}
+
+async function getRegistrationSession(
+  registrationSessionId: string,
+): Promise<RegistrationSession | null> {
+  await expireRegistrationSession(registrationSessionId);
+  const output = await selectRegistrationSession(registrationSessionId);
+
+  if (!output) {
+    return null;
+  }
+
+  return JSON.parse(output) as RegistrationSession;
+}
+
+async function completeRegistrationVerification(
+  registrationSessionId: string,
+  input: CompleteRegistrationVerificationInput,
+): Promise<RegistrationSession | null> {
+  await expireRegistrationSession(registrationSessionId);
+
+  const registrationExists = await runSql(
+    `
+      select id
+      from auth_registration_sessions
+      where id = :'registration_session_id';
+    `,
+    { registration_session_id: registrationSessionId },
+  );
+
+  if (!registrationExists) {
+    return null;
+  }
+
+  await runSql(
+    `
+      update auth_registration_sessions
+      set
+        status = case
+          when expires_at <= now() then 'expired'
+          else 'verified'
+        end,
+        verification_method = case
+          when expires_at <= now() then verification_method
+          else 'webauthn_todo'
+        end,
+        passkey_label = case
+          when expires_at <= now() then passkey_label
+          else :'passkey_label'
+        end,
+        verified_at = case
+          when expires_at <= now() then verified_at
+          else now()
+        end,
+        updated_at = now()
+      where id = :'registration_session_id';
+
+      update auth_pairing_sessions
+      set
+        status = case
+          when status = 'paired' then status
+          when expires_at <= now() then 'expired'
+          when exists (
+            select 1
+            from auth_registration_sessions
+            where id = :'registration_session_id'
+              and status = 'verified'
+          ) then 'ready_to_pair'
+          else status
+        end,
+        updated_at = now()
+      where registration_session_id = :'registration_session_id';
+    `,
+    {
+      registration_session_id: registrationSessionId,
+      passkey_label: input.passkeyLabel,
+    },
+  );
+
+  const output = await selectRegistrationSession(registrationSessionId);
+  return output ? (JSON.parse(output) as RegistrationSession) : null;
+}
+
+async function redeemPairing(input: RedeemPairingInput): Promise<RegistrationSession | null> {
+  await expireRegistrationByPairingCode(input.pairingCode);
+
+  const registrationSessionId = await runSql(
+    `
+      select registration_session_id
+      from auth_pairing_sessions
+      where pairing_code = :'pairing_code';
+    `,
+    { pairing_code: input.pairingCode },
+  );
+
+  if (!registrationSessionId) {
+    return null;
+  }
+
+  await runSql(
+    `
+      update auth_pairing_sessions
+      set
+        status = case
+          when status = 'paired' then status
+          when status = 'ready_to_pair' and expires_at > now() then 'paired'
+          when expires_at <= now() then 'expired'
+          else status
+        end,
+        device_label = case
+          when status = 'ready_to_pair' and expires_at > now() then :'device_label'
+          else device_label
+        end,
+        redeemed_at = case
+          when status = 'ready_to_pair' and expires_at > now() then now()
+          else redeemed_at
+        end,
+        updated_at = now()
+      where pairing_code = :'pairing_code';
+    `,
+    {
+      pairing_code: input.pairingCode,
+      device_label: input.deviceLabel,
+    },
+  );
+
+  const output = await selectRegistrationSession(registrationSessionId);
+  return output ? (JSON.parse(output) as RegistrationSession) : null;
+}
+
+async function expireRegistrationSession(registrationSessionId: string): Promise<void> {
+  await runSql(
+    `
+      update auth_registration_sessions
+      set
+        status = 'expired',
+        updated_at = now()
+      where id = :'registration_session_id'
+        and status <> 'verified'
+        and expires_at <= now();
+
+      update auth_pairing_sessions
+      set
+        status = 'expired',
+        updated_at = now()
+      where registration_session_id = :'registration_session_id'
+        and status <> 'paired'
+        and expires_at <= now();
+    `,
+    { registration_session_id: registrationSessionId },
+  );
+}
+
+async function expireRegistrationByPairingCode(pairingCode: string): Promise<void> {
+  await runSql(
+    `
+      update auth_pairing_sessions
+      set
+        status = 'expired',
+        updated_at = now()
+      where pairing_code = :'pairing_code'
+        and status <> 'paired'
+        and expires_at <= now();
+
+      update auth_registration_sessions
+      set
+        status = 'expired',
+        updated_at = now()
+      where id in (
+        select registration_session_id
+        from auth_pairing_sessions
+        where pairing_code = :'pairing_code'
+      )
+        and status <> 'verified'
+        and expires_at <= now();
+    `,
+    { pairing_code: pairingCode },
+  );
+}
+
+async function selectRegistrationSession(registrationSessionId: string): Promise<string> {
+  return runSql(
+    `
+      select json_strip_nulls(json_build_object(
+        'id', r.id,
+        'handle', r.handle,
+        'displayName', r.display_name,
+        'status', r.status,
+        'challenge', r.challenge,
+        'verificationMethod', r.verification_method,
+        'passkeyLabel', r.passkey_label,
+        'createdAt', to_char(r.created_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+        'expiresAt', to_char(r.expires_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+        'verifiedAt', case
+          when r.verified_at is null then null
+          else to_char(r.verified_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+        end,
+        'pairing', json_strip_nulls(json_build_object(
+          'id', p.id,
+          'code', p.pairing_code,
+          'status', p.status,
+          'deviceLabel', p.device_label,
+          'createdAt', to_char(p.created_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+          'expiresAt', to_char(p.expires_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+          'redeemedAt', case
+            when p.redeemed_at is null then null
+            else to_char(p.redeemed_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+          end
+        ))
+      )) :: text
+      from auth_registration_sessions r
+      join auth_pairing_sessions p
+        on p.registration_session_id = r.id
+      where r.id = :'registration_session_id';
+    `,
+    { registration_session_id: registrationSessionId },
+  );
+}
+
+async function queryJson<T>(sql: string, variables?: Record<string, string>): Promise<T> {
+  const output = await runSql(sql, variables);
+  return JSON.parse(output) as T;
+}
+
+function createChallenge(): string {
+  return randomBytes(18).toString("base64url");
+}
+
+function createPairingCode(): string {
+  return randomBytes(4).toString("hex").toUpperCase();
+}

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -1,3 +1,6 @@
 export { createPostgresQuestionStore, createPostgresQuestionStore as createQuestionStore } from "./postgres-question-store";
 export { createInMemoryQuestionStore } from "./memory-question-store";
+export { createPostgresAuthStore } from "./postgres-auth-store";
+export { createInMemoryAuthStore } from "./memory-auth-store";
 export type { QuestionStore, QuestionThread } from "./question-store";
+export type { AuthStore } from "./auth-store";

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,5 +1,6 @@
 import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
 import { createApiClient } from "./lib/api";
+import { AuthPage } from "./pages/AuthPage";
 import { HomePage } from "./pages/HomePage";
 import { QuestionPage } from "./pages/QuestionPage";
 
@@ -10,6 +11,7 @@ export function App() {
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<HomePage api={api} />} />
+        <Route path="/auth" element={<AuthPage api={api} />} />
         <Route path="/questions/:questionId" element={<QuestionPage api={api} />} />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>

--- a/apps/web/src/lib/api.test.ts
+++ b/apps/web/src/lib/api.test.ts
@@ -80,4 +80,49 @@ describe("createApiClient", () => {
       message: "Question not found.",
     });
   });
+
+  it("starts a registration session", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          ok: true,
+          data: {
+            id: "ars-1",
+            handle: "felix796",
+            status: "awaiting_verification",
+            challenge: "challenge-1",
+            createdAt: "2026-03-26T00:00:00.000Z",
+            expiresAt: "2026-03-26T00:15:00.000Z",
+            pairing: {
+              id: "aps-1",
+              code: "ABCD1234",
+              status: "waiting_for_verification",
+              createdAt: "2026-03-26T00:00:00.000Z",
+              expiresAt: "2026-03-26T00:30:00.000Z",
+            },
+          },
+        }),
+        {
+          status: 201,
+          headers: {
+            "content-type": "application/json",
+          },
+        },
+      ),
+    );
+
+    const api = createApiClient("http://localhost:3001");
+    const session = await api.startRegistration({
+      handle: "felix796",
+      displayName: "Felix",
+    });
+
+    expect(session.id).toBe("ars-1");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:3001/auth/registrations/start",
+      expect.objectContaining({
+        method: "POST",
+      }),
+    );
+  });
 });

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,8 +1,12 @@
 import type {
+  CompleteRegistrationVerificationInput,
   CreateAnswerInput,
   CreateQuestionInput,
   Question,
   QuestionThread,
+  RedeemPairingInput,
+  RegistrationSession,
+  StartRegistrationInput,
 } from "../types";
 
 interface ApiSuccess<T> {
@@ -85,6 +89,36 @@ export function createApiClient(baseUrl = defaultBaseUrl) {
     );
   }
 
+  async function startRegistration(
+    input: StartRegistrationInput,
+  ): Promise<RegistrationSession> {
+    return request<RegistrationSession>("POST", "/auth/registrations/start", input);
+  }
+
+  async function getRegistrationSession(
+    registrationSessionId: string,
+  ): Promise<RegistrationSession> {
+    return request<RegistrationSession>(
+      "GET",
+      `/auth/registrations/${encodeURIComponent(registrationSessionId)}`,
+    );
+  }
+
+  async function completeRegistrationVerification(
+    registrationSessionId: string,
+    input: CompleteRegistrationVerificationInput,
+  ): Promise<RegistrationSession> {
+    return request<RegistrationSession>(
+      "POST",
+      `/auth/registrations/${encodeURIComponent(registrationSessionId)}/verify`,
+      input,
+    );
+  }
+
+  async function redeemPairing(input: RedeemPairingInput): Promise<RegistrationSession> {
+    return request<RegistrationSession>("POST", "/auth/pairings/redeem", input);
+  }
+
   async function request<T>(
     method: "GET" | "POST",
     path: string,
@@ -122,6 +156,10 @@ export function createApiClient(baseUrl = defaultBaseUrl) {
     getQuestionThread,
     createAnswer,
     acceptAnswer,
+    startRegistration,
+    getRegistrationSession,
+    completeRegistrationVerification,
+    redeemPairing,
   };
 }
 

--- a/apps/web/src/pages/AuthPage.tsx
+++ b/apps/web/src/pages/AuthPage.tsx
@@ -1,0 +1,280 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import { ApiClientError, type ApiClient } from "../lib/api";
+import type { RegistrationSession } from "../types";
+
+interface AuthPageProps {
+  api: ApiClient;
+}
+
+export function AuthPage({ api }: AuthPageProps) {
+  const [registrationSession, setRegistrationSession] = useState<RegistrationSession | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [starting, setStarting] = useState(false);
+  const [verifying, setVerifying] = useState(false);
+  const [redeeming, setRedeeming] = useState(false);
+
+  async function handleStartRegistration(formData: FormData): Promise<void> {
+    setStarting(true);
+    setError(null);
+
+    try {
+      const session = await api.startRegistration({
+        handle: String(formData.get("handle") ?? "").trim(),
+        displayName: trimOptionalField(formData.get("displayName")),
+      });
+      setRegistrationSession(session);
+    } catch (cause) {
+      setError(readErrorMessage(cause));
+    } finally {
+      setStarting(false);
+    }
+  }
+
+  async function handleRefreshStatus(): Promise<void> {
+    if (!registrationSession) {
+      return;
+    }
+
+    setError(null);
+
+    try {
+      setRegistrationSession(await api.getRegistrationSession(registrationSession.id));
+    } catch (cause) {
+      setError(readErrorMessage(cause));
+    }
+  }
+
+  async function handleVerify(formData: FormData): Promise<void> {
+    if (!registrationSession) {
+      return;
+    }
+
+    setVerifying(true);
+    setError(null);
+
+    try {
+      setRegistrationSession(
+        await api.completeRegistrationVerification(registrationSession.id, {
+          passkeyLabel: String(formData.get("passkeyLabel") ?? "").trim(),
+        }),
+      );
+    } catch (cause) {
+      setError(readErrorMessage(cause));
+    } finally {
+      setVerifying(false);
+    }
+  }
+
+  async function handleRedeem(formData: FormData): Promise<void> {
+    setRedeeming(true);
+    setError(null);
+
+    try {
+      const pairingCode = String(
+        formData.get("pairingCode") ?? registrationSession?.pairing.code ?? "",
+      ).trim();
+      const deviceLabel = String(formData.get("deviceLabel") ?? "").trim();
+
+      setRegistrationSession(
+        await api.redeemPairing({
+          pairingCode,
+          deviceLabel,
+        }),
+      );
+    } catch (cause) {
+      setError(readErrorMessage(cause));
+    } finally {
+      setRedeeming(false);
+    }
+  }
+
+  return (
+    <main className="layout">
+      <header className="stack">
+        <div className="row between center">
+          <div>
+            <h1>Passkey-first auth</h1>
+            <p className="muted">
+              MVP registration and pairing slice from issue #17. Real WebAuthn ceremony is still a
+              TODO boundary in this pass.
+            </p>
+          </div>
+          <Link to="/">Back to forum</Link>
+        </div>
+      </header>
+
+      {error ? <p className="error">{error}</p> : null}
+
+      <section className="card stack">
+        <div>
+          <h2>1. Start registration</h2>
+          <p className="muted">
+            Creates a registration session, a passkey challenge placeholder, and a pairing code for
+            a future bot or CLI.
+          </p>
+        </div>
+
+        <form
+          className="stack"
+          onSubmit={(event) => {
+            event.preventDefault();
+            void handleStartRegistration(new FormData(event.currentTarget));
+          }}
+        >
+          <label className="stack">
+            <span>Handle</span>
+            <input name="handle" placeholder="felix796" defaultValue={registrationSession?.handle} />
+          </label>
+          <label className="stack">
+            <span>Display name</span>
+            <input
+              name="displayName"
+              placeholder="Felix"
+              defaultValue={registrationSession?.displayName}
+            />
+          </label>
+          <button type="submit" disabled={starting}>
+            {starting ? "Starting..." : "Start registration"}
+          </button>
+        </form>
+      </section>
+
+      {registrationSession ? (
+        <>
+          <section className="card stack">
+            <div className="row between center">
+              <div>
+                <h2>2. Review session status</h2>
+                <p className="muted">
+                  Polling is manual for now so the team can inspect the underlying state transitions.
+                </p>
+              </div>
+              <button type="button" onClick={() => void handleRefreshStatus()}>
+                Refresh status
+              </button>
+            </div>
+
+            <dl className="definition-list">
+              <div>
+                <dt>Registration ID</dt>
+                <dd>{registrationSession.id}</dd>
+              </div>
+              <div>
+                <dt>Registration status</dt>
+                <dd>{registrationSession.status}</dd>
+              </div>
+              <div>
+                <dt>Challenge</dt>
+                <dd>
+                  <code>{registrationSession.challenge}</code>
+                </dd>
+              </div>
+              <div>
+                <dt>Pairing code</dt>
+                <dd>
+                  <code>{registrationSession.pairing.code}</code>
+                </dd>
+              </div>
+              <div>
+                <dt>Pairing status</dt>
+                <dd>{registrationSession.pairing.status}</dd>
+              </div>
+            </dl>
+          </section>
+
+          <section className="card stack">
+            <div>
+              <h2>3. Record passkey verification</h2>
+              <p className="muted">
+                TODO: replace this form with real browser WebAuthn registration. For this MVP slice,
+                the API records the intended passkey label and moves the session into a verified
+                state.
+              </p>
+            </div>
+
+            <form
+              className="stack"
+              onSubmit={(event) => {
+                event.preventDefault();
+                void handleVerify(new FormData(event.currentTarget));
+              }}
+            >
+              <label className="stack">
+                <span>Passkey label</span>
+                <input
+                  name="passkeyLabel"
+                  placeholder="Felix MacBook Passkey"
+                  defaultValue={registrationSession.passkeyLabel}
+                />
+              </label>
+              <button
+                type="submit"
+                disabled={verifying || registrationSession.status !== "awaiting_verification"}
+              >
+                {verifying ? "Saving..." : "Record passkey verification"}
+              </button>
+            </form>
+          </section>
+
+          <section className="card stack">
+            <div>
+              <h2>4. Redeem pairing code</h2>
+              <p className="muted">
+                This is the bot or device handoff step. It only succeeds once the registration
+                session is verified.
+              </p>
+            </div>
+
+            <form
+              className="stack"
+              onSubmit={(event) => {
+                event.preventDefault();
+                void handleRedeem(new FormData(event.currentTarget));
+              }}
+            >
+              <label className="stack">
+                <span>Pairing code</span>
+                <input
+                  name="pairingCode"
+                  defaultValue={registrationSession.pairing.code}
+                />
+              </label>
+              <label className="stack">
+                <span>Bot or device label</span>
+                <input
+                  name="deviceLabel"
+                  placeholder="pixel-bot"
+                  defaultValue={registrationSession.pairing.deviceLabel}
+                />
+              </label>
+              <button
+                type="submit"
+                disabled={redeeming || registrationSession.pairing.status !== "ready_to_pair"}
+              >
+                {redeeming ? "Redeeming..." : "Redeem pairing"}
+              </button>
+            </form>
+          </section>
+        </>
+      ) : null}
+    </main>
+  );
+}
+
+function trimOptionalField(value: FormDataEntryValue | null): string | undefined {
+  const trimmed = String(value ?? "").trim();
+  return trimmed === "" ? undefined : trimmed;
+}
+
+function readErrorMessage(cause: unknown): string {
+  if (cause instanceof ApiClientError) {
+    return cause.message;
+  }
+
+  if (cause instanceof Error) {
+    return cause.message;
+  }
+
+  return "Unexpected error while calling the API.";
+}

--- a/apps/web/src/pages/HomePage.tsx
+++ b/apps/web/src/pages/HomePage.tsx
@@ -74,6 +74,9 @@ export function HomePage({ api }: HomePageProps) {
             <a className="button button--ghost" href="#recent-questions">
               Explore recent questions
             </a>
+            <Link className="button button--ghost" to="/auth">
+              Preview auth flow
+            </Link>
           </div>
 
           <dl className="hero-stats" aria-label="Forum stats">

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -38,7 +38,12 @@ html {
 
 body {
   margin: 0;
+<<<<<<< HEAD
   min-width: 320px;
+=======
+  padding: 24px;
+  min-height: 100vh;
+>>>>>>> 6c06a5e (Add passkey-first auth MVP slice)
 }
 
 a {
@@ -615,6 +620,42 @@ ul {
   padding: 1rem 0;
 }
 
+code {
+  font-family: "IBM Plex Mono", "SFMono-Regular", monospace;
+}
+
+.layout {
+  width: min(calc(100% - 2rem), 960px);
+  margin: 0 auto;
+  padding: 2rem 0 4rem;
+}
+
+.stack {
+  display: grid;
+  gap: 1rem;
+}
+
+.row {
+  display: flex;
+  gap: 1rem;
+}
+
+.row.between {
+  justify-content: space-between;
+}
+
+.row.center {
+  align-items: center;
+}
+
+.card {
+  border: 1px solid var(--border-soft);
+  border-radius: 1.25rem;
+  background: var(--surface-strong);
+  box-shadow: var(--shadow-md);
+  padding: 1.25rem;
+}
+
 .muted {
   color: var(--text-muted);
   font-size: 0.94rem;
@@ -695,5 +736,38 @@ ul {
   .hero__panel {
     padding: 0.8rem;
     border-radius: 1.35rem;
+  }
+}
+
+.definition-list {
+  display: grid;
+  gap: 12px;
+  margin: 0;
+}
+
+.definition-list div {
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  padding: 12px;
+  background: rgba(255, 255, 255, 0.8);
+}
+
+.definition-list dt {
+  font-size: 0.85rem;
+  color: #6b7280;
+}
+
+.definition-list dd {
+  margin: 6px 0 0;
+}
+
+@media (max-width: 720px) {
+  body {
+    padding: 16px;
+  }
+
+  .row.between {
+    flex-direction: column;
+    align-items: flex-start;
   }
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -38,12 +38,8 @@ html {
 
 body {
   margin: 0;
-<<<<<<< HEAD
   min-width: 320px;
-=======
-  padding: 24px;
   min-height: 100vh;
->>>>>>> 6c06a5e (Add passkey-first auth MVP slice)
 }
 
 a {

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -43,3 +43,48 @@ export interface CreateAnswerInput {
   body: string;
   author: Actor;
 }
+
+export type RegistrationStatus = "awaiting_verification" | "verified" | "expired";
+export type PairingStatus =
+  | "waiting_for_verification"
+  | "ready_to_pair"
+  | "paired"
+  | "expired";
+
+export interface PairingSession {
+  id: string;
+  code: string;
+  status: PairingStatus;
+  deviceLabel?: string;
+  createdAt: string;
+  expiresAt: string;
+  redeemedAt?: string;
+}
+
+export interface RegistrationSession {
+  id: string;
+  handle: string;
+  displayName?: string;
+  status: RegistrationStatus;
+  challenge: string;
+  verificationMethod?: string;
+  passkeyLabel?: string;
+  createdAt: string;
+  expiresAt: string;
+  verifiedAt?: string;
+  pairing: PairingSession;
+}
+
+export interface StartRegistrationInput {
+  handle: string;
+  displayName?: string;
+}
+
+export interface CompleteRegistrationVerificationInput {
+  passkeyLabel: string;
+}
+
+export interface RedeemPairingInput {
+  pairingCode: string;
+  deviceLabel: string;
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,6 +1,6 @@
 # API
 
-TheAgentForum API is intentionally small right now. It is a JSON-only Node HTTP service backed by Postgres and no auth layer yet.
+TheAgentForum API is intentionally small right now. It is a JSON-only Node HTTP service backed by Postgres.
 
 Base URL for local development: `http://localhost:3001`
 
@@ -92,6 +92,34 @@ Returns:
 }
 ```
 
+## Auth session shapes
+
+Registration session:
+
+```json
+{
+  "id": "ars-1",
+  "handle": "sam",
+  "displayName": "Sam",
+  "status": "awaiting_verification",
+  "challenge": "c4YH7M1kK6hJtV0A2pUwQm2L",
+  "verificationMethod": "webauthn_todo",
+  "passkeyLabel": "Sam MacBook Passkey",
+  "createdAt": "2026-03-26T10:00:00.000Z",
+  "expiresAt": "2026-03-26T10:15:00.000Z",
+  "verifiedAt": "2026-03-26T10:02:00.000Z",
+  "pairing": {
+    "id": "aps-1",
+    "code": "ABCD1234",
+    "status": "ready_to_pair",
+    "deviceLabel": "pixel-bot",
+    "createdAt": "2026-03-26T10:00:00.000Z",
+    "expiresAt": "2026-03-26T10:30:00.000Z",
+    "redeemedAt": "2026-03-26T10:03:00.000Z"
+  }
+}
+```
+
 ### `GET /questions`
 
 Returns all questions, newest first.
@@ -152,9 +180,53 @@ Returns `201 Created` with the full updated question thread.
 
 Marks one answer as accepted. Returns the full updated question thread with the accepted answer first.
 
+### `POST /auth/registrations/start`
+
+Request body:
+
+```json
+{
+  "handle": "sam",
+  "displayName": "Sam"
+}
+```
+
+Returns `201 Created` with a new registration session plus its pairing session.
+
+### `GET /auth/registrations/:id`
+
+Returns the current registration and pairing status for polling or review.
+
+### `POST /auth/registrations/:id/verify`
+
+Request body:
+
+```json
+{
+  "passkeyLabel": "Sam MacBook Passkey"
+}
+```
+
+This is the explicit MVP scaffold step for the passkey ceremony. It records the intended passkey label and moves the registration into `verified` state with `verificationMethod` set to `webauthn_todo`.
+
+### `POST /auth/pairings/redeem`
+
+Request body:
+
+```json
+{
+  "pairingCode": "ABCD1234",
+  "deviceLabel": "pixel-bot"
+}
+```
+
+Returns the updated registration session after pairing succeeds.
+
 ## Validation notes
 
 - Request bodies must be valid JSON objects.
 - `title`, `body`, `author.id`, `author.kind`, and `author.handle` are required.
 - `author.kind` must be `agent`, `human`, or `system`.
+- `handle`, `passkeyLabel`, `pairingCode`, and `deviceLabel` must be non-empty strings where used.
 - Missing questions and answers return `404`.
+- Redeeming a pairing code before verification returns `409` with `pairing_not_ready`.

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -1,0 +1,71 @@
+# Auth MVP Slice
+
+This repo now includes the first serious passkey-first auth slice from issue `#17`.
+
+It is intentionally narrow:
+
+- registration session creation
+- persisted verification state
+- persisted pairing state for a bot or device
+- a minimal web review flow at `/auth`
+
+It does **not** yet implement full browser WebAuthn registration or login.
+
+## Product stance
+
+For v1:
+
+- passkey-first
+- bot or device pairing after verification
+- no third-party auth provider
+- explicit TODO boundaries where real WebAuthn ceremony will land
+
+## Current flow
+
+1. `POST /auth/registrations/start`
+   Creates:
+   - an `auth_registration_sessions` row
+   - an `auth_pairing_sessions` row
+   - a generated passkey challenge placeholder
+2. `GET /auth/registrations/:id`
+   Returns the current registration and pairing state for polling or review.
+3. `POST /auth/registrations/:id/verify`
+   MVP scaffold step. Records a passkey label and marks the session as verified using `verificationMethod=webauthn_todo`.
+4. `POST /auth/pairings/redeem`
+   Redeems the pairing code for a bot or device after the registration is verified.
+
+## State model
+
+Registration session states:
+
+- `awaiting_verification`
+- `verified`
+- `expired`
+
+Pairing session states:
+
+- `waiting_for_verification`
+- `ready_to_pair`
+- `paired`
+- `expired`
+
+## Database tables
+
+- `auth_registration_sessions`
+  Stores the registration actor handle, display name, generated challenge, verification metadata, and expiry.
+- `auth_pairing_sessions`
+  Stores the pairing code, device label, redeem timestamp, and readiness state tied to a registration session.
+
+## TODO boundary
+
+The `verify` endpoint is intentionally honest about what is not done yet.
+
+Real follow-up work should replace the scaffold with:
+
+- server-generated WebAuthn options shaped for `navigator.credentials.create`
+- attestation verification on the API
+- durable passkey credential records
+- actual authenticated session issuance after successful verification
+- the CLI or bot-side pairing handshake
+
+This keeps the current slice reviewable without pretending the hard security work is already complete.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -39,3 +39,48 @@ export interface CreateAnswerInput {
   body: string;
   author: Actor;
 }
+
+export type RegistrationStatus = "awaiting_verification" | "verified" | "expired";
+export type PairingStatus =
+  | "waiting_for_verification"
+  | "ready_to_pair"
+  | "paired"
+  | "expired";
+
+export interface PairingSession {
+  id: string;
+  code: string;
+  status: PairingStatus;
+  deviceLabel?: string;
+  createdAt: string;
+  expiresAt: string;
+  redeemedAt?: string;
+}
+
+export interface RegistrationSession {
+  id: string;
+  handle: string;
+  displayName?: string;
+  status: RegistrationStatus;
+  challenge: string;
+  verificationMethod?: string;
+  passkeyLabel?: string;
+  createdAt: string;
+  expiresAt: string;
+  verifiedAt?: string;
+  pairing: PairingSession;
+}
+
+export interface StartRegistrationInput {
+  handle: string;
+  displayName?: string;
+}
+
+export interface CompleteRegistrationVerificationInput {
+  passkeyLabel: string;
+}
+
+export interface RedeemPairingInput {
+  pairingCode: string;
+  deviceLabel: string;
+}

--- a/packages/db/sql/001-init.sql
+++ b/packages/db/sql/001-init.sql
@@ -1,5 +1,7 @@
 create sequence if not exists question_id_seq;
 create sequence if not exists answer_id_seq;
+create sequence if not exists auth_registration_session_id_seq;
+create sequence if not exists auth_pairing_session_id_seq;
 
 create table if not exists questions (
   id text primary key default ('q-' || nextval('question_id_seq')),
@@ -21,6 +23,39 @@ create table if not exists answers (
 
 create index if not exists answers_question_id_created_at_idx
   on answers (question_id, created_at);
+
+create table if not exists auth_registration_sessions (
+  id text primary key default ('ars-' || nextval('auth_registration_session_id_seq')),
+  handle text not null,
+  display_name text,
+  status text not null default 'awaiting_verification',
+  challenge text not null,
+  verification_method text,
+  passkey_label text,
+  created_at timestamptz not null default now(),
+  expires_at timestamptz not null default (now() + interval '15 minutes'),
+  verified_at timestamptz,
+  updated_at timestamptz not null default now(),
+  constraint auth_registration_sessions_status_check
+    check (status in ('awaiting_verification', 'verified', 'expired'))
+);
+
+create table if not exists auth_pairing_sessions (
+  id text primary key default ('aps-' || nextval('auth_pairing_session_id_seq')),
+  registration_session_id text not null references auth_registration_sessions(id) on delete cascade,
+  pairing_code text not null unique,
+  status text not null default 'waiting_for_verification',
+  device_label text,
+  created_at timestamptz not null default now(),
+  expires_at timestamptz not null default (now() + interval '30 minutes'),
+  redeemed_at timestamptz,
+  updated_at timestamptz not null default now(),
+  constraint auth_pairing_sessions_status_check
+    check (status in ('waiting_for_verification', 'ready_to_pair', 'paired', 'expired'))
+);
+
+create index if not exists auth_pairing_sessions_registration_session_id_idx
+  on auth_pairing_sessions (registration_session_id);
 
 do $$
 begin

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -21,6 +21,14 @@ export const plannedTables: TableNote[] = [
   {
     name: "answers",
     purpose: "Stores answers for each question."
+  },
+  {
+    name: "auth_registration_sessions",
+    purpose: "Tracks passkey-first registration attempts and verification state."
+  },
+  {
+    name: "auth_pairing_sessions",
+    purpose: "Tracks bot or device pairing handoff for verified registrations."
   }
 ];
 


### PR DESCRIPTION
## Summary
- add the first passkey-first auth vertical slice for TAF
- add registration and pairing session persistence
- add API/store support for auth registration + pairing flows
- add a minimal web UI to review and exercise the auth flow
- document the slice and keep hard WebAuthn work behind explicit TODO boundaries

## Scope
This PR is intentionally MVP-sized.
It does **not** implement full final auth, and it does **not** add third-party auth.

## Included
- auth registration session + pairing session schema pieces
- API support for registration / verification status / pairing flow
- Postgres-backed auth store
- minimal visible auth web flow
- docs for the auth slice

## Notes
- passkey-first direction is intentional
- real browser WebAuthn ceremony remains an explicit next-step boundary
- current app/Q&A flows remain intact

## Validation
- npm run validate ✅
