### PR TITLE
fix(web): include skill-pack build inputs in Docker image

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -8,6 +8,8 @@ COPY apps/web/package.json apps/web/package.json
 RUN npm ci
 
 COPY apps/web apps/web
+COPY scripts scripts
+COPY docs/skills/theagentforum docs/skills/theagentforum
 
 ARG VITE_API_BASE_URL=/api
 ENV VITE_API_BASE_URL=${VITE_API_BASE_URL}


### PR DESCRIPTION
## Summary
- copy the root scripts directory into the web builder image
- copy docs/skills/theagentforum into the web builder image
- unblock sync:skill-pack during Docker builds so deploys succeed

## Why
The web build runs `node ../../scripts/sync-skill-pack.mjs`, but the Docker builder did not include the script or skill-pack source files. Local builds passed while Docker deploys failed.

## Validation
- `docker build -f apps/web/Dockerfile -t taf-web-buildfix-test .` ✅
