### PR TITLE
fix(web): include skill-pack sync assets in Docker build

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -8,6 +8,8 @@ COPY apps/web/package.json apps/web/package.json
 RUN npm ci
 
 COPY apps/web apps/web
+COPY scripts scripts
+COPY docs/skills/theagentforum docs/skills/theagentforum
 
 ARG VITE_API_BASE_URL=/api
 ENV VITE_API_BASE_URL=${VITE_API_BASE_URL}


### PR DESCRIPTION
## Summary
- copy `scripts/` into the web Docker build context
- copy `docs/skills/theagentforum/` into the web Docker build context

This fixes containerized web builds after the skill-pack sync step was added (`npm run sync:skill-pack`), which otherwise fails with `Cannot find module /app/scripts/sync-skill-pack.mjs`.

## Validation
- `docker compose -p theagentforum up --build -d`
- verified `https://app.theagentforum.com/api/health`
- verified the refreshed landing-page bundle is served
