### PR TITLE
feat(web): improve browsing and add dark mode

### DIFF
--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,4 +1,5 @@
 import type {
+  AnswerSkill,
   CreateAnswerInput,
   CreateQuestionInput,
   Question,
@@ -75,6 +76,16 @@ export function createApiClient(baseUrl = defaultBaseUrl) {
     );
   }
 
+  async function listAnswerSkills(
+    questionId: string,
+    answerId: string,
+  ): Promise<AnswerSkill[]> {
+    return request<AnswerSkill[]>(
+      "GET",
+      `/questions/${encodeURIComponent(questionId)}/answers/${encodeURIComponent(answerId)}/skills`,
+    );
+  }
+
   async function acceptAnswer(
     questionId: string,
     answerId: string,
@@ -121,6 +132,7 @@ export function createApiClient(baseUrl = defaultBaseUrl) {
     createQuestion,
     getQuestionThread,
     createAnswer,
+    listAnswerSkills,
     acceptAnswer,
   };
 }

--- a/apps/web/src/pages/HomePage.test.tsx
+++ b/apps/web/src/pages/HomePage.test.tsx
@@ -1,66 +1,83 @@
 import { describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { HomePage } from "./HomePage";
 import type { ApiClient } from "../lib/api";
+import type { Question } from "../types";
 
-function createApi(): ApiClient {
+function buildQuestion(index: number, status: "open" | "answered"): Question {
   return {
-    listQuestions: vi.fn().mockResolvedValue([
-      {
-        id: "q-1",
-        title: "How should an agent clean up stale memory?",
-        body: "Need a repeatable cleanup loop for long-lived sessions.",
-        author: {
-          id: "felix796",
-          kind: "human",
-          handle: "felix796",
-        },
-        status: "answered",
-        createdAt: "2026-03-25T00:00:00.000Z",
-      },
-      {
-        id: "q-2",
-        title: "What is the right artifact shape for accepted answers?",
-        body: "Trying to preserve outputs without bloating the thread.",
-        author: {
-          id: "pixel",
-          kind: "agent",
-          handle: "pixel",
-        },
-        status: "open",
-        createdAt: "2026-03-24T00:00:00.000Z",
-      },
-    ]),
-    createQuestion: vi.fn(),
-    getQuestionThread: vi.fn(),
-    createAnswer: vi.fn(),
-    acceptAnswer: vi.fn(),
+    id: `q-${index}`,
+    title: `Question ${index}`,
+    body: `Body ${index}`,
+    status,
+    createdAt: `2026-03-${String(index).padStart(2, "0")}T12:00:00.000Z`,
+    author: {
+      id: `author-${index}`,
+      kind: "human",
+      handle: `user${index}`,
+      displayName: `User ${index}`,
+    },
   };
 }
 
-describe("HomePage", () => {
-  it("renders the landing sections while keeping the question list visible", async () => {
-    const api = createApi();
+function renderHomePage(questions: Question[]) {
+  const api = {
+    listQuestions: vi.fn().mockResolvedValue(questions),
+    createQuestion: vi.fn(),
+    getQuestionThread: vi.fn(),
+    createAnswer: vi.fn(),
+    listAnswerSkills: vi.fn(),
+    acceptAnswer: vi.fn(),
+  } as unknown as ApiClient;
 
-    render(
-      <MemoryRouter>
-        <HomePage api={api} />
-      </MemoryRouter>,
-    );
+  render(
+    <MemoryRouter>
+      <HomePage api={api} />
+    </MemoryRouter>,
+  );
+
+  return { api };
+}
+
+describe("HomePage", () => {
+  it("limits the default list, filters by status, and loads more questions", async () => {
+    const user = userEvent.setup();
+    const questions = [
+      buildQuestion(1, "open"),
+      buildQuestion(2, "answered"),
+      buildQuestion(3, "open"),
+      buildQuestion(4, "answered"),
+      buildQuestion(5, "open"),
+      buildQuestion(6, "answered"),
+      buildQuestion(7, "open"),
+      buildQuestion(8, "answered"),
+    ];
+
+    renderHomePage(questions);
 
     await waitFor(() => {
-      expect(api.listQuestions).toHaveBeenCalledTimes(1);
+      expect(screen.getByText("Showing 6 of 8 questions")).toBeInTheDocument();
     });
 
-    expect(
-      screen.getByRole("heading", {
-        name: "Operational answers that stay useful after the thread is over.",
-      }),
-    ).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "Threads worth opening first" })).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "Ask a question worth reusing" })).toBeInTheDocument();
-    expect(screen.getAllByRole("link", { name: "How should an agent clean up stale memory?" }).length).toBeGreaterThan(0);
-    expect(screen.getAllByRole("link", { name: "What is the right artifact shape for accepted answers?" }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("link", { name: "Question 1" }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("link", { name: "Question 6" }).length).toBeGreaterThan(0);
+    expect(screen.queryByRole("link", { name: "Question 7" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Load more" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("tab", { name: "Answered" }));
+
+    expect(screen.getByText("Showing 4 of 4 answered questions")).toBeInTheDocument();
+    expect(screen.getAllByRole("link", { name: "Question 2" }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("link", { name: "Question 8" }).length).toBeGreaterThan(0);
+    expect(screen.queryByRole("button", { name: "Load more" })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("tab", { name: "All" }));
+    await user.click(screen.getByRole("button", { name: "Load more" }));
+
+    expect(screen.getByText("Showing 8 of 8 questions")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Question 8" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Load more" })).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/pages/HomePage.tsx
+++ b/apps/web/src/pages/HomePage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import type { ApiClient } from "../lib/api";
-import type { Question } from "../types";
+import type { Question, QuestionStatus } from "../types";
 import { CreateQuestionForm, type CreateQuestionFormValues } from "../components/CreateQuestionForm";
 import { AppShell, Section } from "../components/AppShell";
 import { HomeHero } from "../components/HomeHero";
@@ -19,13 +19,35 @@ interface HomePageProps {
   api: ApiClient;
 }
 
+type QuestionStatusFilter = "all" | QuestionStatus;
+
+const INITIAL_VISIBLE_QUESTIONS = 6;
+const LOAD_MORE_STEP = 6;
+
 export function HomePage({ api }: HomePageProps) {
   const navigate = useNavigate();
   const [questions, setQuestions] = useState<Question[]>([]);
+  const [statusFilter, setStatusFilter] = useState<QuestionStatusFilter>("all");
+  const [visibleCount, setVisibleCount] = useState(INITIAL_VISIBLE_QUESTIONS);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const answeredCount = questions.filter((question) => question.status === "answered").length;
   const featuredQuestions = questions.slice(0, 3);
+
+  const filteredQuestions = questions.filter((question) => {
+    if (statusFilter === "all") {
+      return true;
+    }
+
+    return question.status === statusFilter;
+  });
+  const visibleQuestions = filteredQuestions.slice(0, visibleCount);
+  const hasMoreQuestions = visibleQuestions.length < filteredQuestions.length;
+  const statusOptions: Array<{ value: QuestionStatusFilter; label: string }> = [
+    { value: "all", label: "All" },
+    { value: "open", label: "Open" },
+    { value: "answered", label: "Answered" },
+  ];
 
   useEffect(() => {
     void refreshQuestions();
@@ -37,11 +59,17 @@ export function HomePage({ api }: HomePageProps) {
 
     try {
       setQuestions(await api.listQuestions());
+      setVisibleCount(INITIAL_VISIBLE_QUESTIONS);
     } catch (cause) {
       setError(readErrorMessage(cause));
     } finally {
       setLoading(false);
     }
+  }
+
+  function handleStatusFilterChange(nextFilter: QuestionStatusFilter): void {
+    setStatusFilter(nextFilter);
+    setVisibleCount(INITIAL_VISIBLE_QUESTIONS);
   }
 
   async function handleCreateQuestion(values: CreateQuestionFormValues): Promise<void> {
@@ -135,27 +163,73 @@ export function HomePage({ api }: HomePageProps) {
         {!loading && questions.length === 0 ? <p className="empty-state">No questions yet.</p> : null}
 
         {!loading && questions.length > 0 ? (
-          <ul className="question-list" aria-label="Recent questions">
-            {questions.map((question) => (
-              <li key={question.id}>
-                <article className="question-card">
-                  <div className="question-card__topline">
-                    <span className={`status-pill status-pill--${question.status}`}>{question.status}</span>
-                    <p className="muted">
-                      @{question.author.handle} · {formatDate(question.createdAt)}
-                    </p>
+          <>
+            <div className="question-browser" aria-label="Question browsing controls">
+              <div className="filter-group" role="tablist" aria-label="Question status filter">
+                {statusOptions.map((option) => {
+                  const selected = option.value === statusFilter;
+
+                  return (
+                    <button
+                      key={option.value}
+                      type="button"
+                      role="tab"
+                      aria-selected={selected}
+                      className={`filter-chip${selected ? " filter-chip--active" : ""}`}
+                      onClick={() => handleStatusFilterChange(option.value)}
+                    >
+                      {option.label}
+                    </button>
+                  );
+                })}
+              </div>
+
+              <p className="muted question-browser__summary">
+                Showing {visibleQuestions.length} of {filteredQuestions.length}{" "}
+                {statusFilter === "all" ? "questions" : `${statusFilter} questions`}
+              </p>
+            </div>
+
+            {filteredQuestions.length === 0 ? (
+              <p className="empty-state">No {statusFilter === "all" ? "" : statusFilter} questions yet.</p>
+            ) : (
+              <>
+                <ul className="question-list" aria-label="Recent questions">
+                  {visibleQuestions.map((question) => (
+                    <li key={question.id}>
+                      <article className="question-card">
+                        <div className="question-card__topline">
+                          <span className={`status-pill status-pill--${question.status}`}>{question.status}</span>
+                          <p className="muted">
+                            @{question.author.handle} · {formatDate(question.createdAt)}
+                          </p>
+                        </div>
+                        <h3>
+                          <Link to={`/questions/${question.id}`}>{question.title}</Link>
+                        </h3>
+                        <MarkdownContent className="markdown-content question-card__body" content={question.body} />
+                        <Link className="text-link" to={`/questions/${question.id}`}>
+                          Open thread
+                        </Link>
+                      </article>
+                    </li>
+                  ))}
+                </ul>
+
+                {hasMoreQuestions ? (
+                  <div className="question-browser__actions">
+                    <button
+                      type="button"
+                      className="button button--ghost"
+                      onClick={() => setVisibleCount((count) => count + LOAD_MORE_STEP)}
+                    >
+                      Load more
+                    </button>
                   </div>
-                  <h3>
-                    <Link to={`/questions/${question.id}`}>{question.title}</Link>
-                  </h3>
-                  <MarkdownContent className="markdown-content question-card__body" content={question.body} />
-                  <Link className="text-link" to={`/questions/${question.id}`}>
-                    Open thread
-                  </Link>
-                </article>
-              </li>
-            ))}
-          </ul>
+                ) : null}
+              </>
+            )}
+          </>
         ) : null}
       </Section>
     </AppShell>

--- a/apps/web/src/pages/QuestionPage.tsx
+++ b/apps/web/src/pages/QuestionPage.tsx
@@ -1,11 +1,23 @@
 import { useEffect, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import type { ApiClient } from "../lib/api";
-import type { QuestionThread } from "../types";
+import type { AnswerSkill, QuestionThread } from "../types";
 import { AnswerForm, type AnswerFormValues } from "../components/AnswerForm";
 import { AppShell, Section } from "../components/AppShell";
 import { MarkdownContent } from "../components/MarkdownContent";
 import { formatDate, readErrorMessage } from "../lib/ui";
+
+function formatSkillType(skill: AnswerSkill): string {
+  if (skill.mimeType) {
+    return skill.mimeType;
+  }
+
+  if (skill.url) {
+    return "remote reference";
+  }
+
+  return "inline artifact";
+}
 
 interface QuestionPageProps {
   api: ApiClient;
@@ -14,6 +26,7 @@ interface QuestionPageProps {
 export function QuestionPage({ api }: QuestionPageProps) {
   const { questionId } = useParams<{ questionId: string }>();
   const [thread, setThread] = useState<QuestionThread | null>(null);
+  const [answerSkills, setAnswerSkills] = useState<Record<string, AnswerSkill[]>>({});
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [acceptingAnswerId, setAcceptingAnswerId] = useState<string | null>(null);
@@ -33,10 +46,23 @@ export function QuestionPage({ api }: QuestionPageProps) {
     setError(null);
 
     try {
-      setThread(await api.getQuestionThread(questionId));
+      const nextThread = await api.getQuestionThread(questionId);
+      setThread(nextThread);
+
+      const nextSkills = Object.fromEntries(
+        await Promise.all(
+          nextThread.answers.map(async (answer) => [
+            answer.id,
+            await api.listAnswerSkills(questionId, answer.id),
+          ]),
+        ),
+      );
+
+      setAnswerSkills(nextSkills);
     } catch (cause) {
       setError(readErrorMessage(cause));
       setThread(null);
+      setAnswerSkills({});
     } finally {
       setLoading(false);
     }
@@ -138,6 +164,46 @@ export function QuestionPage({ api }: QuestionPageProps) {
                         </div>
 
                         <MarkdownContent className="markdown-content answer-card__body" content={answer.body} />
+
+                        {answerSkills[answer.id]?.length ? (
+                          <section className="artifact-panel" aria-label={`Attached skills for answer ${answer.id}`}>
+                            <div className="artifact-panel__header">
+                              <h3>Attached skills / artifacts</h3>
+                              <span className="status-pill status-pill--artifact">
+                                {answerSkills[answer.id].length}
+                              </span>
+                            </div>
+
+                            <ul className="artifact-list">
+                              {answerSkills[answer.id].map((skill) => (
+                                <li key={skill.id} className="artifact-card">
+                                  <div className="artifact-card__meta">
+                                    <strong>{skill.name}</strong>
+                                    <span>{formatSkillType(skill)}</span>
+                                  </div>
+
+                                  {skill.content ? (
+                                    <MarkdownContent
+                                      className="markdown-content artifact-card__content"
+                                      content={skill.content}
+                                    />
+                                  ) : null}
+
+                                  {skill.url ? (
+                                    <a
+                                      className="text-link artifact-card__link"
+                                      href={skill.url}
+                                      target="_blank"
+                                      rel="noreferrer"
+                                    >
+                                      Open linked artifact
+                                    </a>
+                                  ) : null}
+                                </li>
+                              ))}
+                            </ul>
+                          </section>
+                        ) : null}
 
                         <button
                           type="button"

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1,7 +1,7 @@
 @import url("https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&family=Fraunces:opsz,wght@9..144,600;9..144,700&display=swap");
 
 :root {
-  color-scheme: light;
+  color-scheme: light dark;
   font-family: "Manrope", system-ui, sans-serif;
   --page-max-width: 1180px;
   --radius-xl: 2rem;
@@ -24,14 +24,48 @@
   --highlight-soft: rgba(234, 122, 65, 0.18);
   --accepted: #1f7a47;
   --accepted-soft: #e4f5ea;
+  --artifact-soft: rgba(50, 68, 95, 0.12);
+  --artifact-text: #32445f;
   --shadow-lg: 0 30px 80px rgba(10, 23, 40, 0.16);
   --shadow-md: 0 18px 45px rgba(10, 23, 40, 0.1);
   --shadow-sm: 0 12px 28px rgba(10, 23, 40, 0.08);
-  color: var(--text-strong);
-  background:
+  --page-background:
     radial-gradient(circle at top left, rgba(255, 218, 194, 0.95), transparent 30%),
     radial-gradient(circle at top right, rgba(121, 192, 182, 0.2), transparent 26%),
     linear-gradient(180deg, #fbfcfe 0%, #f2f6fb 34%, #e8eef6 100%);
+  color: var(--text-strong);
+  background: var(--page-background);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --text-strong: #e6eef8;
+    --text-muted: #a8b7c9;
+    --text-soft: #90a4bc;
+    --surface-page: #0f1722;
+    --surface-strong: rgba(12, 21, 34, 0.88);
+    --surface-soft: rgba(17, 28, 42, 0.78);
+    --surface-dark: #07111c;
+    --surface-dark-soft: rgba(10, 20, 32, 0.9);
+    --border-strong: rgba(181, 202, 226, 0.18);
+    --border-soft: rgba(181, 202, 226, 0.1);
+    --accent: #34b3a7;
+    --accent-strong: #7be2d8;
+    --accent-soft: rgba(52, 179, 167, 0.16);
+    --highlight: #ffb089;
+    --highlight-soft: rgba(255, 176, 137, 0.16);
+    --accepted: #78d99d;
+    --accepted-soft: rgba(23, 114, 69, 0.18);
+    --artifact-soft: rgba(123, 151, 187, 0.18);
+    --artifact-text: #c6d7ed;
+    --shadow-lg: 0 30px 80px rgba(1, 7, 15, 0.52);
+    --shadow-md: 0 18px 45px rgba(1, 7, 15, 0.36);
+    --shadow-sm: 0 12px 28px rgba(1, 7, 15, 0.28);
+    --page-background:
+      radial-gradient(circle at top left, rgba(255, 167, 106, 0.12), transparent 30%),
+      radial-gradient(circle at top right, rgba(88, 145, 255, 0.14), transparent 28%),
+      linear-gradient(180deg, #08111d 0%, #0d1623 38%, #111c2a 100%);
+  }
 }
 
 *,
@@ -47,7 +81,8 @@ html {
 body {
   margin: 0;
   min-width: 320px;
-  background: transparent;
+  color: var(--text-strong);
+  background: var(--page-background);
 }
 
 a {
@@ -538,7 +573,8 @@ ul {
 .mini-grid,
 .why-grid,
 .question-list,
-.answer-list {
+.answer-list,
+.artifact-list {
   display: grid;
   gap: 1rem;
 }
@@ -697,8 +733,51 @@ ul {
 }
 
 .question-list,
-.answer-list {
+.answer-list,
+.artifact-list {
   list-style: none;
+}
+
+.question-browser {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+}
+
+.question-browser__summary {
+  font-weight: 700;
+}
+
+.question-browser__actions {
+  display: flex;
+  justify-content: center;
+  margin-top: 1.25rem;
+}
+
+.filter-group {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.filter-chip {
+  min-height: 2.4rem;
+  padding: 0.55rem 0.95rem;
+  border-radius: 999px;
+  border: 1px solid var(--border-strong);
+  background: var(--surface-soft);
+  color: var(--text-strong);
+  font-weight: 700;
+  box-shadow: none;
+}
+
+.filter-chip--active {
+  background: linear-gradient(135deg, var(--accent) 0%, #169084 100%);
+  color: #f6fffd;
+  border-color: transparent;
 }
 
 .question-card,
@@ -832,6 +911,11 @@ ul {
   color: var(--accepted);
 }
 
+.status-pill--artifact {
+  background: var(--artifact-soft);
+  color: var(--artifact-text);
+}
+
 .answer-card.accepted {
   border-color: rgba(31, 122, 71, 0.22);
   background:
@@ -840,6 +924,53 @@ ul {
 
 .answer-card__author {
   font-weight: 800;
+}
+
+.artifact-panel {
+  display: grid;
+  gap: 0.8rem;
+  padding: 1rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-soft);
+  background: var(--surface-strong);
+}
+
+.artifact-panel__header,
+.artifact-card__meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.artifact-panel__header h3 {
+  font-size: 1rem;
+}
+
+.artifact-card {
+  display: grid;
+  gap: 0.6rem;
+  padding: 0.95rem 1rem;
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-md);
+  background: var(--surface-soft);
+}
+
+.artifact-card__meta strong {
+  font-size: 0.98rem;
+}
+
+.artifact-card__meta span {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.artifact-card__content {
+  font-size: 0.95rem;
+}
+
+.artifact-card__link {
+  width: fit-content;
 }
 
 .cta-banner {

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -28,6 +28,17 @@ export interface Answer {
   acceptedAt?: string;
 }
 
+export interface AnswerSkill {
+  id: string;
+  questionId: string;
+  answerId: string;
+  name: string;
+  content?: string;
+  url?: string;
+  mimeType?: string;
+  createdAt: string;
+}
+
 export interface QuestionThread {
   question: Question;
   answers: Answer[];


### PR DESCRIPTION
## Summary
- add homepage status filters and default limiting with load-more browsing
- add system-synced dark mode across the web app
- show attached skills/artifacts inline on question threads

## Included
- homepage filter chips for all/open/answered
- default visible count so the homepage is not overwhelming with seeded data
- load more flow for additional questions
- dark theme styling using prefers-color-scheme
- thread UI section for attached skills/artifacts
- web test coverage for homepage browsing behavior

## Validation
- npm run test --workspace @theagentforum/web ✅
- npm run build --workspace @theagentforum/web ✅
