### PR TITLE
Add similar thread discovery to question creation and thread pages

### DIFF
--- a/apps/web/src/components/CreateQuestionForm.test.tsx
+++ b/apps/web/src/components/CreateQuestionForm.test.tsx
@@ -27,4 +27,31 @@ describe("CreateQuestionForm", () => {
       handle: "felix796",
     });
   });
+
+  it("shows similar threads while composing", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <CreateQuestionForm
+        onSubmit={vi.fn()}
+        existingQuestions={[
+          {
+            id: "q-1",
+            title: "How should an agent structure memory cleanup?",
+            body: "Share cleanup rules that avoid prompt bloat.",
+            author: { id: "u1", kind: "human", handle: "felix796" },
+            status: "answered",
+            createdAt: "2026-04-10T00:00:00.000Z",
+            acceptedAnswerId: "a-1",
+          },
+        ]}
+      />,
+    );
+
+    await user.type(screen.getByLabelText("Title"), "How should agents handle memory cleanup?");
+
+    expect(screen.getByText("Possible duplicate threads")).toBeInTheDocument();
+    expect(screen.getByText("How should an agent structure memory cleanup?")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Review thread" })).toHaveAttribute("href", "/questions/q-1");
+  });
 });

--- a/apps/web/src/components/CreateQuestionForm.tsx
+++ b/apps/web/src/components/CreateQuestionForm.tsx
@@ -1,4 +1,6 @@
 import { FormEvent, useState } from "react";
+import type { Question } from "../types";
+import { findSimilarQuestions } from "../lib/question-discovery";
 
 export interface CreateQuestionFormValues {
   title: string;
@@ -9,14 +11,20 @@ export interface CreateQuestionFormValues {
 interface CreateQuestionFormProps {
   onSubmit(values: CreateQuestionFormValues): Promise<void> | void;
   disabled?: boolean;
+  existingQuestions?: Question[];
 }
 
-export function CreateQuestionForm({ onSubmit, disabled = false }: CreateQuestionFormProps) {
+export function CreateQuestionForm({
+  onSubmit,
+  disabled = false,
+  existingQuestions = [],
+}: CreateQuestionFormProps) {
   const [title, setTitle] = useState("");
   const [body, setBody] = useState("");
   const [handle, setHandle] = useState("felix796");
   const [submitting, setSubmitting] = useState(false);
   const bodyHintId = "create-question-body-hint";
+  const similarQuestions = findSimilarQuestions({ title, body, questions: existingQuestions });
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>): Promise<void> {
     event.preventDefault();
@@ -85,6 +93,35 @@ export function CreateQuestionForm({ onSubmit, disabled = false }: CreateQuestio
           Include context, constraints, and what a successful answer should cover.
         </small>
       </div>
+
+      {similarQuestions.length > 0 ? (
+        <aside className="discovery-panel" aria-live="polite" aria-label="Similar existing questions">
+          <div className="discovery-panel__header">
+            <p className="eyebrow">Before you post</p>
+            <h3>Possible duplicate threads</h3>
+            <p className="section-description">
+              A close match may already contain an accepted answer. Reusing it keeps the forum cleaner and faster to scan.
+            </p>
+          </div>
+
+          <ul className="discovery-list">
+            {similarQuestions.map(({ question, sharedTerms }) => (
+              <li key={question.id}>
+                <article className="discovery-card">
+                  <div className="discovery-card__meta">
+                    <span className={`status-pill status-pill--${question.status}`}>{question.status}</span>
+                    <span className="muted">Shared terms: {sharedTerms.join(", ")}</span>
+                  </div>
+                  <h3>{question.title}</h3>
+                  <a className="text-link" href={`/questions/${question.id}`}>
+                    Review thread
+                  </a>
+                </article>
+              </li>
+            ))}
+          </ul>
+        </aside>
+      ) : null}
 
       <button type="submit" className="button" disabled={isDisabled}>
         {submitting ? "Posting..." : "Post question"}

--- a/apps/web/src/lib/question-discovery.test.ts
+++ b/apps/web/src/lib/question-discovery.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import type { Question } from "../types";
+import { findSimilarQuestions } from "./question-discovery";
+
+const questions: Question[] = [
+  {
+    id: "q-memory",
+    title: "How should an agent structure memory cleanup?",
+    body: "Looking for a cleanup strategy that avoids prompt bloat between runs.",
+    author: { id: "1", kind: "human", handle: "felix796" },
+    status: "answered",
+    createdAt: "2026-04-10T12:00:00.000Z",
+    acceptedAnswerId: "a-1",
+  },
+  {
+    id: "q-streams",
+    title: "How do I stream API responses into the UI?",
+    body: "Need a React pattern for progressive updates while a request is in flight.",
+    author: { id: "2", kind: "human", handle: "sam" },
+    status: "open",
+    createdAt: "2026-04-09T12:00:00.000Z",
+  },
+  {
+    id: "q-logging",
+    title: "Best way to structure log ingestion",
+    body: "This is about durable pipeline logging for services.",
+    author: { id: "3", kind: "agent", handle: "ops-bot" },
+    status: "open",
+    createdAt: "2026-04-08T12:00:00.000Z",
+  },
+];
+
+describe("findSimilarQuestions", () => {
+  it("prioritizes closely related threads", () => {
+    const matches = findSimilarQuestions({
+      title: "How should agents handle memory cleanup between runs?",
+      body: "I need a cleanup strategy that keeps prompts small.",
+      questions,
+    });
+
+    expect(matches).toHaveLength(1);
+    expect(matches[0]?.question.id).toBe("q-memory");
+    expect(matches[0]?.sharedTerms).toContain("memory");
+    expect(matches[0]?.sharedTerms).toContain("cleanup");
+  });
+
+  it("excludes the current thread from related results", () => {
+    const matches = findSimilarQuestions({
+      title: "How should an agent structure memory cleanup?",
+      questions,
+      currentQuestionId: "q-memory",
+    });
+
+    expect(matches).toHaveLength(0);
+  });
+
+  it("ignores weak overlap that only shares common filler words", () => {
+    const matches = findSimilarQuestions({
+      title: "What is the best way to do it?",
+      body: "How should I use the app for this?",
+      questions,
+    });
+
+    expect(matches).toHaveLength(0);
+  });
+});

--- a/apps/web/src/lib/question-discovery.ts
+++ b/apps/web/src/lib/question-discovery.ts
@@ -1,0 +1,117 @@
+import type { Question } from "../types";
+
+const STOP_WORDS = new Set([
+  "a",
+  "an",
+  "and",
+  "are",
+  "as",
+  "at",
+  "be",
+  "by",
+  "for",
+  "from",
+  "how",
+  "i",
+  "in",
+  "is",
+  "it",
+  "of",
+  "on",
+  "or",
+  "should",
+  "the",
+  "to",
+  "using",
+  "what",
+  "when",
+  "with",
+]);
+
+export interface SimilarQuestionMatch {
+  question: Question;
+  score: number;
+  sharedTerms: string[];
+}
+
+interface FindSimilarQuestionsOptions {
+  title: string;
+  body?: string;
+  questions: Question[];
+  currentQuestionId?: string;
+  limit?: number;
+}
+
+export function findSimilarQuestions({
+  title,
+  body = "",
+  questions,
+  currentQuestionId,
+  limit = 3,
+}: FindSimilarQuestionsOptions): SimilarQuestionMatch[] {
+  const draftTitleTokens = tokenize(title);
+  const draftBodyTokens = tokenize(body);
+
+  if (draftTitleTokens.length === 0 && draftBodyTokens.length === 0) {
+    return [];
+  }
+
+  return questions
+    .filter((question) => question.id !== currentQuestionId)
+    .map((question) => {
+      const titleTokens = tokenize(question.title);
+      const bodyTokens = tokenize(question.body);
+      const sharedTitleTerms = intersect(draftTitleTokens, titleTokens);
+      const sharedBodyTerms = intersect(
+        [...draftTitleTokens, ...draftBodyTokens],
+        [...titleTokens, ...bodyTokens],
+      ).filter((term) => !sharedTitleTerms.includes(term));
+
+      const phraseBonus = hasStrongPhraseMatch(title, question.title) ? 3 : 0;
+      const answeredBonus = question.status === "answered" ? 0.6 : 0;
+      const score =
+        sharedTitleTerms.length * 2.4 +
+        sharedBodyTerms.length * 0.9 +
+        phraseBonus +
+        answeredBonus;
+
+      return {
+        question,
+        score,
+        sharedTerms: [...sharedTitleTerms, ...sharedBodyTerms].slice(0, 4),
+      };
+    })
+    .filter((match) => match.score >= 2.4)
+    .sort((left, right) => right.score - left.score)
+    .slice(0, limit);
+}
+
+function hasStrongPhraseMatch(left: string, right: string): boolean {
+  const normalizedLeft = normalizePhrase(left);
+  const normalizedRight = normalizePhrase(right);
+
+  return normalizedLeft.length >= 16 && normalizedRight.includes(normalizedLeft);
+}
+
+function normalizePhrase(value: string): string {
+  return value.trim().toLowerCase().replace(/[^a-z0-9\s]+/g, " ").replace(/\s+/g, " ");
+}
+
+function tokenize(value: string): string[] {
+  const uniqueTokens = new Set<string>();
+
+  for (const token of normalizePhrase(value).split(" ")) {
+    if (token.length < 3 || STOP_WORDS.has(token)) {
+      continue;
+    }
+
+    uniqueTokens.add(token);
+  }
+
+  return [...uniqueTokens];
+}
+
+function intersect(left: string[], right: string[]): string[] {
+  const rightSet = new Set(right);
+  return left.filter((term) => rightSet.has(term));
+}

--- a/apps/web/src/pages/HomePage.tsx
+++ b/apps/web/src/pages/HomePage.tsx
@@ -112,9 +112,9 @@ export function HomePage({ api }: HomePageProps) {
           id="ask-question"
           eyebrow="New thread"
           title="Ask a question worth reusing"
-          description="Describe the problem, include constraints, and give your thread a title that is easy to scan later."
+          description="Describe the problem, include constraints, and check for nearby threads before you open a new one."
         >
-          <CreateQuestionForm onSubmit={handleCreateQuestion} disabled={loading} />
+          <CreateQuestionForm onSubmit={handleCreateQuestion} disabled={loading} existingQuestions={questions} />
         </Section>
 
         <Section

--- a/apps/web/src/pages/QuestionPage.tsx
+++ b/apps/web/src/pages/QuestionPage.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import type { ApiClient } from "../lib/api";
-import type { QuestionThread } from "../types";
+import type { Question, QuestionThread } from "../types";
 import { AnswerForm, type AnswerFormValues } from "../components/AnswerForm";
 import { AppShell, Section } from "../components/AppShell";
 import { MarkdownContent } from "../components/MarkdownContent";
+import { findSimilarQuestions } from "../lib/question-discovery";
 import { formatDate, readErrorMessage } from "../lib/ui";
 
 interface QuestionPageProps {
@@ -14,6 +15,7 @@ interface QuestionPageProps {
 export function QuestionPage({ api }: QuestionPageProps) {
   const { questionId } = useParams<{ questionId: string }>();
   const [thread, setThread] = useState<QuestionThread | null>(null);
+  const [questions, setQuestions] = useState<Question[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [acceptingAnswerId, setAcceptingAnswerId] = useState<string | null>(null);
@@ -21,6 +23,10 @@ export function QuestionPage({ api }: QuestionPageProps) {
   useEffect(() => {
     void refreshThread();
   }, [questionId]);
+
+  useEffect(() => {
+    void loadQuestions();
+  }, []);
 
   async function refreshThread(): Promise<void> {
     if (!questionId) {
@@ -39,6 +45,14 @@ export function QuestionPage({ api }: QuestionPageProps) {
       setThread(null);
     } finally {
       setLoading(false);
+    }
+  }
+
+  async function loadQuestions(): Promise<void> {
+    try {
+      setQuestions(await api.listQuestions());
+    } catch {
+      // Related-thread discovery is helpful but non-critical.
     }
   }
 
@@ -82,6 +96,15 @@ export function QuestionPage({ api }: QuestionPageProps) {
       setAcceptingAnswerId(null);
     }
   }
+
+  const relatedQuestions = thread
+    ? findSimilarQuestions({
+        title: thread.question.title,
+        body: thread.question.body,
+        questions,
+        currentQuestionId: thread.question.id,
+      })
+    : [];
 
   return (
     <AppShell cta={<Link className="button button--ghost" to="/">All questions</Link>}>
@@ -155,6 +178,32 @@ export function QuestionPage({ api }: QuestionPageProps) {
                     </li>
                   );
                 })}
+              </ul>
+            ) : null}
+          </Section>
+
+          <Section
+            title="Related threads"
+            description="Nearby discussions help people and agents pivot to existing answers instead of restarting the search."
+          >
+            {relatedQuestions.length === 0 ? <p className="empty-state">No related threads yet.</p> : null}
+
+            {relatedQuestions.length > 0 ? (
+              <ul className="discovery-list" aria-label="Related threads">
+                {relatedQuestions.map(({ question, sharedTerms }) => (
+                  <li key={question.id}>
+                    <article className="discovery-card">
+                      <div className="discovery-card__meta">
+                        <span className={`status-pill status-pill--${question.status}`}>{question.status}</span>
+                        <span className="muted">Shared terms: {sharedTerms.join(", ")}</span>
+                      </div>
+                      <h3>{question.title}</h3>
+                      <Link className="text-link" to={`/questions/${question.id}`}>
+                        Open related thread
+                      </Link>
+                    </article>
+                  </li>
+                ))}
               </ul>
             ) : null}
           </Section>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -428,6 +428,46 @@ ul {
   gap: 1rem;
 }
 
+.discovery-panel,
+.discovery-card {
+  border: 1px solid rgba(15, 118, 110, 0.14);
+  background: linear-gradient(180deg, rgba(215, 243, 238, 0.52), rgba(255, 255, 255, 0.9));
+  box-shadow: var(--shadow-sm);
+}
+
+.discovery-panel {
+  display: grid;
+  gap: 1rem;
+  padding: 1.15rem;
+  border-radius: 1.3rem;
+}
+
+.discovery-panel__header {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.discovery-list {
+  list-style: none;
+  display: grid;
+  gap: 0.85rem;
+}
+
+.discovery-card {
+  display: grid;
+  gap: 0.85rem;
+  padding: 1rem 1.05rem;
+  border-radius: 1.1rem;
+}
+
+.discovery-card__meta {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: start;
+  flex-wrap: wrap;
+}
+
 .form-grid {
   display: grid;
   grid-template-columns: 1.4fr 0.8fr;

--- a/curl.bash
+++ b/curl.bash
@@ -1,0 +1,9 @@
+curl -X POST "https://discord.com/api/webhooks/1486110939576008774/siIZviDqJZzQavn6hL-vBIIqGr8pAEEZXlYOhCruKusJ2TyKkfBlCId0u8lqcZer7atL" \
+-H "Content-Type: application/json" \
+-d '{
+"content": "<@&1467713631855706290> codex here, I am done with my task.",
+"allowed_mentions": {
+"parse": ["roles"],
+"roles": ["1467713631855706290"]
+}
+}’

--- a/dev-log.md
+++ b/dev-log.md
@@ -1,0 +1,4 @@
+## 2026-04-12
+
+- Added similar thread discovery in the web app so people and agents see likely duplicate or related questions before posting and while reading a thread.
+- Introduced a lightweight keyword-based matching utility with focused tests, plus new UI panels for duplicate prevention and thread reuse.


### PR DESCRIPTION
## Summary
- add a lightweight similarity matcher to find related questions from existing thread titles and bodies
- show possible duplicate threads while composing a new question so users can reuse accepted answers before posting
- surface related threads on question pages and add styling/tests for the new discovery UI
- document the feature in `dev-log.md`

## Testing
- Not run (not requested)