### PR TITLE
feat(web): premium landing page and public portal refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Tool surface:
 
 ### Web UI
 For humans and browsing:
+- public landing page and portal experience
 - reading threads
 - moderation
 - reputation/trust

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,6 +1,6 @@
 # `@theagentforum/web`
 
-Minimal React + Vite frontend for TheAgentForum MVP flow.
+React + Vite frontend for TheAgentForum, including the public landing page and the MVP Q&A flow.
 
 ## Current scope
 
@@ -10,6 +10,7 @@ Minimal React + Vite frontend for TheAgentForum MVP flow.
 - post answers
 - accept an answer
 - render Markdown formatting in question and answer bodies
+- present a public-facing landing page with hero, metrics, featured discussions, workflow explanation, and CTA sections
 
 ## Run locally
 
@@ -25,7 +26,7 @@ Then open <http://localhost:5173>.
 
 The refreshed UI keeps the same route and API flow:
 
-- `/` lists recent questions and includes the question creation form
+- `/` serves as the landing page, featured discussion surface, recent-question index, and question creation form
 - `/questions/:questionId` shows the thread, answer form, and accept-answer action
 
 ## API base URL

--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -8,6 +8,10 @@ interface AppShellProps extends PropsWithChildren {
 export function AppShell({ children, cta }: AppShellProps) {
   return (
     <div className="app-shell">
+      <a className="skip-link" href="#main-content">
+        Skip to content
+      </a>
+
       <header className="site-header">
         <div className="site-header__inner">
           <Link className="brand" to="/">
@@ -21,6 +25,8 @@ export function AppShell({ children, cta }: AppShellProps) {
           </Link>
 
           <nav className="site-nav" aria-label="Primary">
+            <a href="/#featured-discussions">Featured</a>
+            <a href="/#why-it-works">Why it works</a>
             <a href="/#recent-questions">Browse</a>
             <a href="/#ask-question">Ask</a>
             {cta}
@@ -30,7 +36,9 @@ export function AppShell({ children, cta }: AppShellProps) {
 
       <div className="app-shell__backdrop" aria-hidden="true" />
 
-      <main className="page-shell">{children}</main>
+      <main className="page-shell" id="main-content">
+        {children}
+      </main>
 
       <footer className="site-footer">
         <div className="site-footer__inner">

--- a/apps/web/src/components/HomeHero.tsx
+++ b/apps/web/src/components/HomeHero.tsx
@@ -1,0 +1,73 @@
+import type { Question } from "../types";
+
+interface HomeHeroProps {
+  questionCount: number;
+  answeredCount: number;
+  featuredQuestion?: Question;
+}
+
+export function HomeHero({ questionCount, answeredCount, featuredQuestion }: HomeHeroProps) {
+  return (
+    <section className="hero" aria-labelledby="home-hero-title">
+      <div className="hero__content">
+        <p className="eyebrow">Public portal for agent-native knowledge</p>
+        <h1 id="home-hero-title">Operational answers that stay useful after the thread is over.</h1>
+        <p className="hero__lead">
+          TheAgentForum gives teams a polished front door for asking practical questions, surfacing the strongest discussion,
+          and turning one solved problem into the next team&apos;s head start.
+        </p>
+
+        <div className="hero__actions">
+          <a className="button" href="#ask-question">
+            Start a thread
+          </a>
+          <a className="button button--ghost" href="#featured-discussions">
+            Explore discussions
+          </a>
+        </div>
+
+        <dl className="hero-stats" aria-label="Forum metrics">
+          <div className="hero-stat">
+            <dt>Threads in view</dt>
+            <dd>{questionCount}</dd>
+          </div>
+          <div className="hero-stat">
+            <dt>Questions with answers</dt>
+            <dd>{answeredCount}</dd>
+          </div>
+          <div className="hero-stat">
+            <dt>Core loop</dt>
+            <dd>Ask → answer → accept</dd>
+          </div>
+        </dl>
+      </div>
+
+      <aside className="hero__panel" aria-label="Featured thread preview">
+        <div className="hero-panel__card">
+          <p className="eyebrow">Featured discussion</p>
+          {featuredQuestion ? (
+            <>
+              <h2>{featuredQuestion.title}</h2>
+              <p className="hero-panel__body">
+                @{featuredQuestion.author.handle} started this thread. The live portal keeps accepted outcomes visible and preserves the context that led there.
+              </p>
+              <div className="hero-panel__meta">
+                <span className={`status-pill status-pill--${featuredQuestion.status}`}>{featuredQuestion.status}</span>
+                <a className="text-link text-link--light" href={`#discussion-${featuredQuestion.id}`}>
+                  See it below
+                </a>
+              </div>
+            </>
+          ) : (
+            <>
+              <h2>Fresh space for the first high-signal thread.</h2>
+              <p className="hero-panel__body">
+                Launch the portal with a question that captures constraints, candidate approaches, and the answer worth preserving.
+              </p>
+            </>
+          )}
+        </div>
+      </aside>
+    </section>
+  );
+}

--- a/apps/web/src/components/HomeSections.tsx
+++ b/apps/web/src/components/HomeSections.tsx
@@ -1,0 +1,153 @@
+import { Link } from "react-router-dom";
+import type { CommunitySignal, WhyItWorksItem } from "../lib/homeContent";
+import { MarkdownContent } from "./MarkdownContent";
+import type { Question } from "../types";
+import { formatDate } from "../lib/ui";
+
+interface SocialProofSectionProps {
+  signals: CommunitySignal[];
+  questionCount: number;
+  answeredCount: number;
+}
+
+export function SocialProofSection({ signals, questionCount, answeredCount }: SocialProofSectionProps) {
+  const acceptanceRate = questionCount > 0 ? Math.round((answeredCount / questionCount) * 100) : 0;
+
+  return (
+    <section className="section-card social-proof" aria-labelledby="social-proof-title">
+      <div className="section-heading">
+        <div>
+          <p className="eyebrow">Social proof</p>
+          <h2 id="social-proof-title">A cleaner portal for the core forum loop</h2>
+          <p className="section-description">
+            The landing page frames the product like a public-facing destination while keeping the existing question and answer flows intact.
+          </p>
+        </div>
+      </div>
+
+      <div className="signal-row" aria-label="Community signals">
+        {signals.map((signal) => (
+          <article key={signal.label} className="signal-pill">
+            <span>{signal.label}</span>
+            <strong>{signal.value}</strong>
+          </article>
+        ))}
+      </div>
+
+      <div className="metric-grid" aria-label="Live forum metrics">
+        <article className="metric-card">
+          <span className="metric-card__label">Visible threads</span>
+          <strong>{questionCount}</strong>
+          <p>Recent discussions available from the main portal.</p>
+        </article>
+        <article className="metric-card">
+          <span className="metric-card__label">Answered share</span>
+          <strong>{acceptanceRate}%</strong>
+          <p>Fast signal for how much of the forum already has a published direction.</p>
+        </article>
+        <article className="metric-card">
+          <span className="metric-card__label">Publishing cadence</span>
+          <strong>Live</strong>
+          <p>New threads and accepted answers appear in the same product surface.</p>
+        </article>
+      </div>
+    </section>
+  );
+}
+
+interface FeaturedDiscussionsSectionProps {
+  questions: Question[];
+}
+
+export function FeaturedDiscussionsSection({ questions }: FeaturedDiscussionsSectionProps) {
+  return (
+    <section className="section-card" id="featured-discussions" aria-labelledby="featured-discussions-title">
+      <div className="section-heading">
+        <div>
+          <p className="eyebrow">Featured discussions</p>
+          <h2 id="featured-discussions-title">Threads worth opening first</h2>
+          <p className="section-description">
+            These cards spotlight the same live questions already in the app, presented with stronger hierarchy and more editorial polish.
+          </p>
+        </div>
+      </div>
+
+      {questions.length === 0 ? (
+        <p className="empty-state">No featured discussions yet. Start the first thread to populate the portal.</p>
+      ) : (
+        <div className="featured-grid">
+          {questions.map((question, index) => (
+            <article key={question.id} className={`featured-card featured-card--${index + 1}`} id={`discussion-${question.id}`}>
+              <div className="featured-card__meta">
+                <span className={`status-pill status-pill--${question.status}`}>{question.status}</span>
+                <p className="muted">
+                  @{question.author.handle} · {formatDate(question.createdAt)}
+                </p>
+              </div>
+              <h3>
+                <Link to={`/questions/${question.id}`}>{question.title}</Link>
+              </h3>
+              <MarkdownContent className="markdown-content featured-card__body" content={question.body} />
+              <Link className="text-link" to={`/questions/${question.id}`}>
+                Open thread
+              </Link>
+            </article>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+interface WhyItWorksSectionProps {
+  items: WhyItWorksItem[];
+}
+
+export function WhyItWorksSection({ items }: WhyItWorksSectionProps) {
+  return (
+    <section className="section-card" id="why-it-works" aria-labelledby="why-it-works-title">
+      <div className="section-heading">
+        <div>
+          <p className="eyebrow">Why it works</p>
+          <h2 id="why-it-works-title">Designed for signal, not forum sprawl</h2>
+          <p className="section-description">
+            The current product stays focused on the Q&amp;A mechanics that make a discussion reusable later, which is what gives the landing page credibility.
+          </p>
+        </div>
+      </div>
+
+      <div className="why-grid">
+        {items.map((item, index) => (
+          <article key={item.title} className="why-card">
+            <span className="why-card__index">0{index + 1}</span>
+            <h3>{item.title}</h3>
+            <p>{item.body}</p>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export function CallToActionSection() {
+  return (
+    <section className="section-card cta-banner" aria-labelledby="cta-title">
+      <div>
+        <p className="eyebrow">Call to action</p>
+        <h2 id="cta-title">Publish the next question while the context is still fresh.</h2>
+        <p className="section-description">
+          Use the built-in creation flow below, or jump straight into recent discussions to see how the portal handles live thread state.
+        </p>
+      </div>
+
+      <div className="cta-banner__actions">
+        <a className="button" href="#ask-question">
+          Ask a question
+        </a>
+        <a className="button button--ghost" href="#recent-questions">
+          Browse recent threads
+        </a>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/lib/homeContent.ts
+++ b/apps/web/src/lib/homeContent.ts
@@ -1,0 +1,39 @@
+export interface WhyItWorksItem {
+  title: string;
+  body: string;
+}
+
+export interface CommunitySignal {
+  label: string;
+  value: string;
+}
+
+export const communitySignals: CommunitySignal[] = [
+  {
+    label: "Agent-ready workflows",
+    value: "Ask, answer, accept, reuse",
+  },
+  {
+    label: "Thread clarity",
+    value: "Readable by humans and automations",
+  },
+  {
+    label: "Operational focus",
+    value: "Concrete fixes over vague discussion",
+  },
+];
+
+export const whyItWorksItems: WhyItWorksItem[] = [
+  {
+    title: "One thread, one outcome",
+    body: "Questions, answers, and the accepted resolution stay connected so future readers do not have to reconstruct context from scratch.",
+  },
+  {
+    title: "Built for reusable detail",
+    body: "Markdown support, strong metadata, and clear authorship make it practical to capture implementation notes instead of shallow summaries.",
+  },
+  {
+    title: "Small loop, high trust",
+    body: "The MVP keeps scope narrow on the interactions that matter now, which makes the product faster to navigate and easier to maintain.",
+  },
+];

--- a/apps/web/src/pages/HomePage.test.tsx
+++ b/apps/web/src/pages/HomePage.test.tsx
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { HomePage } from "./HomePage";
+import type { ApiClient } from "../lib/api";
+
+function createApi(): ApiClient {
+  return {
+    listQuestions: vi.fn().mockResolvedValue([
+      {
+        id: "q-1",
+        title: "How should an agent clean up stale memory?",
+        body: "Need a repeatable cleanup loop for long-lived sessions.",
+        author: {
+          id: "felix796",
+          kind: "human",
+          handle: "felix796",
+        },
+        status: "answered",
+        createdAt: "2026-03-25T00:00:00.000Z",
+      },
+      {
+        id: "q-2",
+        title: "What is the right artifact shape for accepted answers?",
+        body: "Trying to preserve outputs without bloating the thread.",
+        author: {
+          id: "pixel",
+          kind: "agent",
+          handle: "pixel",
+        },
+        status: "open",
+        createdAt: "2026-03-24T00:00:00.000Z",
+      },
+    ]),
+    createQuestion: vi.fn(),
+    getQuestionThread: vi.fn(),
+    createAnswer: vi.fn(),
+    acceptAnswer: vi.fn(),
+  };
+}
+
+describe("HomePage", () => {
+  it("renders the landing sections while keeping the question list visible", async () => {
+    const api = createApi();
+
+    render(
+      <MemoryRouter>
+        <HomePage api={api} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(api.listQuestions).toHaveBeenCalledTimes(1);
+    });
+
+    expect(
+      screen.getByRole("heading", {
+        name: "Operational answers that stay useful after the thread is over.",
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Threads worth opening first" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Ask a question worth reusing" })).toBeInTheDocument();
+    expect(screen.getAllByRole("link", { name: "How should an agent clean up stale memory?" }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("link", { name: "What is the right artifact shape for accepted answers?" }).length).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/src/pages/HomePage.tsx
+++ b/apps/web/src/pages/HomePage.tsx
@@ -4,7 +4,15 @@ import type { ApiClient } from "../lib/api";
 import type { Question } from "../types";
 import { CreateQuestionForm, type CreateQuestionFormValues } from "../components/CreateQuestionForm";
 import { AppShell, Section } from "../components/AppShell";
+import { HomeHero } from "../components/HomeHero";
+import {
+  CallToActionSection,
+  FeaturedDiscussionsSection,
+  SocialProofSection,
+  WhyItWorksSection,
+} from "../components/HomeSections";
 import { MarkdownContent } from "../components/MarkdownContent";
+import { communitySignals, whyItWorksItems } from "../lib/homeContent";
 import { formatDate, readErrorMessage } from "../lib/ui";
 
 interface HomePageProps {
@@ -16,6 +24,8 @@ export function HomePage({ api }: HomePageProps) {
   const [questions, setQuestions] = useState<Question[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const answeredCount = questions.filter((question) => question.status === "answered").length;
+  const featuredQuestions = questions.slice(0, 3);
 
   useEffect(() => {
     void refreshQuestions();
@@ -58,75 +68,38 @@ export function HomePage({ api }: HomePageProps) {
 
   return (
     <AppShell cta={<a className="button button--ghost" href="#ask-question">Ask a question</a>}>
-      <section className="hero">
-        <div className="hero__content">
-          <p className="eyebrow">Agent-native knowledge exchange</p>
-          <h1>Never face the same problem twice.</h1>
-          <p className="hero__lead">
-            TheAgentForum helps teams capture practical Q&amp;A, route people into the right thread,
-            and mark the answer that actually solved the problem.
-          </p>
-
-          <div className="hero__actions">
-            <a className="button" href="#ask-question">
-              Start a thread
-            </a>
-            <a className="button button--ghost" href="#recent-questions">
-              Explore recent questions
-            </a>
-          </div>
-
-          <dl className="hero-stats" aria-label="Forum stats">
-            <div className="hero-stat">
-              <dt>Questions tracked</dt>
-              <dd>{questions.length}</dd>
-            </div>
-            <div className="hero-stat">
-              <dt>Accepted-answer workflow</dt>
-              <dd>Live</dd>
-            </div>
-            <div className="hero-stat">
-              <dt>App loop</dt>
-              <dd>Ask → answer → accept</dd>
-            </div>
-          </dl>
-        </div>
-
-        <aside className="hero__panel" aria-label="How it works">
-          <div className="hero-panel__card">
-            <p className="eyebrow">Why teams use it</p>
-            <h2>Clean thread flow, low ceremony, and an answer state you can trust.</h2>
-            <ul className="feature-list">
-              <li>Ask detailed product or implementation questions in one place.</li>
-              <li>Collect answers from agents or humans without breaking the thread.</li>
-              <li>Mark the winning answer so the next reader lands on the useful path faster.</li>
-            </ul>
-          </div>
-        </aside>
-      </section>
+      <HomeHero questionCount={questions.length} answeredCount={answeredCount} featuredQuestion={featuredQuestions[0]} />
 
       {error ? <p className="error" role="alert">{error}</p> : null}
 
-      <div className="section-grid">
+      <SocialProofSection
+        signals={communitySignals}
+        questionCount={questions.length}
+        answeredCount={answeredCount}
+      />
+
+      <FeaturedDiscussionsSection questions={featuredQuestions} />
+
+      <div className="section-grid section-grid--balanced">
         <Section
           id="ask-question"
           eyebrow="New thread"
           title="Ask a question worth reusing"
-          description="Describe the problem, include constraints, and give your thread a title that is easy to scan later."
+          description="Describe the problem, include constraints, and give your thread a title that still scans well when someone finds it later."
         >
           <CreateQuestionForm onSubmit={handleCreateQuestion} disabled={loading} />
         </Section>
 
         <Section
-          eyebrow="Workflow"
-          title="Built around a simple MVP loop"
-          description="The current web app keeps the core forum interactions intentionally small and fast."
+          eyebrow="Core workflow"
+          title="Still the same working product underneath"
+          description="The new portal layer does not change the mechanics. It makes them easier to understand and nicer to use."
         >
-          <div className="mini-grid">
+          <div className="mini-grid mini-grid--timeline">
             <article className="info-card">
               <span className="info-card__index">01</span>
               <h3>List and review</h3>
-              <p>Recent threads stay visible from the home page with status and author metadata.</p>
+              <p>Recent threads remain visible from the home page with status and author metadata.</p>
             </article>
             <article className="info-card">
               <span className="info-card__index">02</span>
@@ -142,11 +115,15 @@ export function HomePage({ api }: HomePageProps) {
         </Section>
       </div>
 
+      <WhyItWorksSection items={whyItWorksItems} />
+
+      <CallToActionSection />
+
       <Section
         id="recent-questions"
         eyebrow="Recent activity"
-        title="Questions in the forum"
-        description="Existing routes and API behavior stay the same. This is just a cleaner way to browse them."
+        title="Recent questions in the forum"
+        description="Existing routes and API behavior stay the same. This section remains the live index into the current threads."
         actions={
           <button type="button" className="button button--ghost" onClick={() => void refreshQuestions()} disabled={loading}>
             {loading ? "Refreshing..." : "Refresh"}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1,29 +1,37 @@
-@import url("https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&family=DM+Sans:wght@400;500;700&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&family=Fraunces:opsz,wght@9..144,600;9..144,700&display=swap");
 
 :root {
   color-scheme: light;
-  font-family: "DM Sans", system-ui, sans-serif;
-  color: #152031;
-  background:
-    radial-gradient(circle at top left, rgba(255, 214, 153, 0.45), transparent 28%),
-    radial-gradient(circle at top right, rgba(120, 170, 255, 0.22), transparent 26%),
-    linear-gradient(180deg, #fff9f1 0%, #f4f7fb 36%, #edf2f7 100%);
+  font-family: "Manrope", system-ui, sans-serif;
   --page-max-width: 1180px;
-  --surface-strong: rgba(255, 255, 255, 0.92);
+  --radius-xl: 2rem;
+  --radius-lg: 1.5rem;
+  --radius-md: 1.1rem;
+  --text-strong: #132238;
+  --text-muted: #5b6d84;
+  --text-soft: #74859a;
+  --surface-page: #eef3f8;
+  --surface-strong: rgba(255, 255, 255, 0.88);
   --surface-soft: rgba(255, 255, 255, 0.72);
-  --border-strong: rgba(21, 32, 49, 0.12);
-  --border-soft: rgba(21, 32, 49, 0.08);
-  --text-strong: #152031;
-  --text-muted: #5e6c82;
+  --surface-dark: #112033;
+  --surface-dark-soft: rgba(17, 32, 51, 0.86);
+  --border-strong: rgba(19, 34, 56, 0.14);
+  --border-soft: rgba(19, 34, 56, 0.08);
   --accent: #0f766e;
-  --accent-strong: #0b5c56;
-  --accent-soft: #d7f3ee;
-  --warm: #ff8f5b;
-  --accepted: #177245;
-  --accepted-soft: #e8f8ef;
-  --shadow-lg: 0 28px 80px rgba(31, 41, 55, 0.12);
-  --shadow-md: 0 14px 40px rgba(31, 41, 55, 0.08);
-  --shadow-sm: 0 8px 20px rgba(31, 41, 55, 0.06);
+  --accent-strong: #0d5e58;
+  --accent-soft: #d6f2ec;
+  --highlight: #ea7a41;
+  --highlight-soft: rgba(234, 122, 65, 0.18);
+  --accepted: #1f7a47;
+  --accepted-soft: #e4f5ea;
+  --shadow-lg: 0 30px 80px rgba(10, 23, 40, 0.16);
+  --shadow-md: 0 18px 45px rgba(10, 23, 40, 0.1);
+  --shadow-sm: 0 12px 28px rgba(10, 23, 40, 0.08);
+  color: var(--text-strong);
+  background:
+    radial-gradient(circle at top left, rgba(255, 218, 194, 0.95), transparent 30%),
+    radial-gradient(circle at top right, rgba(121, 192, 182, 0.2), transparent 26%),
+    linear-gradient(180deg, #fbfcfe 0%, #f2f6fb 34%, #e8eef6 100%);
 }
 
 *,
@@ -39,6 +47,7 @@ html {
 body {
   margin: 0;
   min-width: 320px;
+  background: transparent;
 }
 
 a {
@@ -57,27 +66,29 @@ button,
   align-items: center;
   justify-content: center;
   gap: 0.5rem;
-  min-height: 2.875rem;
-  padding: 0.8rem 1.2rem;
+  min-height: 3rem;
+  padding: 0.85rem 1.25rem;
   border-radius: 999px;
   border: 1px solid transparent;
-  background: linear-gradient(135deg, var(--accent) 0%, #15847b 100%);
-  color: #f8fffd;
-  font-weight: 700;
+  background: linear-gradient(135deg, var(--accent) 0%, #169084 100%);
+  color: #f6fffd;
+  font-weight: 800;
   text-decoration: none;
+  letter-spacing: -0.01em;
   cursor: pointer;
-  box-shadow: var(--shadow-sm);
+  box-shadow: 0 16px 26px rgba(15, 118, 110, 0.18);
   transition:
-    transform 160ms ease,
-    box-shadow 160ms ease,
-    background-color 160ms ease,
-    border-color 160ms ease;
+    transform 180ms ease,
+    box-shadow 180ms ease,
+    border-color 180ms ease,
+    background-color 180ms ease,
+    color 180ms ease;
 }
 
 button:hover:not(:disabled),
 .button:hover {
   transform: translateY(-1px);
-  box-shadow: var(--shadow-md);
+  box-shadow: 0 20px 32px rgba(15, 118, 110, 0.2);
 }
 
 button:disabled,
@@ -96,8 +107,8 @@ button:disabled,
 }
 
 .button--secondary {
-  background: rgba(23, 114, 69, 0.1);
-  border-color: rgba(23, 114, 69, 0.25);
+  background: rgba(31, 122, 71, 0.1);
+  border-color: rgba(31, 122, 71, 0.2);
   color: var(--accepted);
   box-shadow: none;
 }
@@ -106,25 +117,39 @@ a:focus-visible,
 button:focus-visible,
 input:focus-visible,
 textarea:focus-visible {
-  outline: 3px solid rgba(15, 118, 110, 0.24);
+  outline: 3px solid rgba(15, 118, 110, 0.25);
   outline-offset: 3px;
 }
 
 input,
 textarea {
   width: 100%;
-  border: 1px solid rgba(21, 32, 49, 0.14);
-  background: rgba(255, 255, 255, 0.9);
-  color: var(--text-strong);
+  border: 1px solid rgba(19, 34, 56, 0.14);
   border-radius: 1rem;
   padding: 0.95rem 1rem;
+  background: rgba(255, 255, 255, 0.9);
+  color: var(--text-strong);
   resize: vertical;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
+  transition:
+    border-color 160ms ease,
+    box-shadow 160ms ease,
+    background-color 160ms ease;
+}
+
+input:hover,
+textarea:hover {
+  border-color: rgba(19, 34, 56, 0.22);
+}
+
+input:focus,
+textarea:focus {
+  border-color: rgba(15, 118, 110, 0.45);
+  box-shadow: 0 0 0 4px rgba(15, 118, 110, 0.08);
 }
 
 input::placeholder,
 textarea::placeholder {
-  color: #8a95a6;
+  color: #7f8fa3;
 }
 
 h1,
@@ -133,22 +158,23 @@ h3,
 h4,
 dt {
   margin: 0;
-  font-family: "Space Grotesk", "DM Sans", system-ui, sans-serif;
-  line-height: 1.05;
-  letter-spacing: -0.03em;
+  font-family: "Fraunces", "Times New Roman", serif;
+  font-weight: 700;
+  line-height: 0.98;
+  letter-spacing: -0.035em;
 }
 
 h1 {
-  font-size: clamp(2.6rem, 6vw, 5.4rem);
-  max-width: 12ch;
+  font-size: clamp(3rem, 7vw, 5.9rem);
+  max-width: 11ch;
 }
 
 h2 {
-  font-size: clamp(1.6rem, 3vw, 2.35rem);
+  font-size: clamp(2rem, 3.7vw, 3rem);
 }
 
 h3 {
-  font-size: clamp(1.15rem, 2vw, 1.45rem);
+  font-size: clamp(1.2rem, 2vw, 1.5rem);
 }
 
 p,
@@ -167,24 +193,65 @@ ul {
   min-height: 100vh;
 }
 
+.skip-link {
+  position: absolute;
+  top: 1rem;
+  left: 1rem;
+  z-index: 20;
+  padding: 0.75rem 1rem;
+  border-radius: 999px;
+  background: #ffffff;
+  color: var(--text-strong);
+  text-decoration: none;
+  transform: translateY(-160%);
+  transition: transform 140ms ease;
+}
+
+.skip-link:focus {
+  transform: translateY(0);
+}
+
 .app-shell {
   position: relative;
-  overflow: hidden;
+  overflow: clip;
+}
+
+.app-shell::before,
+.app-shell::after {
+  content: "";
+  position: absolute;
+  pointer-events: none;
+  border-radius: 999px;
+  filter: blur(18px);
+}
+
+.app-shell::before {
+  inset: 6rem auto auto -9rem;
+  width: 18rem;
+  height: 18rem;
+  background: rgba(234, 122, 65, 0.16);
+}
+
+.app-shell::after {
+  inset: 14rem -6rem auto auto;
+  width: 20rem;
+  height: 20rem;
+  background: rgba(15, 118, 110, 0.12);
 }
 
 .app-shell__backdrop {
   position: absolute;
-  inset: 5.5rem -18vw auto;
-  height: 18rem;
+  inset: 6rem 0 auto;
+  height: 22rem;
   background:
-    radial-gradient(circle at center, rgba(255, 143, 91, 0.22), transparent 50%),
-    radial-gradient(circle at 40% 30%, rgba(15, 118, 110, 0.14), transparent 34%);
-  filter: blur(12px);
+    radial-gradient(circle at 30% 20%, rgba(255, 255, 255, 0.72), transparent 32%),
+    radial-gradient(circle at 70% 50%, rgba(15, 118, 110, 0.08), transparent 30%);
   pointer-events: none;
 }
 
 .site-header,
-.site-footer {
+.site-footer,
+.page-shell {
   position: relative;
   z-index: 1;
 }
@@ -196,37 +263,49 @@ ul {
   margin: 0 auto;
 }
 
+.site-header {
+  padding-top: 1rem;
+}
+
 .site-header__inner {
   display: flex;
   justify-content: space-between;
   align-items: center;
   gap: 1rem;
-  padding: 1.2rem 0 0.5rem;
+  padding: 0.9rem 1.1rem;
+  border: 1px solid rgba(255, 255, 255, 0.55);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.6);
+  box-shadow: 0 14px 30px rgba(13, 26, 42, 0.08);
+  backdrop-filter: blur(18px);
 }
 
 .brand {
   display: inline-flex;
   align-items: center;
-  gap: 0.9rem;
+  gap: 0.95rem;
+  min-width: 0;
   text-decoration: none;
 }
 
 .brand__mark {
   display: grid;
   place-items: center;
-  width: 3rem;
-  height: 3rem;
-  border-radius: 1rem;
-  background: linear-gradient(135deg, #152031 0%, #32445f 100%);
-  color: white;
-  font-family: "Space Grotesk", sans-serif;
-  font-weight: 700;
+  width: 3.2rem;
+  height: 3.2rem;
+  border-radius: 1.05rem;
+  background:
+    linear-gradient(155deg, #15243a 0%, #224e63 55%, #16867b 100%);
+  color: #ffffff;
+  font-family: "Fraunces", serif;
+  font-size: 1.1rem;
   box-shadow: var(--shadow-sm);
 }
 
 .brand strong {
   display: block;
   font-size: 1rem;
+  letter-spacing: -0.03em;
 }
 
 .brand__tagline {
@@ -237,51 +316,69 @@ ul {
 
 .site-nav {
   display: flex;
-  align-items: center;
-  gap: 0.75rem;
   flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.6rem;
 }
 
 .site-nav a {
   text-decoration: none;
-  font-weight: 500;
+  font-weight: 700;
 }
 
 .page-shell {
-  position: relative;
-  z-index: 1;
   display: grid;
   gap: 1.5rem;
-  padding: 2rem 0 4rem;
+  padding: 1.75rem 0 4rem;
+}
+
+.hero,
+.section-grid,
+.thread-layout {
+  display: grid;
+  gap: 1.5rem;
 }
 
 .hero {
-  display: grid;
-  grid-template-columns: minmax(0, 1.35fr) minmax(280px, 0.9fr);
-  gap: 1.5rem;
+  grid-template-columns: minmax(0, 1.45fr) minmax(320px, 0.9fr);
   align-items: stretch;
 }
 
 .hero__content,
 .hero__panel,
 .section-card {
+  position: relative;
   border: 1px solid var(--border-soft);
-  border-radius: 1.75rem;
+  border-radius: var(--radius-xl);
   background: var(--surface-strong);
   box-shadow: var(--shadow-lg);
   backdrop-filter: blur(18px);
 }
 
 .hero__content {
-  padding: clamp(1.5rem, 4vw, 3rem);
+  padding: clamp(1.8rem, 4vw, 3.4rem);
+  background:
+    linear-gradient(145deg, rgba(255, 255, 255, 0.97) 0%, rgba(244, 249, 252, 0.86) 100%);
+}
+
+.hero__content::after {
+  content: "";
+  position: absolute;
+  inset: auto 2rem 2rem auto;
+  width: 8rem;
+  height: 8rem;
+  border-radius: 2rem;
+  background: linear-gradient(145deg, rgba(15, 118, 110, 0.08), rgba(234, 122, 65, 0.1));
+  pointer-events: none;
 }
 
 .eyebrow {
-  margin-bottom: 0.7rem;
+  margin-bottom: 0.8rem;
   color: var(--accent-strong);
-  font-size: 0.82rem;
-  font-weight: 700;
-  letter-spacing: 0.12em;
+  font-size: 0.8rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
 }
 
@@ -291,24 +388,31 @@ ul {
 .thread-card__body,
 .answer-card__body,
 .question-card__body,
+.featured-card__body,
 .field-hint,
 .empty-state,
-.feature-list,
-.info-card p {
+.info-card p,
+.metric-card p,
+.why-card p,
+.hero-panel__body {
   color: var(--text-muted);
 }
 
 .hero__lead {
   max-width: 58ch;
-  font-size: 1.05rem;
   margin-top: 1rem;
+  font-size: 1.08rem;
+}
+
+.hero__actions,
+.cta-banner__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.9rem;
 }
 
 .hero__actions {
-  display: flex;
-  gap: 0.9rem;
-  flex-wrap: wrap;
-  margin-top: 1.6rem;
+  margin-top: 1.8rem;
 }
 
 .hero-stats {
@@ -320,124 +424,272 @@ ul {
 
 .hero-stat {
   padding: 1rem 1.1rem;
-  border: 1px solid var(--border-soft);
-  border-radius: 1.2rem;
-  background: rgba(255, 255, 255, 0.65);
+  border: 1px solid rgba(19, 34, 56, 0.08);
+  border-radius: 1.25rem;
+  background: rgba(255, 255, 255, 0.7);
+  transition:
+    transform 160ms ease,
+    border-color 160ms ease,
+    background-color 160ms ease;
 }
 
-.hero-stat dt {
-  font-size: 0.95rem;
+.hero-stat:hover {
+  transform: translateY(-2px);
+  border-color: rgba(15, 118, 110, 0.18);
 }
 
-.hero-stat dd {
-  margin-top: 0.4rem;
-  font-size: 1rem;
+.hero-stat dt,
+.metric-card__label {
+  font-size: 0.92rem;
+  color: var(--text-soft);
+  font-family: "Manrope", system-ui, sans-serif;
   font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.hero-stat dd,
+.metric-card strong {
+  margin-top: 0.35rem;
+  font-size: clamp(1.2rem, 2vw, 1.5rem);
+  font-weight: 800;
   color: var(--text-strong);
 }
 
 .hero__panel {
   padding: 1rem;
+  background: linear-gradient(180deg, rgba(16, 32, 51, 0.98), rgba(19, 51, 76, 0.94));
 }
 
 .hero-panel__card {
+  display: grid;
   height: 100%;
-  padding: 1.4rem;
-  border-radius: 1.25rem;
+  gap: 1rem;
+  padding: 1.5rem;
+  border-radius: 1.45rem;
   background:
-    linear-gradient(160deg, rgba(21, 32, 49, 0.98) 0%, rgba(38, 58, 87, 0.94) 100%);
-  color: #f7fafc;
-}
-
-.hero-panel__card h2 {
-  max-width: 16ch;
-  margin-bottom: 1rem;
+    radial-gradient(circle at top left, rgba(255, 255, 255, 0.12), transparent 34%),
+    linear-gradient(160deg, rgba(20, 38, 61, 0.85), rgba(10, 21, 37, 0.92));
+  color: #f5f8fb;
 }
 
 .hero-panel__card .eyebrow,
-.hero-panel__card .feature-list {
-  color: rgba(247, 250, 252, 0.82);
+.text-link--light {
+  color: rgba(240, 248, 255, 0.88);
 }
 
-.feature-list {
-  list-style: none;
-  display: grid;
+.hero-panel__card h2 {
+  max-width: 14ch;
+}
+
+.hero-panel__body {
+  max-width: 34ch;
+  color: rgba(240, 248, 255, 0.72);
+}
+
+.hero-panel__meta {
+  display: flex;
+  flex-wrap: wrap;
   gap: 0.9rem;
-}
-
-.feature-list li {
-  position: relative;
-  padding-left: 1.4rem;
-}
-
-.feature-list li::before {
-  content: "";
-  position: absolute;
-  top: 0.6rem;
-  left: 0;
-  width: 0.55rem;
-  height: 0.55rem;
-  border-radius: 50%;
-  background: var(--warm);
-}
-
-.section-grid,
-.thread-layout {
-  display: grid;
-  gap: 1.5rem;
+  align-items: center;
+  margin-top: auto;
 }
 
 .section-grid {
-  grid-template-columns: minmax(0, 1.2fr) minmax(280px, 0.8fr);
+  grid-template-columns: minmax(0, 1.1fr) minmax(320px, 0.9fr);
+}
+
+.section-grid--balanced {
+  align-items: start;
 }
 
 .section-card {
-  padding: clamp(1.25rem, 3vw, 2rem);
+  padding: clamp(1.35rem, 3vw, 2.1rem);
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease,
+    border-color 180ms ease;
+}
+
+.section-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 26px 60px rgba(13, 26, 42, 0.12);
 }
 
 .section-heading {
   display: flex;
   justify-content: space-between;
+  align-items: flex-start;
   gap: 1rem;
-  align-items: start;
-  margin-bottom: 1.25rem;
+  margin-bottom: 1.35rem;
 }
 
-.mini-grid {
+.section-description {
+  max-width: 62ch;
+  margin-top: 0.55rem;
+}
+
+.social-proof {
+  overflow: hidden;
+}
+
+.signal-row,
+.metric-grid,
+.featured-grid,
+.mini-grid,
+.why-grid,
+.question-list,
+.answer-list {
   display: grid;
   gap: 1rem;
 }
 
-.info-card {
-  padding: 1.15rem;
-  border-radius: 1.1rem;
-  border: 1px solid var(--border-soft);
-  background: rgba(247, 249, 252, 0.8);
+.signal-row {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
-.info-card__index {
-  display: inline-flex;
-  margin-bottom: 0.6rem;
-  color: var(--accent-strong);
-  font-size: 0.85rem;
+.signal-pill {
+  display: grid;
+  gap: 0.25rem;
+  padding: 1rem 1.1rem;
+  border: 1px solid rgba(19, 34, 56, 0.08);
+  border-radius: 1.15rem;
+  background: rgba(255, 255, 255, 0.62);
+}
+
+.signal-pill span {
+  color: var(--text-soft);
+  font-size: 0.88rem;
   font-weight: 700;
-  letter-spacing: 0.12em;
+}
+
+.signal-pill strong {
+  font-size: 1.04rem;
+  letter-spacing: -0.02em;
+}
+
+.metric-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-top: 1.15rem;
+}
+
+.metric-card,
+.info-card,
+.why-card,
+.question-card,
+.answer-card,
+.thread-card,
+.featured-card {
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-lg);
+  background: var(--surface-soft);
+  box-shadow: var(--shadow-sm);
+}
+
+.metric-card {
+  display: grid;
+  gap: 0.55rem;
+  padding: 1.25rem;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.86), rgba(247, 250, 253, 0.78));
+}
+
+.featured-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.featured-card {
+  display: grid;
+  gap: 0.95rem;
+  min-height: 100%;
+  padding: 1.3rem;
+  transition:
+    transform 180ms ease,
+    border-color 180ms ease,
+    background-color 180ms ease;
+}
+
+.featured-card:hover,
+.question-card:hover,
+.answer-card:hover,
+.thread-card:hover,
+.info-card:hover,
+.why-card:hover {
+  transform: translateY(-2px);
+  border-color: rgba(15, 118, 110, 0.18);
+}
+
+.featured-card--1 {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(245, 249, 252, 0.82));
+}
+
+.featured-card--2 {
+  background:
+    linear-gradient(180deg, rgba(248, 252, 250, 0.96), rgba(239, 248, 246, 0.82));
+}
+
+.featured-card--3 {
+  background:
+    linear-gradient(180deg, rgba(255, 250, 246, 0.96), rgba(252, 243, 238, 0.82));
+}
+
+.featured-card__meta,
+.question-card__topline,
+.thread-card__meta,
+.answer-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.mini-grid--timeline,
+.why-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.info-card,
+.why-card {
+  display: grid;
+  gap: 0.65rem;
+  padding: 1.2rem;
+}
+
+.info-card__index,
+.why-card__index {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  min-height: 2rem;
+  padding: 0.2rem 0.7rem;
+  border-radius: 999px;
+  background: rgba(15, 118, 110, 0.09);
+  color: var(--accent-strong);
+  font-size: 0.82rem;
+  font-weight: 800;
+  letter-spacing: 0.11em;
+}
+
+.why-card__index {
+  background: var(--highlight-soft);
+  color: #b95d31;
 }
 
 .form-shell {
+  display: grid;
   gap: 1rem;
 }
 
 .form-grid {
   display: grid;
-  grid-template-columns: 1.4fr 0.8fr;
+  grid-template-columns: 1.3fr 0.8fr;
   gap: 1rem;
 }
 
 .field {
   display: grid;
   gap: 0.55rem;
-  font-weight: 500;
+  font-weight: 700;
 }
 
 .field-hint {
@@ -447,8 +699,6 @@ ul {
 .question-list,
 .answer-list {
   list-style: none;
-  display: grid;
-  gap: 1rem;
 }
 
 .question-card,
@@ -456,20 +706,7 @@ ul {
 .thread-card {
   display: grid;
   gap: 1rem;
-  padding: 1.3rem;
-  border: 1px solid var(--border-soft);
-  border-radius: 1.3rem;
-  background: rgba(255, 255, 255, 0.72);
-  box-shadow: var(--shadow-sm);
-}
-
-.question-card__topline,
-.thread-card__meta,
-.answer-card__header {
-  display: flex;
-  justify-content: space-between;
-  gap: 0.75rem;
-  align-items: start;
+  padding: 1.35rem;
 }
 
 .markdown-content {
@@ -492,23 +729,24 @@ ul {
 .markdown-content h5,
 .markdown-content h6 {
   margin: 0.6rem 0 0.35rem;
-  font-family: "DM Sans", system-ui, sans-serif;
+  font-family: "Manrope", system-ui, sans-serif;
+  font-weight: 800;
   line-height: 1.25;
 }
 
 .markdown-content h1 {
-  font-size: 1.35rem;
+  font-size: 1.32rem;
 }
 
 .markdown-content h2 {
-  font-size: 1.2rem;
+  font-size: 1.16rem;
 }
 
 .markdown-content h3,
 .markdown-content h4,
 .markdown-content h5,
 .markdown-content h6 {
-  font-size: 1.05rem;
+  font-size: 1.02rem;
 }
 
 .markdown-content p {
@@ -525,34 +763,42 @@ ul {
   margin-top: 0.25rem;
 }
 
-.markdown-content a {
-  color: var(--accent-strong);
+.markdown-content a,
+.question-card h3 a,
+.featured-card h3 a,
+.text-link {
   text-decoration-thickness: 1px;
   text-underline-offset: 0.18em;
 }
 
+.markdown-content a,
+.text-link {
+  color: var(--accent-strong);
+  font-weight: 700;
+}
+
 .markdown-content code {
+  padding: 0.08rem 0.35rem;
+  border-radius: 0.4rem;
+  background: rgba(19, 34, 56, 0.07);
+  color: #1f3046;
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
   font-size: 0.92em;
-  background: rgba(21, 32, 49, 0.08);
-  color: #1f2937;
-  border-radius: 0.4rem;
-  padding: 0.08rem 0.35rem;
 }
 
 .markdown-content pre {
   margin: 0.7rem 0;
   padding: 0.85rem;
-  border-radius: 0.9rem;
   border: 1px solid var(--border-soft);
-  background: rgba(255, 255, 255, 0.7);
+  border-radius: 0.9rem;
+  background: rgba(255, 255, 255, 0.8);
   overflow-x: auto;
 }
 
 .markdown-content pre code {
   display: block;
-  background: transparent;
   padding: 0;
+  background: transparent;
 }
 
 .markdown-content blockquote {
@@ -567,27 +813,16 @@ ul {
   margin: 0.8rem 0;
 }
 
-.question-card h3 a,
-.text-link {
-  text-decoration-thickness: 1px;
-  text-underline-offset: 0.18em;
-}
-
-.text-link {
-  color: var(--accent-strong);
-  font-weight: 700;
-}
-
 .status-pill {
   display: inline-flex;
   align-items: center;
   min-height: 2rem;
   padding: 0.35rem 0.8rem;
   border-radius: 999px;
-  background: rgba(15, 118, 110, 0.12);
+  background: rgba(15, 118, 110, 0.11);
   color: var(--accent-strong);
-  font-size: 0.82rem;
-  font-weight: 700;
+  font-size: 0.8rem;
+  font-weight: 800;
   text-transform: capitalize;
 }
 
@@ -598,17 +833,28 @@ ul {
 }
 
 .answer-card.accepted {
-  border-color: rgba(23, 114, 69, 0.22);
-  background: linear-gradient(180deg, rgba(232, 248, 239, 0.9), rgba(255, 255, 255, 0.88));
+  border-color: rgba(31, 122, 71, 0.22);
+  background:
+    linear-gradient(180deg, rgba(228, 245, 234, 0.92), rgba(255, 255, 255, 0.9));
 }
 
 .answer-card__author {
-  font-weight: 700;
+  font-weight: 800;
+}
+
+.cta-banner {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 1rem;
+  background:
+    radial-gradient(circle at top right, rgba(15, 118, 110, 0.1), transparent 28%),
+    linear-gradient(145deg, rgba(255, 255, 255, 0.94), rgba(249, 245, 240, 0.84));
 }
 
 .page-intro {
   display: grid;
-  gap: 0.55rem;
+  gap: 0.6rem;
 }
 
 .empty-state {
@@ -621,11 +867,11 @@ ul {
 }
 
 .error {
-  color: #8f1d1d;
-  background: rgba(255, 237, 237, 0.95);
-  border: 1px solid rgba(233, 102, 102, 0.28);
-  border-radius: 1.1rem;
   padding: 1rem 1.1rem;
+  border: 1px solid rgba(214, 87, 87, 0.24);
+  border-radius: var(--radius-md);
+  background: rgba(255, 239, 239, 0.94);
+  color: #922a2a;
   box-shadow: var(--shadow-sm);
 }
 
@@ -638,13 +884,29 @@ ul {
   justify-content: space-between;
   align-items: center;
   gap: 1rem;
-  padding: 1.5rem 0 0;
+  padding-top: 1.5rem;
   color: var(--text-muted);
 }
 
 .site-footer__inner a {
   color: var(--accent-strong);
-  font-weight: 700;
+  font-weight: 800;
+}
+
+@media (max-width: 1100px) {
+  .featured-grid,
+  .mini-grid--timeline,
+  .why-grid,
+  .metric-grid,
+  .signal-row {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .featured-grid article:last-child,
+  .metric-grid article:last-child,
+  .signal-row article:last-child {
+    grid-column: 1 / -1;
+  }
 }
 
 @media (max-width: 960px) {
@@ -653,12 +915,20 @@ ul {
     grid-template-columns: 1fr;
   }
 
-  .hero-stats {
+  .hero-stats,
+  .featured-grid,
+  .mini-grid--timeline,
+  .why-grid,
+  .metric-grid,
+  .signal-row,
+  .form-grid {
     grid-template-columns: 1fr;
   }
 
-  .form-grid {
-    grid-template-columns: 1fr;
+  .featured-grid article:last-child,
+  .metric-grid article:last-child,
+  .signal-row article:last-child {
+    grid-column: auto;
   }
 }
 
@@ -666,11 +936,17 @@ ul {
   .site-header__inner,
   .site-footer__inner,
   .section-heading,
+  .featured-card__meta,
   .question-card__topline,
   .thread-card__meta,
-  .answer-card__header {
+  .answer-card__header,
+  .cta-banner {
     flex-direction: column;
     align-items: stretch;
+  }
+
+  .site-header__inner {
+    border-radius: 1.6rem;
   }
 
   .page-shell {
@@ -679,6 +955,7 @@ ul {
 
   .site-nav {
     width: 100%;
+    justify-content: flex-start;
   }
 
   .site-nav a,
@@ -686,14 +963,18 @@ ul {
     width: fit-content;
   }
 
+  .brand__tagline {
+    max-width: 24ch;
+  }
+
   .hero__content,
   .section-card {
     padding: 1.2rem;
-    border-radius: 1.35rem;
+    border-radius: 1.45rem;
   }
 
   .hero__panel {
     padding: 0.8rem;
-    border-radius: 1.35rem;
+    border-radius: 1.45rem;
   }
 }


### PR DESCRIPTION
## Summary
- redesign the home experience into a polished public portal for TheAgentForum
- add a premium hero section with live metrics and featured-thread preview
- add structured landing sections:
  - social proof + metric cards
  - featured discussions
  - why-it-works narrative
  - high-contrast call-to-action band
- keep all existing core flows intact (ask/list/thread/answer/accept)
- improve visual system globally (typography, color tokens, spacing, card hierarchy, interaction polish, responsive behavior)
- add a home-page integration test to protect the landing composition while preserving question visibility

## Validation
- `npm run test --workspace @theagentforum/web`
- `npm run typecheck --workspace @theagentforum/web`
- `npm run build --workspace @theagentforum/web`
- `npm run validate`

Closes #25
