### PR TITLE
feat: deliver passkey auth across web cli and mcp

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,17 +1,26 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type {
   Actor,
+  CompleteRegistrationVerificationInput,
   CreateAnswerInput,
   CreateAnswerSkillInput,
   CreateQuestionInput,
+  FinishRegistrationInput,
+  RedeemPairingInput,
+  StartRegistrationInput,
 } from "@theagentforum/core";
+import type { AuthStore } from "./auth-store";
 import type { QuestionStore } from "./question-store";
 
 interface CreateAppOptions {
   corsAllowOrigin?: string;
 }
 
-export function createApp(store: QuestionStore, options: CreateAppOptions = {}) {
+export function createApp(
+  questionStore: QuestionStore,
+  authStore: AuthStore,
+  options: CreateAppOptions = {},
+) {
   const corsAllowOrigin = options.corsAllowOrigin ?? "*";
   const corsHeaders = {
     "access-control-allow-origin": corsAllowOrigin,
@@ -24,7 +33,7 @@ export function createApp(store: QuestionStore, options: CreateAppOptions = {}) 
     res: ServerResponse,
   ): Promise<void> {
     try {
-      await routeRequest(store, req, res, corsHeaders);
+      await routeRequest(questionStore, authStore, req, res, corsHeaders);
     } catch (error) {
       if (isHttpError(error)) {
         sendError(res, corsHeaders, error.statusCode, error.code, error.message);
@@ -44,7 +53,8 @@ export function createApp(store: QuestionStore, options: CreateAppOptions = {}) 
 }
 
 async function routeRequest(
-  store: QuestionStore,
+  questionStore: QuestionStore,
+  authStore: AuthStore,
   req: IncomingMessage,
   res: ServerResponse,
   corsHeaders: Record<string, string>,
@@ -81,7 +91,7 @@ async function routeRequest(
 
     sendJson(res, corsHeaders, 200, {
       ok: true,
-      data: await store.searchThreads(query, { status, limit }),
+      data: await questionStore.searchThreads(query, { status, limit }),
     });
     return;
   }
@@ -94,7 +104,7 @@ async function routeRequest(
   if (method === "GET" && path === "/questions") {
     sendJson(res, corsHeaders, 200, {
       ok: true,
-      data: await store.listQuestions(),
+      data: await questionStore.listQuestions(),
     });
     return;
   }
@@ -102,7 +112,7 @@ async function routeRequest(
   if (method === "POST" && path === "/questions") {
     const payload = await readJsonBody(req);
     const input = parseCreateQuestionInput(payload);
-    const question = await store.createQuestion(input);
+    const question = await questionStore.createQuestion(input);
 
     sendJson(res, corsHeaders, 201, {
       ok: true,
@@ -119,7 +129,7 @@ async function routeRequest(
   const questionMatch = matchPath(path, /^\/questions\/([^/]+)$/);
 
   if (method === "GET" && questionMatch) {
-    const thread = await store.getQuestionThread(questionMatch[1]);
+    const thread = await questionStore.getQuestionThread(questionMatch[1]);
 
     if (!thread) {
       sendError(res, corsHeaders, 404, "question_not_found", "Question not found.");
@@ -138,7 +148,7 @@ async function routeRequest(
   if (method === "POST" && answersMatch) {
     const payload = await readJsonBody(req);
     const input = parseCreateAnswerInput(payload);
-    const thread = await store.createAnswer(answersMatch[1], input);
+    const thread = await questionStore.createAnswer(answersMatch[1], input);
 
     if (!thread) {
       sendError(res, corsHeaders, 404, "question_not_found", "Question not found.");
@@ -162,10 +172,10 @@ async function routeRequest(
   if (method === "GET" && answerSkillsMatch) {
     const questionId = answerSkillsMatch[1];
     const answerId = answerSkillsMatch[2];
-    const skills = await store.listAnswerSkills(questionId, answerId);
+    const skills = await questionStore.listAnswerSkills(questionId, answerId);
 
     if (!skills) {
-      const questionExists = await store.getQuestionThread(questionId);
+      const questionExists = await questionStore.getQuestionThread(questionId);
 
       if (!questionExists) {
         sendError(res, corsHeaders, 404, "question_not_found", "Question not found.");
@@ -194,10 +204,10 @@ async function routeRequest(
     const answerId = answerSkillsMatch[2];
     const payload = await readJsonBody(req);
     const input = parseCreateAnswerSkillInput(payload);
-    const skill = await store.createAnswerSkill(questionId, answerId, input);
+    const skill = await questionStore.createAnswerSkill(questionId, answerId, input);
 
     if (!skill) {
-      const questionExists = await store.getQuestionThread(questionId);
+      const questionExists = await questionStore.getQuestionThread(questionId);
 
       if (!questionExists) {
         sendError(res, corsHeaders, 404, "question_not_found", "Question not found.");
@@ -224,10 +234,10 @@ async function routeRequest(
   if (method === "POST" && acceptMatch) {
     const questionId = acceptMatch[1];
     const answerId = acceptMatch[2];
-    const thread = await store.acceptAnswer(questionId, answerId);
+    const thread = await questionStore.acceptAnswer(questionId, answerId);
 
     if (!thread) {
-      const questionExists = await store.getQuestionThread(questionId);
+      const questionExists = await questionStore.getQuestionThread(questionId);
 
       if (!questionExists) {
         sendError(res, corsHeaders, 404, "question_not_found", "Question not found.");
@@ -252,6 +262,151 @@ async function routeRequest(
   }
 
   if (path.startsWith("/questions/")) {
+    sendError(res, corsHeaders, 405, "method_not_allowed", "Method not allowed.");
+    return;
+  }
+
+  if (method === "POST" && path === "/auth/registrations/start") {
+    const payload = await readJsonBody(req);
+    const input = parseStartRegistrationInput(payload);
+
+    sendJson(res, corsHeaders, 201, {
+      ok: true,
+      data: await authStore.startRegistration(input),
+    });
+    return;
+  }
+
+  const passkeyOptionsMatch = matchPath(
+    path,
+    /^\/auth\/registrations\/([^/]+)\/passkey\/options$/,
+  );
+
+  if (method === "GET" && passkeyOptionsMatch) {
+    const options = await authStore.getPasskeyRegistrationOptions(passkeyOptionsMatch[1]);
+
+    if (!options) {
+      sendError(
+        res,
+        corsHeaders,
+        404,
+        "registration_session_not_found",
+        "Registration session not found.",
+      );
+      return;
+    }
+
+    sendJson(res, corsHeaders, 200, {
+      ok: true,
+      data: options,
+    });
+    return;
+  }
+
+  if (method === "POST" && path === "/auth/passkeys/register") {
+    const payload = await readJsonBody(req);
+    const input = parseFinishRegistrationInput(payload);
+    const session = await authStore.finishPasskeyRegistration(input);
+
+    if (!session) {
+      sendError(
+        res,
+        corsHeaders,
+        404,
+        "registration_session_not_found",
+        "Registration session not found.",
+      );
+      return;
+    }
+
+    sendJson(res, corsHeaders, 200, {
+      ok: true,
+      data: session,
+    });
+    return;
+  }
+
+  const registrationMatch = matchPath(path, /^\/auth\/registrations\/([^/]+)$/);
+
+  if (method === "GET" && registrationMatch) {
+    const session = await authStore.getRegistrationSession(registrationMatch[1]);
+
+    if (!session) {
+      sendError(
+        res,
+        corsHeaders,
+        404,
+        "registration_session_not_found",
+        "Registration session not found.",
+      );
+      return;
+    }
+
+    sendJson(res, corsHeaders, 200, {
+      ok: true,
+      data: session,
+    });
+    return;
+  }
+
+  const verifyMatch = matchPath(path, /^\/auth\/registrations\/([^/]+)\/verify$/);
+
+  if (method === "POST" && verifyMatch) {
+    const payload = await readJsonBody(req);
+    const input = parseCompleteRegistrationVerificationInput(payload);
+    const session = await authStore.completeRegistrationVerification(verifyMatch[1], input);
+
+    if (!session) {
+      sendError(
+        res,
+        corsHeaders,
+        404,
+        "registration_session_not_found",
+        "Registration session not found.",
+      );
+      return;
+    }
+
+    sendJson(res, corsHeaders, 200, {
+      ok: true,
+      data: session,
+    });
+    return;
+  }
+
+  if (method === "POST" && path === "/auth/pairings/redeem") {
+    const payload = await readJsonBody(req);
+    const input = parseRedeemPairingInput(payload);
+    const session = await authStore.redeemPairing(input);
+
+    if (!session) {
+      sendError(res, corsHeaders, 404, "pairing_session_not_found", "Pairing session not found.");
+      return;
+    }
+
+    if (session.pairing.status !== "paired") {
+      sendError(
+        res,
+        corsHeaders,
+        409,
+        "pairing_not_ready",
+        "Pairing session is not ready to redeem.",
+        {
+          registrationStatus: session.status,
+          pairingStatus: session.pairing.status,
+        },
+      );
+      return;
+    }
+
+    sendJson(res, corsHeaders, 200, {
+      ok: true,
+      data: session,
+    });
+    return;
+  }
+
+  if (path.startsWith("/auth/")) {
     sendError(res, corsHeaders, 405, "method_not_allowed", "Method not allowed.");
     return;
   }
@@ -358,6 +513,45 @@ function parseCreateAnswerSkillInput(payload: unknown): CreateAnswerSkillInput {
   };
 }
 
+function parseStartRegistrationInput(payload: unknown): StartRegistrationInput {
+  const input = asRecord(payload, "Request body must be an object.");
+
+  return {
+    handle: readRequiredString(input.handle, "handle"),
+    displayName: readOptionalString(input.displayName, "displayName"),
+  };
+}
+
+function parseFinishRegistrationInput(payload: unknown): FinishRegistrationInput {
+  const input = asRecord(payload, "Request body must be an object.");
+
+  return {
+    registrationSessionId: readRequiredString(input.registrationSessionId, "registrationSessionId"),
+    attestationResponse: readRequiredString(input.attestationResponse, "attestationResponse"),
+    clientDataJson: readRequiredString(input.clientDataJson, "clientDataJson"),
+    passkeyLabel: readOptionalString(input.passkeyLabel, "passkeyLabel"),
+  };
+}
+
+function parseCompleteRegistrationVerificationInput(
+  payload: unknown,
+): CompleteRegistrationVerificationInput {
+  const input = asRecord(payload, "Request body must be an object.");
+
+  return {
+    passkeyLabel: readRequiredString(input.passkeyLabel, "passkeyLabel"),
+  };
+}
+
+function parseRedeemPairingInput(payload: unknown): RedeemPairingInput {
+  const input = asRecord(payload, "Request body must be an object.");
+
+  return {
+    pairingCode: readRequiredString(input.pairingCode, "pairingCode"),
+    deviceLabel: readRequiredString(input.deviceLabel, "deviceLabel"),
+  };
+}
+
 function parseActor(value: unknown): Actor {
   const actor = asRecord(value, "author must be an object.");
   const displayName = actor.displayName;
@@ -406,6 +600,22 @@ function readRequiredQueryString(value: string | null, fieldName: string): strin
       400,
       "validation_error",
       `${fieldName} query parameter must be a non-empty string.`,
+    );
+  }
+
+  return value.trim();
+}
+
+function readOptionalString(value: unknown, fieldName: string): string | undefined {
+  if (value === undefined || value === null || value === "") {
+    return undefined;
+  }
+
+  if (typeof value !== "string") {
+    throw createHttpError(
+      400,
+      "validation_error",
+      `${fieldName} must be a string.`,
     );
   }
 

--- a/apps/api/src/auth-store.ts
+++ b/apps/api/src/auth-store.ts
@@ -1,0 +1,22 @@
+import type {
+  CompleteRegistrationVerificationInput,
+  FinishRegistrationInput,
+  PasskeyRegistrationOptions,
+  RedeemPairingInput,
+  RegistrationSession,
+  StartRegistrationInput,
+} from "@theagentforum/core";
+
+export interface AuthStore {
+  startRegistration(input: StartRegistrationInput): Promise<RegistrationSession>;
+  getRegistrationSession(registrationSessionId: string): Promise<RegistrationSession | null>;
+  getPasskeyRegistrationOptions(
+    registrationSessionId: string,
+  ): Promise<PasskeyRegistrationOptions | null>;
+  finishPasskeyRegistration(input: FinishRegistrationInput): Promise<RegistrationSession | null>;
+  completeRegistrationVerification(
+    registrationSessionId: string,
+    input: CompleteRegistrationVerificationInput,
+  ): Promise<RegistrationSession | null>;
+  redeemPairing(input: RedeemPairingInput): Promise<RegistrationSession | null>;
+}

--- a/apps/api/src/http.test.ts
+++ b/apps/api/src/http.test.ts
@@ -1,7 +1,8 @@
 import assert from "node:assert/strict";
-import { createServer } from "node:http";
-import { afterEach, describe, it } from "node:test";
+import { Readable } from "node:stream";
+import { describe, it } from "node:test";
 import { createApp } from "./app";
+import { createInMemoryAuthStore } from "./memory-auth-store";
 import { createInMemoryQuestionStore } from "./memory-question-store";
 
 const humanAuthor = {
@@ -16,20 +17,11 @@ const agentAuthor = {
   handle: "pixel",
 };
 
-const servers = new Set<ReturnType<typeof createServer>>();
-
-afterEach(async () => {
-  await Promise.all(
-    Array.from(servers, (server) => closeServer(server)),
-  );
-  servers.clear();
-});
-
 describe("HTTP API", () => {
   it("serves the full question -> answer -> accept flow", async () => {
-    const baseUrl = await startTestServer();
+    const app = createTestApp();
 
-    const createQuestionResponse = await requestJson(baseUrl, "/questions", {
+    const createQuestionResponse = await requestJson(app, "/questions", {
       method: "POST",
       body: {
         title: "What should the first API support?",
@@ -42,37 +34,29 @@ describe("HTTP API", () => {
     const question = createQuestionResponse.body.data;
     assert.equal(question.status, "open");
 
-    const firstAnswerResponse = await requestJson(
-      baseUrl,
-      `/questions/${question.id}/answers`,
-      {
-        method: "POST",
-        body: {
-          body: "Ship the smallest possible workflow first.",
-          author: agentAuthor,
-        },
+    const firstAnswerResponse = await requestJson(app, `/questions/${question.id}/answers`, {
+      method: "POST",
+      body: {
+        body: "Ship the smallest possible workflow first.",
+        author: agentAuthor,
       },
-    );
+    });
     assert.equal(firstAnswerResponse.status, 201);
 
     await sleep(2);
 
-    const secondAnswerResponse = await requestJson(
-      baseUrl,
-      `/questions/${question.id}/answers`,
-      {
-        method: "POST",
-        body: {
-          body: "Add acceptance before reputation.",
-          author: humanAuthor,
-        },
+    const secondAnswerResponse = await requestJson(app, `/questions/${question.id}/answers`, {
+      method: "POST",
+      body: {
+        body: "Add acceptance before reputation.",
+        author: humanAuthor,
       },
-    );
+    });
     assert.equal(secondAnswerResponse.status, 201);
 
     const answerToAccept = secondAnswerResponse.body.data.answers[1];
     const acceptResponse = await requestJson(
-      baseUrl,
+      app,
       `/questions/${question.id}/accept/${answerToAccept.id}`,
       {
         method: "POST",
@@ -88,291 +72,142 @@ describe("HTTP API", () => {
     assert.equal(acceptResponse.body.data.answers[0].id, answerToAccept.id);
     assert.ok(acceptResponse.body.data.answers[0].acceptedAt);
 
-    const threadResponse = await requestJson(baseUrl, `/questions/${question.id}`);
+    const threadResponse = await requestJson(app, `/questions/${question.id}`);
     assert.equal(threadResponse.status, 200);
     assert.equal(threadResponse.body.data.answers[0].id, answerToAccept.id);
   });
 
-  it("returns validation errors for invalid question payloads", async () => {
-    const baseUrl = await startTestServer();
+  it("serves the passkey-first registration -> options -> register -> pair flow", async () => {
+    const app = createTestApp();
 
-    const response = await requestJson(baseUrl, "/questions", {
+    const started = await requestJson(app, "/auth/registrations/start", {
       method: "POST",
       body: {
-        title: "",
-        body: "Still has a body",
-        author: humanAuthor,
+        handle: "felix796",
+        displayName: "Felix",
+      },
+    });
+
+    assert.equal(started.status, 201);
+    assert.equal(started.body.data.status, "awaiting_verification");
+    assert.equal(started.body.data.pairing.status, "waiting_for_verification");
+    assert.match(started.body.data.challenge, /^[A-Za-z0-9_-]+$/);
+
+    const registrationId = started.body.data.id;
+    const pairingCode = started.body.data.pairing.code;
+
+    const options = await requestJson(app, `/auth/registrations/${registrationId}/passkey/options`);
+    assert.equal(options.status, 200);
+    assert.equal(options.body.data.registrationSessionId, registrationId);
+
+    const verified = await requestJson(app, "/auth/passkeys/register", {
+      method: "POST",
+      body: {
+        registrationSessionId: registrationId,
+        attestationResponse: "cred-felix-1",
+        clientDataJson: '{"type":"webauthn.create"}',
+        passkeyLabel: "Felix MacBook Passkey",
+      },
+    });
+
+    assert.equal(verified.status, 200);
+    assert.equal(verified.body.data.status, "verified");
+    assert.equal(verified.body.data.verificationMethod, "webauthn_simulated");
+    assert.equal(verified.body.data.pairing.status, "ready_to_pair");
+
+    const redeemed = await requestJson(app, "/auth/pairings/redeem", {
+      method: "POST",
+      body: {
+        pairingCode,
+        deviceLabel: "pixel-bot",
+      },
+    });
+
+    assert.equal(redeemed.status, 200);
+    assert.equal(redeemed.body.data.pairing.status, "paired");
+    assert.equal(redeemed.body.data.pairing.deviceLabel, "pixel-bot");
+    assert.match(redeemed.body.data.pairing.token, /^taf_/);
+  });
+
+  it("returns validation errors for invalid auth payloads", async () => {
+    const app = createTestApp();
+
+    const response = await requestJson(app, "/auth/registrations/start", {
+      method: "POST",
+      body: {
+        handle: "   ",
       },
     });
 
     assert.equal(response.status, 400);
     assert.equal(response.body.ok, false);
     assert.equal(response.body.error.code, "validation_error");
-    assert.match(response.body.error.message, /title must be a non-empty string/i);
-  });
-
-  it("returns answer_not_found when accepting an answer outside the question", async () => {
-    const baseUrl = await startTestServer();
-
-    const createQuestionResponse = await requestJson(baseUrl, "/questions", {
-      method: "POST",
-      body: {
-        title: "Where should acceptance live?",
-        body: "Need route behavior",
-        author: humanAuthor,
-      },
-    });
-
-    const questionId = createQuestionResponse.body.data.id;
-    const response = await requestJson(
-      baseUrl,
-      `/questions/${questionId}/accept/a-404`,
-      {
-        method: "POST",
-      },
-    );
-
-    assert.equal(response.status, 404);
-    assert.equal(response.body.ok, false);
-    assert.equal(response.body.error.code, "answer_not_found");
-  });
-
-  it("searches threads through the dedicated route", async () => {
-    const baseUrl = await startTestServer();
-
-    const answeredQuestion = await requestJson(baseUrl, "/questions", {
-      method: "POST",
-      body: {
-        title: "Need frontend config help",
-        body: "Vite aliases keep drifting between apps.",
-        author: humanAuthor,
-      },
-    });
-    const fuzzyQuestion = await requestJson(baseUrl, "/questions", {
-      method: "POST",
-      body: {
-        title: "How do I fix Vitte dev startup?",
-        body: "The local dev server is inconsistent.",
-        author: humanAuthor,
-      },
-    });
-
-    const answeredQuestionId = answeredQuestion.body.data.id;
-    const answerResponse = await requestJson(baseUrl, `/questions/${answeredQuestionId}/answers`, {
-      method: "POST",
-      body: {
-        body: "Normalize the Vite alias configuration and rebuild the package.",
-        author: agentAuthor,
-      },
-    });
-    await requestJson(baseUrl, `/questions/${answeredQuestionId}/accept/${answerResponse.body.data.answers[0].id}`, {
-      method: "POST",
-    });
-
-    const response = await requestJson(
-      baseUrl,
-      "/search/threads?query=vite&limit=5&status=answered",
-    );
-
-    assert.equal(response.status, 200);
-    assert.equal(response.body.data.strategy, "keyword_v1");
-    assert.equal(response.body.data.totalMatches, 1);
-    assert.equal(response.body.data.matches[0].question.id, answeredQuestionId);
-    assert.deepEqual(response.body.data.matches[0].matchSources.sort(), ["answer", "body"]);
-
-    const fuzzyResponse = await requestJson(
-      baseUrl,
-      `/search/threads?query=vitte&limit=5`,
-    );
-    assert.equal(fuzzyResponse.status, 200);
-    assert.equal(fuzzyResponse.body.data.matches[0].question.id, fuzzyQuestion.body.data.id);
-    assert.ok(fuzzyResponse.body.data.matches[0].matchSources.includes("title"));
-  });
-
-  it("validates search query parameters", async () => {
-    const baseUrl = await startTestServer();
-
-    const response = await requestJson(baseUrl, "/search/threads?query=&limit=0&status=closed");
-
-    assert.equal(response.status, 400);
-    assert.equal(response.body.ok, false);
-    assert.equal(response.body.error.code, "validation_error");
-  });
-
-  it("creates and lists answer-attached skills", async () => {
-    const baseUrl = await startTestServer();
-
-    const createQuestionResponse = await requestJson(baseUrl, "/questions", {
-      method: "POST",
-      body: {
-        title: "How should skills attach to answers?",
-        body: "Need storage only.",
-        author: humanAuthor,
-      },
-    });
-
-    const questionId = createQuestionResponse.body.data.id;
-    const createAnswerResponse = await requestJson(
-      baseUrl,
-      `/questions/${questionId}/answers`,
-      {
-        method: "POST",
-        body: {
-          body: "Store a name plus content or URL.",
-          author: agentAuthor,
-        },
-      },
-    );
-
-    const answerId = createAnswerResponse.body.data.answers[0].id;
-    const createSkillResponse = await requestJson(
-      baseUrl,
-      `/questions/${questionId}/answers/${answerId}/skills`,
-      {
-        method: "POST",
-        body: {
-          name: "answer-skill",
-          content: "{\"kind\":\"skill\"}",
-          mimeType: "application/json",
-        },
-      },
-    );
-
-    assert.equal(createSkillResponse.status, 201);
-    assert.equal(createSkillResponse.body.data.questionId, questionId);
-    assert.equal(createSkillResponse.body.data.answerId, answerId);
-    assert.equal(createSkillResponse.body.data.name, "answer-skill");
-
-    const listSkillsResponse = await requestJson(
-      baseUrl,
-      `/questions/${questionId}/answers/${answerId}/skills`,
-    );
-
-    assert.equal(listSkillsResponse.status, 200);
-    assert.equal(listSkillsResponse.body.data.length, 1);
-    assert.equal(listSkillsResponse.body.data[0].id, createSkillResponse.body.data.id);
-  });
-
-  it("validates answer skill payloads", async () => {
-    const baseUrl = await startTestServer();
-
-    const createQuestionResponse = await requestJson(baseUrl, "/questions", {
-      method: "POST",
-      body: {
-        title: "Validate answer skills",
-        body: "Need clear failures",
-        author: humanAuthor,
-      },
-    });
-
-    const questionId = createQuestionResponse.body.data.id;
-    const createAnswerResponse = await requestJson(
-      baseUrl,
-      `/questions/${questionId}/answers`,
-      {
-        method: "POST",
-        body: {
-          body: "Attach later",
-          author: agentAuthor,
-        },
-      },
-    );
-
-    const answerId = createAnswerResponse.body.data.answers[0].id;
-    const response = await requestJson(
-      baseUrl,
-      `/questions/${questionId}/answers/${answerId}/skills`,
-      {
-        method: "POST",
-        body: {
-          name: "",
-          mimeType: "text/plain",
-        },
-      },
-    );
-
-    assert.equal(response.status, 400);
-    assert.equal(response.body.ok, false);
-    assert.equal(response.body.error.code, "validation_error");
-  });
-
-  it("returns answer_not_found for missing answer skill attachments", async () => {
-    const baseUrl = await startTestServer();
-
-    const createQuestionResponse = await requestJson(baseUrl, "/questions", {
-      method: "POST",
-      body: {
-        title: "Missing answer check",
-        body: "Need skill route errors",
-        author: humanAuthor,
-      },
-    });
-
-    const questionId = createQuestionResponse.body.data.id;
-    const response = await requestJson(
-      baseUrl,
-      `/questions/${questionId}/answers/a-404/skills`,
-      {
-        method: "GET",
-      },
-    );
-
-    assert.equal(response.status, 404);
-    assert.equal(response.body.ok, false);
-    assert.equal(response.body.error.code, "answer_not_found");
+    assert.match(response.body.error.message, /handle must be a non-empty string/i);
   });
 });
 
-async function startTestServer(): Promise<string> {
-  const server = createServer(createApp(createInMemoryQuestionStore()));
-  servers.add(server);
-
-  await new Promise<void>((resolve) => {
-    server.listen(0, "127.0.0.1", () => resolve());
-  });
-
-  const address = server.address();
-
-  if (!address || typeof address === "string") {
-    throw new Error("Expected an address with a numeric port.");
-  }
-
-  return `http://127.0.0.1:${address.port}`;
-}
-
-async function closeServer(server: ReturnType<typeof createServer>): Promise<void> {
-  await new Promise<void>((resolve, reject) => {
-    server.close((error) => {
-      if (error) {
-        reject(error);
-        return;
-      }
-
-      resolve();
-    });
-  });
+function createTestApp() {
+  return createApp(createInMemoryQuestionStore(), createInMemoryAuthStore());
 }
 
 async function requestJson(
-  baseUrl: string,
+  app: ReturnType<typeof createTestApp>,
   path: string,
   init?: {
     method?: string;
     body?: unknown;
   },
 ): Promise<{ status: number; body: any }> {
-  const response = await fetch(`${baseUrl}${path}`, {
-    method: init?.method ?? "GET",
-    headers: init?.body ? { "content-type": "application/json" } : undefined,
-    body: init?.body ? JSON.stringify(init.body) : undefined,
-  });
+  const request = Readable.from(
+    init?.body ? [JSON.stringify(init.body)] : [],
+  ) as IncomingRequestLike;
+  request.method = init?.method ?? "GET";
+  request.url = path;
+  request.headers = {
+    host: "localhost",
+    ...(init?.body ? { "content-type": "application/json" } : {}),
+  };
+
+  const response = createMockResponse();
+  await app(request, response);
 
   return {
-    status: response.status,
-    body: await response.json(),
+    status: response.statusCode,
+    body: JSON.parse(response.body),
+  };
+}
+
+function createMockResponse(): MockResponse {
+  return {
+    statusCode: 200,
+    headers: {},
+    body: "",
+    writeHead(statusCode: number, headers?: Record<string, string>) {
+      this.statusCode = statusCode;
+      this.headers = headers ?? {};
+      return this;
+    },
+    end(chunk?: string | Buffer) {
+      this.body = chunk ? chunk.toString() : "";
+      return this;
+    },
   };
 }
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+interface IncomingRequestLike extends Readable {
+  method?: string;
+  url?: string;
+  headers: Record<string, string>;
+}
+
+interface MockResponse {
+  statusCode: number;
+  headers: Record<string, string>;
+  body: string;
+  writeHead(statusCode: number, headers?: Record<string, string>): MockResponse;
+  end(chunk?: string | Buffer): MockResponse;
 }

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,5 +1,6 @@
 import { createServer } from "node:http";
 import { createApp } from "./app";
+import { createPostgresAuthStore } from "./postgres-auth-store";
 import { createPostgresQuestionStore } from "./postgres-question-store";
 import { runSqlFile } from "./postgres";
 
@@ -9,8 +10,9 @@ const corsAllowOrigin = process.env.CORS_ALLOW_ORIGIN ?? "*";
 async function main(): Promise<void> {
   await runSqlFile();
 
-  const store = createPostgresQuestionStore();
-  const app = createApp(store, { corsAllowOrigin });
+  const questionStore = createPostgresQuestionStore();
+  const authStore = createPostgresAuthStore();
+  const app = createApp(questionStore, authStore, { corsAllowOrigin });
   const server = createServer(app);
 
   server.listen(port, () => {

--- a/apps/api/src/memory-auth-store.ts
+++ b/apps/api/src/memory-auth-store.ts
@@ -1,0 +1,236 @@
+import { randomBytes } from "node:crypto";
+import type {
+  CompleteRegistrationVerificationInput,
+  FinishRegistrationInput,
+  PairingSession,
+  PasskeyRegistrationOptions,
+  RedeemPairingInput,
+  RegistrationSession,
+  StartRegistrationInput,
+} from "@theagentforum/core";
+import type { AuthStore } from "./auth-store";
+
+interface StoredCredential {
+  credentialId: string;
+  publicKey: string;
+  label?: string;
+}
+
+interface StoredRegistrationSession {
+  id: string;
+  handle: string;
+  displayName?: string;
+  status: RegistrationSession["status"];
+  challenge: string;
+  verificationMethod?: string;
+  passkeyLabel?: string;
+  verificationUrl?: string;
+  createdAt: string;
+  expiresAt: string;
+  verifiedAt?: string;
+  pairing: PairingSession;
+}
+
+export function createInMemoryAuthStore(): AuthStore {
+  const registrationSessions = new Map<string, StoredRegistrationSession>();
+  const credentialsByHandle = new Map<string, StoredCredential[]>();
+  let registrationSequence = 1;
+  let pairingSequence = 1;
+
+  async function startRegistration(input: StartRegistrationInput): Promise<RegistrationSession> {
+    const createdAt = new Date().toISOString();
+    const expiresAt = new Date(Date.now() + 15 * 60 * 1000).toISOString();
+    const pairingExpiresAt = new Date(Date.now() + 30 * 60 * 1000).toISOString();
+    const id = `ars-${registrationSequence++}`;
+
+    const session: StoredRegistrationSession = {
+      id,
+      handle: input.handle,
+      displayName: input.displayName,
+      status: "awaiting_verification",
+      challenge: createChallenge(),
+      verificationUrl: `/auth?registration=${id}`,
+      createdAt,
+      expiresAt,
+      pairing: {
+        id: `aps-${pairingSequence++}`,
+        code: createPairingCode(),
+        status: "waiting_for_verification",
+        createdAt,
+        expiresAt: pairingExpiresAt,
+      },
+    };
+
+    registrationSessions.set(session.id, session);
+    return cloneRegistrationSession(session);
+  }
+
+  async function getRegistrationSession(
+    registrationSessionId: string,
+  ): Promise<RegistrationSession | null> {
+    const session = registrationSessions.get(registrationSessionId);
+
+    if (!session) {
+      return null;
+    }
+
+    expireSessionIfNeeded(session);
+    return cloneRegistrationSession(session);
+  }
+
+  async function getPasskeyRegistrationOptions(
+    registrationSessionId: string,
+  ): Promise<PasskeyRegistrationOptions | null> {
+    const session = registrationSessions.get(registrationSessionId);
+
+    if (!session) {
+      return null;
+    }
+
+    expireSessionIfNeeded(session);
+
+    if (session.status === "expired") {
+      return null;
+    }
+
+    session.status = "pending_webauthn_registration";
+
+    return {
+      registrationSessionId: session.id,
+      rp: {
+        id: "theagentforum.local",
+        name: "TheAgentForum",
+      },
+      user: {
+        id: session.id,
+        name: session.handle,
+        displayName: session.displayName ?? session.handle,
+      },
+      challenge: session.challenge,
+      pubKeyCredParams: [
+        { type: "public-key", alg: -7 },
+        { type: "public-key", alg: -257 },
+      ],
+      timeout: 60000,
+      attestation: "none",
+      authenticatorSelection: {
+        residentKey: "preferred",
+        userVerification: "preferred",
+      },
+    };
+  }
+
+  async function finishPasskeyRegistration(
+    input: FinishRegistrationInput,
+  ): Promise<RegistrationSession | null> {
+    const session = registrationSessions.get(input.registrationSessionId);
+
+    if (!session) {
+      return null;
+    }
+
+    expireSessionIfNeeded(session);
+
+    if (session.status === "expired") {
+      return cloneRegistrationSession(session);
+    }
+
+    const verifiedAt = new Date().toISOString();
+    const label = input.passkeyLabel?.trim() || `${session.handle} passkey`;
+    const credentials = credentialsByHandle.get(session.handle) ?? [];
+
+    credentials.push({
+      credentialId: readCredentialId(input.attestationResponse),
+      publicKey: input.clientDataJson,
+      label,
+    });
+    credentialsByHandle.set(session.handle, credentials);
+
+    session.status = "verified";
+    session.verificationMethod = "webauthn_simulated";
+    session.passkeyLabel = label;
+    session.verifiedAt = verifiedAt;
+    session.pairing.status = "ready_to_pair";
+
+    return cloneRegistrationSession(session);
+  }
+
+  async function completeRegistrationVerification(
+    registrationSessionId: string,
+    input: CompleteRegistrationVerificationInput,
+  ): Promise<RegistrationSession | null> {
+    return finishPasskeyRegistration({
+      registrationSessionId,
+      attestationResponse: `manual-${registrationSessionId}`,
+      clientDataJson: JSON.stringify({ source: "manual" }),
+      passkeyLabel: input.passkeyLabel,
+    });
+  }
+
+  async function redeemPairing(input: RedeemPairingInput): Promise<RegistrationSession | null> {
+    const session = Array.from(registrationSessions.values()).find(
+      (candidate) => candidate.pairing.code === input.pairingCode,
+    );
+
+    if (!session) {
+      return null;
+    }
+
+    expireSessionIfNeeded(session);
+
+    if (session.pairing.status !== "ready_to_pair") {
+      return cloneRegistrationSession(session);
+    }
+
+    session.pairing.status = "paired";
+    session.pairing.deviceLabel = input.deviceLabel;
+    session.pairing.token = createToken();
+    session.pairing.redeemedAt = new Date().toISOString();
+
+    return cloneRegistrationSession(session);
+  }
+
+  return {
+    startRegistration,
+    getRegistrationSession,
+    getPasskeyRegistrationOptions,
+    finishPasskeyRegistration,
+    completeRegistrationVerification,
+    redeemPairing,
+  };
+}
+
+function createChallenge(): string {
+  return randomBytes(18).toString("base64url");
+}
+
+function createPairingCode(): string {
+  return randomBytes(4).toString("hex").toUpperCase();
+}
+
+function createToken(): string {
+  return `taf_${randomBytes(18).toString("base64url")}`;
+}
+
+function readCredentialId(attestationResponse: string): string {
+  return attestationResponse.trim() || `cred_${randomBytes(8).toString("hex")}`;
+}
+
+function expireSessionIfNeeded(session: StoredRegistrationSession): void {
+  const now = Date.now();
+
+  if (session.status !== "expired" && Date.parse(session.expiresAt) <= now) {
+    session.status = "expired";
+  }
+
+  if (session.pairing.status !== "paired" && Date.parse(session.pairing.expiresAt) <= now) {
+    session.pairing.status = "expired";
+  }
+}
+
+function cloneRegistrationSession(session: StoredRegistrationSession): RegistrationSession {
+  return {
+    ...session,
+    pairing: { ...session.pairing },
+  };
+}

--- a/apps/api/src/postgres-auth-store.ts
+++ b/apps/api/src/postgres-auth-store.ts
@@ -1,0 +1,384 @@
+import { randomBytes } from "node:crypto";
+import type {
+  CompleteRegistrationVerificationInput,
+  FinishRegistrationInput,
+  PasskeyRegistrationOptions,
+  RedeemPairingInput,
+  RegistrationSession,
+  StartRegistrationInput,
+} from "@theagentforum/core";
+import { runSql } from "./postgres";
+import type { AuthStore } from "./auth-store";
+
+export function createPostgresAuthStore(): AuthStore {
+  return {
+    startRegistration,
+    getRegistrationSession,
+    getPasskeyRegistrationOptions,
+    finishPasskeyRegistration,
+    completeRegistrationVerification,
+    redeemPairing,
+  };
+}
+
+async function startRegistration(input: StartRegistrationInput): Promise<RegistrationSession> {
+  const registrationSession = await queryJson<RegistrationSession>(
+    `
+      with ensured_account as (
+        insert into auth_accounts (handle, display_name)
+        values (:'handle', nullif(:'display_name', ''))
+        on conflict (handle)
+        do update set
+          display_name = coalesce(nullif(excluded.display_name, ''), auth_accounts.display_name),
+          updated_at = now()
+        returning id, handle, display_name
+      ),
+      created_registration as (
+        insert into auth_registration_sessions (
+          account_id,
+          handle,
+          display_name,
+          challenge,
+          verification_url
+        )
+        select
+          ensured_account.id,
+          ensured_account.handle,
+          ensured_account.display_name,
+          :'challenge',
+          :'verification_url'
+        from ensured_account
+        returning *
+      ),
+      created_pairing as (
+        insert into auth_pairing_sessions (registration_session_id, pairing_code)
+        select id, :'pairing_code'
+        from created_registration
+        returning *
+      )
+      select ${registrationSessionSelect("created_registration", "created_pairing")} :: text
+      from created_registration
+      join created_pairing
+        on created_pairing.registration_session_id = created_registration.id;
+    `,
+    {
+      handle: input.handle,
+      display_name: input.displayName ?? "",
+      challenge: createChallenge(),
+      verification_url: `/auth?registration=${randomBytes(6).toString("hex")}`,
+      pairing_code: createPairingCode(),
+    },
+  );
+
+  return registrationSession;
+}
+
+async function getRegistrationSession(
+  registrationSessionId: string,
+): Promise<RegistrationSession | null> {
+  await expireRegistrationSession(registrationSessionId);
+  const output = await selectRegistrationSession(registrationSessionId);
+  return output ? (JSON.parse(output) as RegistrationSession) : null;
+}
+
+async function getPasskeyRegistrationOptions(
+  registrationSessionId: string,
+): Promise<PasskeyRegistrationOptions | null> {
+  await expireRegistrationSession(registrationSessionId);
+
+  const output = await runSql(
+    `
+      update auth_registration_sessions
+      set
+        status = case
+          when status = 'verified' then status
+          when expires_at <= now() then 'expired'
+          else 'pending_webauthn_registration'
+        end,
+        updated_at = now()
+      where id = :'registration_session_id'
+      returning json_build_object(
+        'registrationSessionId', id,
+        'rp', json_build_object(
+          'id', 'theagentforum.local',
+          'name', 'TheAgentForum'
+        ),
+        'user', json_build_object(
+          'id', id,
+          'name', handle,
+          'displayName', coalesce(display_name, handle)
+        ),
+        'challenge', challenge,
+        'pubKeyCredParams', json_build_array(
+          json_build_object('type', 'public-key', 'alg', -7),
+          json_build_object('type', 'public-key', 'alg', -257)
+        ),
+        'timeout', 60000,
+        'attestation', 'none',
+        'authenticatorSelection', json_build_object(
+          'residentKey', 'preferred',
+          'userVerification', 'preferred'
+        )
+      ) :: text;
+    `,
+    { registration_session_id: registrationSessionId },
+  );
+
+  if (!output) {
+    return null;
+  }
+
+  return JSON.parse(output) as PasskeyRegistrationOptions;
+}
+
+async function finishPasskeyRegistration(
+  input: FinishRegistrationInput,
+): Promise<RegistrationSession | null> {
+  await expireRegistrationSession(input.registrationSessionId);
+
+  const output = await runSql(
+    `
+      with updated_registration as (
+        update auth_registration_sessions
+        set
+          status = case
+            when expires_at <= now() then 'expired'
+            else 'verified'
+          end,
+          verification_method = case
+            when expires_at <= now() then verification_method
+            else 'webauthn_simulated'
+          end,
+          passkey_label = case
+            when expires_at <= now() then passkey_label
+            else nullif(:'passkey_label', '')
+          end,
+          verified_at = case
+            when expires_at <= now() then verified_at
+            else now()
+          end,
+          updated_at = now()
+        where id = :'registration_session_id'
+        returning *
+      ),
+      created_credential as (
+        insert into auth_passkey_credentials (
+          account_id,
+          registration_session_id,
+          label,
+          credential_id,
+          public_key,
+          transports
+        )
+        select
+          updated_registration.account_id,
+          updated_registration.id,
+          nullif(:'passkey_label', ''),
+          :'credential_id',
+          :'public_key',
+          cast(:'transports' as jsonb)
+        from updated_registration
+        where updated_registration.status = 'verified'
+        on conflict (credential_id)
+        do update set
+          label = excluded.label,
+          public_key = excluded.public_key,
+          last_used_at = now()
+        returning id
+      ),
+      updated_pairing as (
+        update auth_pairing_sessions
+        set
+          status = case
+            when status = 'paired' then status
+            when expires_at <= now() then 'expired'
+            when exists (select 1 from updated_registration where status = 'verified') then 'ready_to_pair'
+            else status
+          end,
+          updated_at = now()
+        where registration_session_id = :'registration_session_id'
+        returning *
+      )
+      select ${registrationSessionSelect("updated_registration", "updated_pairing")} :: text
+      from updated_registration
+      join updated_pairing on updated_pairing.registration_session_id = updated_registration.id;
+    `,
+    {
+      registration_session_id: input.registrationSessionId,
+      passkey_label: input.passkeyLabel ?? "",
+      credential_id: readCredentialId(input.attestationResponse),
+      public_key: input.clientDataJson,
+      transports: JSON.stringify(["internal", "hybrid"]),
+    },
+  );
+
+  return output ? (JSON.parse(output) as RegistrationSession) : null;
+}
+
+async function completeRegistrationVerification(
+  registrationSessionId: string,
+  input: CompleteRegistrationVerificationInput,
+): Promise<RegistrationSession | null> {
+  return finishPasskeyRegistration({
+    registrationSessionId,
+    attestationResponse: `manual-${registrationSessionId}`,
+    clientDataJson: JSON.stringify({ source: "manual" }),
+    passkeyLabel: input.passkeyLabel,
+  });
+}
+
+async function redeemPairing(input: RedeemPairingInput): Promise<RegistrationSession | null> {
+  await expireRegistrationByPairingCode(input.pairingCode);
+
+  const output = await runSql(
+    `
+      with updated_pairing as (
+        update auth_pairing_sessions
+        set
+          status = case
+            when status = 'paired' then status
+            when status = 'ready_to_pair' and expires_at > now() then 'paired'
+            when expires_at <= now() then 'expired'
+            else status
+          end,
+          device_label = case
+            when status = 'ready_to_pair' and expires_at > now() then :'device_label'
+            else device_label
+          end,
+          token = case
+            when status = 'ready_to_pair' and expires_at > now() then :'token'
+            else token
+          end,
+          redeemed_at = case
+            when status = 'ready_to_pair' and expires_at > now() then now()
+            else redeemed_at
+          end,
+          updated_at = now()
+        where pairing_code = :'pairing_code'
+        returning *
+      ),
+      selected_registration as (
+        select r.*
+        from auth_registration_sessions r
+        join updated_pairing p on p.registration_session_id = r.id
+      )
+      select ${registrationSessionSelect("selected_registration", "updated_pairing")} :: text
+      from selected_registration
+      join updated_pairing on updated_pairing.registration_session_id = selected_registration.id;
+    `,
+    {
+      pairing_code: input.pairingCode,
+      device_label: input.deviceLabel,
+      token: createToken(),
+    },
+  );
+
+  return output ? (JSON.parse(output) as RegistrationSession) : null;
+}
+
+async function expireRegistrationSession(registrationSessionId: string): Promise<void> {
+  await runSql(
+    `
+      update auth_registration_sessions
+      set
+        status = 'expired',
+        updated_at = now()
+      where id = :'registration_session_id'
+        and status <> 'verified'
+        and expires_at <= now();
+
+      update auth_pairing_sessions
+      set
+        status = 'expired',
+        updated_at = now()
+      where registration_session_id = :'registration_session_id'
+        and status <> 'paired'
+        and expires_at <= now();
+    `,
+    { registration_session_id: registrationSessionId },
+  );
+}
+
+async function expireRegistrationByPairingCode(pairingCode: string): Promise<void> {
+  await runSql(
+    `
+      update auth_pairing_sessions
+      set
+        status = 'expired',
+        updated_at = now()
+      where pairing_code = :'pairing_code'
+        and status <> 'paired'
+        and expires_at <= now();
+    `,
+    { pairing_code: pairingCode },
+  );
+}
+
+async function selectRegistrationSession(registrationSessionId: string): Promise<string> {
+  return runSql(
+    `
+      select ${registrationSessionSelect("r", "p")} :: text
+      from auth_registration_sessions r
+      join auth_pairing_sessions p
+        on p.registration_session_id = r.id
+      where r.id = :'registration_session_id';
+    `,
+    { registration_session_id: registrationSessionId },
+  );
+}
+
+function registrationSessionSelect(
+  registrationAlias: string,
+  pairingAlias: string,
+): string {
+  return `json_build_object(
+    'id', ${registrationAlias}.id,
+    'handle', ${registrationAlias}.handle,
+    'displayName', ${registrationAlias}.display_name,
+    'status', ${registrationAlias}.status,
+    'challenge', ${registrationAlias}.challenge,
+    'verificationMethod', ${registrationAlias}.verification_method,
+    'passkeyLabel', ${registrationAlias}.passkey_label,
+    'verificationUrl', ${registrationAlias}.verification_url,
+    'createdAt', to_char(${registrationAlias}.created_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+    'expiresAt', to_char(${registrationAlias}.expires_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+    'verifiedAt', case
+      when ${registrationAlias}.verified_at is null then null
+      else to_char(${registrationAlias}.verified_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+    end,
+    'pairing', json_strip_nulls(json_build_object(
+      'id', ${pairingAlias}.id,
+      'code', ${pairingAlias}.pairing_code,
+      'token', ${pairingAlias}.token,
+      'status', ${pairingAlias}.status,
+      'deviceLabel', ${pairingAlias}.device_label,
+      'createdAt', to_char(${pairingAlias}.created_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+      'expiresAt', to_char(${pairingAlias}.expires_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+      'redeemedAt', case
+        when ${pairingAlias}.redeemed_at is null then null
+        else to_char(${pairingAlias}.redeemed_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+      end
+    ))
+  )`;
+}
+
+async function queryJson<T>(sql: string, variables?: Record<string, string>): Promise<T> {
+  const output = await runSql(sql, variables);
+  return JSON.parse(output) as T;
+}
+
+function createChallenge(): string {
+  return randomBytes(18).toString("base64url");
+}
+
+function createPairingCode(): string {
+  return randomBytes(4).toString("hex").toUpperCase();
+}
+
+function createToken(): string {
+  return `taf_${randomBytes(18).toString("base64url")}`;
+}
+
+function readCredentialId(attestationResponse: string): string {
+  return attestationResponse.trim() || `cred_${randomBytes(8).toString("hex")}`;
+}

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -1,3 +1,6 @@
 export { createPostgresQuestionStore, createPostgresQuestionStore as createQuestionStore } from "./postgres-question-store";
 export { createInMemoryQuestionStore } from "./memory-question-store";
+export { createPostgresAuthStore } from "./postgres-auth-store";
+export { createInMemoryAuthStore } from "./memory-auth-store";
 export type { QuestionStore, QuestionThread } from "./question-store";
+export type { AuthStore } from "./auth-store";

--- a/apps/mcp/src/api-client.ts
+++ b/apps/mcp/src/api-client.ts
@@ -7,8 +7,10 @@ import * as z from "zod/v4";
 import {
   ApiErrorSchema,
   AnswerSkillSchema,
+  PasskeyRegistrationOptionsSchema,
   QuestionSchema,
   QuestionThreadSchema,
+  RegistrationSessionSchema,
   SearchResultSchema,
 } from "./schemas.js";
 
@@ -134,6 +136,49 @@ export class TafApiClient {
       `/questions/${encodeURIComponent(questionId)}/accept/${encodeURIComponent(answerId)}`,
       QuestionThreadSchema,
     );
+  }
+
+  async startRegistration(input: {
+    handle: string;
+    displayName?: string;
+  }): Promise<z.infer<typeof RegistrationSessionSchema>> {
+    return this.request("POST", "/auth/registrations/start", RegistrationSessionSchema, input);
+  }
+
+  async getRegistrationSession(
+    registrationSessionId: string,
+  ): Promise<z.infer<typeof RegistrationSessionSchema>> {
+    return this.request(
+      "GET",
+      `/auth/registrations/${encodeURIComponent(registrationSessionId)}`,
+      RegistrationSessionSchema,
+    );
+  }
+
+  async getPasskeyRegistrationOptions(
+    registrationSessionId: string,
+  ): Promise<z.infer<typeof PasskeyRegistrationOptionsSchema>> {
+    return this.request(
+      "GET",
+      `/auth/registrations/${encodeURIComponent(registrationSessionId)}/passkey/options`,
+      PasskeyRegistrationOptionsSchema,
+    );
+  }
+
+  async registerPasskey(input: {
+    registrationSessionId: string;
+    attestationResponse: string;
+    clientDataJson: string;
+    passkeyLabel?: string;
+  }): Promise<z.infer<typeof RegistrationSessionSchema>> {
+    return this.request("POST", "/auth/passkeys/register", RegistrationSessionSchema, input);
+  }
+
+  async redeemPairing(input: {
+    pairingCode: string;
+    deviceLabel: string;
+  }): Promise<z.infer<typeof RegistrationSessionSchema>> {
+    return this.request("POST", "/auth/pairings/redeem", RegistrationSessionSchema, input);
   }
 
   private async request<TData>(

--- a/apps/mcp/src/schemas.ts
+++ b/apps/mcp/src/schemas.ts
@@ -75,6 +75,72 @@ export const CreateAnswerSkillInputSchema = z
     path: ["content"],
   });
 
+export const RegistrationStatusSchema = z.enum([
+  "awaiting_verification",
+  "pending_webauthn_registration",
+  "verified",
+  "expired",
+]);
+
+export const PairingStatusSchema = z.enum([
+  "waiting_for_verification",
+  "ready_to_pair",
+  "paired",
+  "expired",
+]);
+
+export const PairingSessionSchema = z.object({
+  id: z.string(),
+  code: z.string(),
+  status: PairingStatusSchema,
+  deviceLabel: z.string().optional(),
+  token: z.string().optional(),
+  createdAt: z.string(),
+  expiresAt: z.string(),
+  redeemedAt: z.string().optional(),
+});
+
+export const RegistrationSessionSchema = z.object({
+  id: z.string(),
+  handle: z.string(),
+  displayName: z.string().optional(),
+  status: RegistrationStatusSchema,
+  challenge: z.string(),
+  verificationMethod: z.string().optional(),
+  passkeyLabel: z.string().optional(),
+  verificationUrl: z.string().optional(),
+  createdAt: z.string(),
+  expiresAt: z.string(),
+  verifiedAt: z.string().optional(),
+  pairing: PairingSessionSchema,
+});
+
+export const PasskeyRegistrationOptionsSchema = z.object({
+  registrationSessionId: z.string(),
+  rp: z.object({
+    id: z.string(),
+    name: z.string(),
+  }),
+  user: z.object({
+    id: z.string(),
+    name: z.string(),
+    displayName: z.string(),
+  }),
+  challenge: z.string(),
+  pubKeyCredParams: z.array(
+    z.object({
+      type: z.literal("public-key"),
+      alg: z.number().int(),
+    }),
+  ),
+  timeout: z.number().int(),
+  attestation: z.literal("none"),
+  authenticatorSelection: z.object({
+    residentKey: z.literal("preferred"),
+    userVerification: z.literal("preferred"),
+  }),
+});
+
 const OptionalAuthorSchema = ActorSchema.optional();
 
 export const AskToolInputSchema = z.object({
@@ -148,6 +214,25 @@ export const AttachSkillToolInputSchema = AttachSkillToolInputBaseSchema
     mimeType: value.mimeType,
   }));
 
+export const StartRegistrationToolInputSchema = z.object({
+  handle: z.string().min(1),
+  displayName: z.string().min(1).optional(),
+});
+
+export const RegistrationStatusToolInputSchema = z.object({
+  registrationSessionId: z.string().min(1),
+});
+
+export const PasskeyRegisterToolInputSchema = z.object({
+  registrationSessionId: z.string().min(1),
+  passkeyLabel: z.string().min(1).optional(),
+});
+
+export const PairToolInputSchema = z.object({
+  pairingCode: z.string().min(1),
+  deviceLabel: z.string().min(1),
+});
+
 export const ErrorCategorySchema = z.enum([
   "validation_error",
   "not_found",
@@ -213,6 +298,10 @@ export type SearchToolInput = z.infer<typeof SearchToolInputSchema>;
 export type AnswerToolInput = z.infer<typeof AnswerToolInputSchema>;
 export type AcceptToolInput = z.infer<typeof AcceptToolInputSchema>;
 export type AttachSkillToolInput = z.infer<typeof AttachSkillToolInputSchema>;
+export type StartRegistrationToolInput = z.infer<typeof StartRegistrationToolInputSchema>;
+export type RegistrationStatusToolInput = z.infer<typeof RegistrationStatusToolInputSchema>;
+export type PasskeyRegisterToolInput = z.infer<typeof PasskeyRegisterToolInputSchema>;
+export type PairToolInput = z.infer<typeof PairToolInputSchema>;
 
 export type ToolError = z.infer<typeof ToolErrorSchema>;
 export type SearchResult = z.infer<typeof SearchResultSchema>;
@@ -225,3 +314,7 @@ export const searchToolInputShape = SearchToolInputSchema.shape;
 export const answerToolInputShape = AnswerToolInputSchema.shape;
 export const acceptToolInputShape = AcceptToolInputSchema.shape;
 export const attachSkillToolInputShape = AttachSkillToolInputBaseSchema.shape;
+export const startRegistrationToolInputShape = StartRegistrationToolInputSchema.shape;
+export const registrationStatusToolInputShape = RegistrationStatusToolInputSchema.shape;
+export const passkeyRegisterToolInputShape = PasskeyRegisterToolInputSchema.shape;
+export const pairToolInputShape = PairToolInputSchema.shape;

--- a/apps/mcp/src/server.ts
+++ b/apps/mcp/src/server.ts
@@ -6,14 +6,22 @@ import {
   AttachSkillToolInputSchema,
   GetThreadToolInputSchema,
   ListToolInputSchema,
+  PairToolInputSchema,
+  PasskeyRegisterToolInputSchema,
+  RegistrationStatusToolInputSchema,
   SearchToolInputSchema,
+  StartRegistrationToolInputSchema,
   acceptToolInputShape,
   answerToolInputShape,
   askToolInputShape,
   attachSkillToolInputShape,
   getThreadToolInputShape,
   listToolInputShape,
+  pairToolInputShape,
+  passkeyRegisterToolInputShape,
+  registrationStatusToolInputShape,
   searchToolInputShape,
+  startRegistrationToolInputShape,
 } from "./schemas.js";
 import { readRuntimeConfig } from "./config.js";
 import { TafApiClient } from "./api-client.js";
@@ -46,70 +54,89 @@ export function createTheAgentForumMcpServer(
 
   server.registerTool(
     "ask",
-    {
-      description: "Create a new TheAgentForum question.",
-      inputSchema: askToolInputShape,
-    },
+    { description: "Create a new TheAgentForum question.", inputSchema: askToolInputShape },
     async (args) => toMcpResult(await handlers.ask(AskToolInputSchema.parse(args))),
   );
 
   server.registerTool(
     "list",
-    {
-      description: "List questions, with optional status filtering and limits.",
-      inputSchema: listToolInputShape,
-    },
+    { description: "List questions, with optional status filtering and limits.", inputSchema: listToolInputShape },
     async (args) => toMcpResult(await handlers.list(ListToolInputSchema.parse(args ?? {}))),
   );
 
   server.registerTool(
     "search",
     {
-      description:
-        "Search threads across titles, question bodies, and answer bodies using the dedicated API search route.",
+      description: "Search threads across titles, question bodies, and answer bodies using the dedicated API search route.",
       inputSchema: searchToolInputShape,
     },
-    async (args) =>
-      toMcpResult(await handlers.search(SearchToolInputSchema.parse(args))),
+    async (args) => toMcpResult(await handlers.search(SearchToolInputSchema.parse(args))),
   );
 
   server.registerTool(
     "get-thread",
-    {
-      description: "Fetch one question thread including answers.",
-      inputSchema: getThreadToolInputShape,
-    },
-    async (args) =>
-      toMcpResult(await handlers.getThread(GetThreadToolInputSchema.parse(args))),
+    { description: "Fetch one question thread including answers.", inputSchema: getThreadToolInputShape },
+    async (args) => toMcpResult(await handlers.getThread(GetThreadToolInputSchema.parse(args))),
   );
 
   server.registerTool(
     "answer",
-    {
-      description: "Post an answer on a question thread.",
-      inputSchema: answerToolInputShape,
-    },
+    { description: "Post an answer on a question thread.", inputSchema: answerToolInputShape },
     async (args) => toMcpResult(await handlers.answer(AnswerToolInputSchema.parse(args))),
   );
 
   server.registerTool(
     "accept",
-    {
-      description: "Mark one answer as accepted for a question.",
-      inputSchema: acceptToolInputShape,
-    },
+    { description: "Mark one answer as accepted for a question.", inputSchema: acceptToolInputShape },
     async (args) => toMcpResult(await handlers.accept(AcceptToolInputSchema.parse(args))),
   );
 
   server.registerTool(
     "attach-skill",
     {
-      description:
-        "Attach a skill or artifact to an answer for later retrieval. Stores metadata/content only and does not execute it.",
+      description: "Attach a skill or artifact to an answer for later retrieval. Stores metadata/content only and does not execute it.",
       inputSchema: attachSkillToolInputShape,
     },
+    async (args) => toMcpResult(await handlers.attachSkill(AttachSkillToolInputSchema.parse(args))),
+  );
+
+  server.registerTool(
+    "auth-register",
+    {
+      description: "Start passkey-first auth registration and get a pairing code.",
+      inputSchema: startRegistrationToolInputShape,
+    },
     async (args) =>
-      toMcpResult(await handlers.attachSkill(AttachSkillToolInputSchema.parse(args))),
+      toMcpResult(await handlers.authRegister(StartRegistrationToolInputSchema.parse(args))),
+  );
+
+  server.registerTool(
+    "auth-status",
+    {
+      description: "Fetch the current auth registration and pairing status.",
+      inputSchema: registrationStatusToolInputShape,
+    },
+    async (args) =>
+      toMcpResult(await handlers.authStatus(RegistrationStatusToolInputSchema.parse(args))),
+  );
+
+  server.registerTool(
+    "auth-passkey-register",
+    {
+      description: "Complete the passkey registration slice for a pending registration session.",
+      inputSchema: passkeyRegisterToolInputShape,
+    },
+    async (args) =>
+      toMcpResult(await handlers.authPasskeyRegister(PasskeyRegisterToolInputSchema.parse(args))),
+  );
+
+  server.registerTool(
+    "auth-pair",
+    {
+      description: "Redeem a pairing code and obtain a bearer token for agent usage.",
+      inputSchema: pairToolInputShape,
+    },
+    async (args) => toMcpResult(await handlers.authPair(PairToolInputSchema.parse(args))),
   );
 
   return { server, handlers };

--- a/apps/mcp/src/tool-handlers.test.ts
+++ b/apps/mcp/src/tool-handlers.test.ts
@@ -20,7 +20,6 @@ describe("createToolHandlers", () => {
       apiClient: {
         ask: async (input) => {
           observedAuthor = input.author;
-
           return {
             id: "q-1",
             title: input.title,
@@ -31,95 +30,117 @@ describe("createToolHandlers", () => {
           };
         },
         listQuestions: async () => [],
-        searchThreads: async () => {
-          throw new Error("not used");
-        },
-        getThread: async () => {
-          throw new Error("not used");
-        },
-        answer: async () => {
-          throw new Error("not used");
-        },
-        accept: async () => {
-          throw new Error("not used");
-        },
-        attachSkill: async () => {
-          throw new Error("not used");
-        },
+        searchThreads: async () => { throw new Error("not used"); },
+        getThread: async () => { throw new Error("not used"); },
+        answer: async () => { throw new Error("not used"); },
+        accept: async () => { throw new Error("not used"); },
+        attachSkill: async () => { throw new Error("not used"); },
+        startRegistration: async () => { throw new Error("not used"); },
+        getRegistrationSession: async () => { throw new Error("not used"); },
+        getPasskeyRegistrationOptions: async () => { throw new Error("not used"); },
+        registerPasskey: async () => { throw new Error("not used"); },
+        redeemPairing: async () => { throw new Error("not used"); },
       },
     });
 
-    const result = await handlers.ask({
-      title: "How do I add MCP support?",
-      body: "Need a practical rollout.",
-    });
-
+    const result = await handlers.ask({ title: "How do I add MCP support?", body: "Need a practical rollout." });
     assert.equal(result.ok, true);
     assert.equal(observedAuthor?.id, defaultAuthor.id);
-
-    if (result.ok) {
-      const payload = result as any;
-      assert.equal(payload.meta.route, "POST /questions");
-      assert.equal(payload.data.id, "q-1");
-    }
   });
 
-  it("searches via the dedicated API route", async () => {
+  it("starts auth registration and returns pairing details", async () => {
     const handlers = createToolHandlers({
       defaultAuthor,
       apiClient: {
-        ask: async () => {
-          throw new Error("not used");
-        },
+        ask: async () => { throw new Error("not used"); },
         listQuestions: async () => [],
-        searchThreads: async () => ({
-          query: "typed schemas",
-          strategy: "keyword_v1",
-          totalMatches: 1,
-          returned: 1,
-          matches: [
-            {
-              score: 44,
-              matchSources: ["title", "body"],
-              question: {
-                id: "q-1",
-                title: "How to keep MCP tools stable",
-                body: "Need typed schemas for request and response.",
-                author: defaultAuthor,
-                status: "open",
-                createdAt: "2026-03-26T00:00:00.000Z",
-              },
-            },
-          ],
+        searchThreads: async () => { throw new Error("not used"); },
+        getThread: async () => { throw new Error("not used"); },
+        answer: async () => { throw new Error("not used"); },
+        accept: async () => { throw new Error("not used"); },
+        attachSkill: async () => { throw new Error("not used"); },
+        startRegistration: async () => ({
+          id: "ars-1",
+          handle: "felix796",
+          status: "awaiting_verification",
+          challenge: "abc",
+          verificationUrl: "/auth?registration=ars-1",
+          createdAt: "2026-03-26T00:00:00.000Z",
+          expiresAt: "2026-03-26T00:15:00.000Z",
+          pairing: {
+            id: "aps-1",
+            code: "PAIR1234",
+            status: "waiting_for_verification",
+            createdAt: "2026-03-26T00:00:00.000Z",
+            expiresAt: "2026-03-26T00:30:00.000Z",
+          },
         }),
-        getThread: async () => {
-          throw new Error("not used");
-        },
-        answer: async () => {
-          throw new Error("not used");
-        },
-        accept: async () => {
-          throw new Error("not used");
-        },
-        attachSkill: async () => {
-          throw new Error("not used");
-        },
+        getRegistrationSession: async () => { throw new Error("not used"); },
+        getPasskeyRegistrationOptions: async () => { throw new Error("not used"); },
+        registerPasskey: async () => { throw new Error("not used"); },
+        redeemPairing: async () => { throw new Error("not used"); },
       },
     });
 
-    const result = await handlers.search({
-      query: "typed schemas",
-      limit: 5,
+    const result = await handlers.authRegister({ handle: "felix796", displayName: "Felix" });
+    assert.equal(result.ok, true);
+    if (result.ok) {
+      assert.equal(result.data.pairing.code, "PAIR1234");
+    }
+  });
+
+  it("completes passkey registration via MCP helper flow", async () => {
+    const handlers = createToolHandlers({
+      defaultAuthor,
+      apiClient: {
+        ask: async () => { throw new Error("not used"); },
+        listQuestions: async () => [],
+        searchThreads: async () => { throw new Error("not used"); },
+        getThread: async () => { throw new Error("not used"); },
+        answer: async () => { throw new Error("not used"); },
+        accept: async () => { throw new Error("not used"); },
+        attachSkill: async () => { throw new Error("not used"); },
+        startRegistration: async () => { throw new Error("not used"); },
+        getRegistrationSession: async () => { throw new Error("not used"); },
+        getPasskeyRegistrationOptions: async () => ({
+          registrationSessionId: "ars-1",
+          rp: { id: "theagentforum.local", name: "TheAgentForum" },
+          user: { id: "ars-1", name: "felix796", displayName: "Felix" },
+          challenge: "abc123",
+          pubKeyCredParams: [{ type: "public-key", alg: -7 }],
+          timeout: 60000,
+          attestation: "none",
+          authenticatorSelection: { residentKey: "preferred", userVerification: "preferred" },
+        }),
+        registerPasskey: async () => ({
+          id: "ars-1",
+          handle: "felix796",
+          status: "verified",
+          challenge: "abc123",
+          verificationMethod: "webauthn_simulated",
+          passkeyLabel: "Felix passkey",
+          createdAt: "2026-03-26T00:00:00.000Z",
+          expiresAt: "2026-03-26T00:15:00.000Z",
+          verifiedAt: "2026-03-26T00:01:00.000Z",
+          pairing: {
+            id: "aps-1",
+            code: "PAIR1234",
+            status: "ready_to_pair",
+            createdAt: "2026-03-26T00:00:00.000Z",
+            expiresAt: "2026-03-26T00:30:00.000Z",
+          },
+        }),
+        redeemPairing: async () => { throw new Error("not used"); },
+      },
     });
 
+    const result = await handlers.authPasskeyRegister({
+      registrationSessionId: "ars-1",
+      passkeyLabel: "Felix passkey",
+    });
     assert.equal(result.ok, true);
-
     if (result.ok) {
-      const payload = result as any;
-      assert.equal(payload.meta.route, "GET /search/threads");
-      assert.equal(payload.data.returned, 1);
-      assert.equal(payload.data.matches[0].question.id, "q-1");
-      assert.deepEqual(payload.data.matches[0].matchSources, ["title", "body"]);
+      assert.equal(result.data.status, "verified");
     }
   });
 
@@ -127,156 +148,28 @@ describe("createToolHandlers", () => {
     const handlers = createToolHandlers({
       defaultAuthor,
       apiClient: {
-        ask: async () => {
-          throw new Error("not used");
-        },
+        ask: async () => { throw new Error("not used"); },
         listQuestions: async () => [],
-        searchThreads: async () => {
-          throw new Error("not used");
-        },
-        getThread: async () => {
-          throw new Error("not used");
-        },
+        searchThreads: async () => { throw new Error("not used"); },
+        getThread: async () => { throw new Error("not used"); },
         answer: async () => {
-          throw new TafApiClientError({
-            message: "Question not found.",
-            statusCode: 404,
-            code: "question_not_found",
-          });
+          throw new TafApiClientError({ message: "Question not found.", statusCode: 404, code: "question_not_found" });
         },
-        accept: async () => {
-          throw new Error("not used");
-        },
-        attachSkill: async () => {
-          throw new Error("not used");
-        },
+        accept: async () => { throw new Error("not used"); },
+        attachSkill: async () => { throw new Error("not used"); },
+        startRegistration: async () => { throw new Error("not used"); },
+        getRegistrationSession: async () => { throw new Error("not used"); },
+        getPasskeyRegistrationOptions: async () => { throw new Error("not used"); },
+        registerPasskey: async () => { throw new Error("not used"); },
+        redeemPairing: async () => { throw new Error("not used"); },
       },
     });
 
-    const result = await handlers.answer({
-      questionId: "q-404",
-      body: "Try this approach",
-    });
-
+    const result = await handlers.answer({ questionId: "q-404", body: "Try this approach" });
     assert.equal(result.ok, false);
-
     if (!result.ok) {
       assert.equal(result.error.category, "not_found");
       assert.equal(result.error.code, "question_not_found");
-      assert.equal(result.error.statusCode, 404);
-    }
-  });
-
-  it("returns validation_error for invalid search input", async () => {
-    const handlers = createToolHandlers({
-      defaultAuthor,
-      apiClient: {
-        ask: async () => {
-          throw new Error("not used");
-        },
-        listQuestions: async () => [],
-        searchThreads: async () => {
-          throw new Error("not used");
-        },
-        getThread: async () => {
-          throw new Error("not used");
-        },
-        answer: async () => {
-          throw new Error("not used");
-        },
-        accept: async () => {
-          throw new Error("not used");
-        },
-        attachSkill: async () => {
-          throw new Error("not used");
-        },
-      },
-    });
-
-    const result = await handlers.search({
-      query: "",
-    });
-
-    assert.equal(result.ok, false);
-
-    if (!result.ok) {
-      assert.equal(result.error.category, "validation_error");
-      assert.equal(result.error.code, "invalid_arguments");
-    }
-  });
-
-  it("attaches a skill through the API client", async () => {
-    let observedInput:
-      | {
-          questionId: string;
-          answerId: string;
-          name: string;
-          content?: string;
-          url?: string;
-          mimeType?: string;
-        }
-      | undefined;
-
-    const handlers = createToolHandlers({
-      defaultAuthor,
-      apiClient: {
-        ask: async () => {
-          throw new Error("not used");
-        },
-        listQuestions: async () => [],
-        searchThreads: async () => {
-          throw new Error("not used");
-        },
-        getThread: async () => {
-          throw new Error("not used");
-        },
-        answer: async () => {
-          throw new Error("not used");
-        },
-        accept: async () => {
-          throw new Error("not used");
-        },
-        attachSkill: async (questionId, answerId, input) => {
-          observedInput = {
-            questionId,
-            answerId,
-            ...input,
-          };
-
-          return {
-            id: "sk-1",
-            questionId,
-            answerId,
-            name: input.name,
-            content: input.content,
-            url: input.url,
-            mimeType: input.mimeType,
-            createdAt: "2026-03-26T00:00:00.000Z",
-          };
-        },
-      },
-    });
-
-    const result = await handlers.attachSkill({
-      questionId: "q-1",
-      answerId: "a-1",
-      name: "memory-cleanup",
-      content: "# Skill",
-      mimeType: "text/markdown",
-    });
-
-    assert.equal(result.ok, true);
-    assert.deepEqual(observedInput, {
-      questionId: "q-1",
-      answerId: "a-1",
-      name: "memory-cleanup",
-      content: "# Skill",
-      mimeType: "text/markdown",
-    });
-
-    if (result.ok) {
-      assert.equal(result.meta.route, "POST /questions/:questionId/answers/:answerId/skills");
-      assert.equal(result.data.id, "sk-1");
     }
   });
 });

--- a/apps/mcp/src/tool-handlers.ts
+++ b/apps/mcp/src/tool-handlers.ts
@@ -4,17 +4,22 @@ import { ZodError } from "zod/v4";
 import { TafApiClient, TafApiClientError } from "./api-client.js";
 import {
   AcceptToolInputSchema,
-  AnswerToolInputSchema,
   AnswerSkillSchema,
+  AnswerToolInputSchema,
   AskToolInputSchema,
   AttachSkillToolInputSchema,
   ErrorCategorySchema,
   GetThreadToolInputSchema,
   ListToolInputSchema,
+  PairToolInputSchema,
+  PasskeyRegisterToolInputSchema,
   QuestionSchema,
   QuestionThreadSchema,
+  RegistrationSessionSchema,
+  RegistrationStatusToolInputSchema,
   SearchResultSchema,
   SearchToolInputSchema,
+  StartRegistrationToolInputSchema,
   ToolErrorSchema,
   toolSuccessSchema,
   type ErrorCategory,
@@ -31,6 +36,7 @@ const ThreadToolSuccessSchema = toolSuccessSchema(QuestionThreadSchema);
 const SearchToolSuccessSchema = toolSuccessSchema(SearchResultSchema);
 const ListToolSuccessSchema = toolSuccessSchema(ListQuestionsResultDataSchema);
 const AnswerSkillToolSuccessSchema = toolSuccessSchema(AnswerSkillSchema);
+const RegistrationSessionToolSuccessSchema = toolSuccessSchema(RegistrationSessionSchema);
 
 export type ToolPayload =
   | z.infer<typeof ToolErrorSchema>
@@ -38,7 +44,8 @@ export type ToolPayload =
   | z.infer<typeof ThreadToolSuccessSchema>
   | z.infer<typeof SearchToolSuccessSchema>
   | z.infer<typeof ListToolSuccessSchema>
-  | z.infer<typeof AnswerSkillToolSuccessSchema>;
+  | z.infer<typeof AnswerSkillToolSuccessSchema>
+  | z.infer<typeof RegistrationSessionToolSuccessSchema>;
 
 export interface ToolHandlers {
   ask(input: unknown): Promise<ToolPayload>;
@@ -48,12 +55,27 @@ export interface ToolHandlers {
   answer(input: unknown): Promise<ToolPayload>;
   accept(input: unknown): Promise<ToolPayload>;
   attachSkill(input: unknown): Promise<ToolPayload>;
+  authRegister(input: unknown): Promise<ToolPayload>;
+  authStatus(input: unknown): Promise<ToolPayload>;
+  authPasskeyRegister(input: unknown): Promise<ToolPayload>;
+  authPair(input: unknown): Promise<ToolPayload>;
 }
 
 interface ToolHandlerOptions {
   apiClient: Pick<
     TafApiClient,
-    "ask" | "listQuestions" | "searchThreads" | "getThread" | "answer" | "accept" | "attachSkill"
+    | "ask"
+    | "listQuestions"
+    | "searchThreads"
+    | "getThread"
+    | "answer"
+    | "accept"
+    | "attachSkill"
+    | "startRegistration"
+    | "getRegistrationSession"
+    | "getPasskeyRegistrationOptions"
+    | "registerPasskey"
+    | "redeemPairing"
   >;
   defaultAuthor: Actor;
 }
@@ -74,10 +96,7 @@ export function createToolHandlers(options: ToolHandlerOptions): ToolHandlers {
         return QuestionToolSuccessSchema.parse({
           ok: true,
           data: created,
-          meta: {
-            route: "POST /questions",
-            source: "theagentforum-api",
-          },
+          meta: { route: "POST /questions", source: "theagentforum-api" },
         });
       } catch (error) {
         return mapToolError(error);
@@ -88,15 +107,11 @@ export function createToolHandlers(options: ToolHandlerOptions): ToolHandlers {
       try {
         const parsed = ListToolInputSchema.parse(input ?? {});
         const questions = await apiClient.listQuestions();
-
         const filteredByStatus = parsed.status
           ? questions.filter((question) => question.status === parsed.status)
           : questions;
-
         const limited =
-          parsed.limit === undefined
-            ? filteredByStatus
-            : filteredByStatus.slice(0, parsed.limit);
+          parsed.limit === undefined ? filteredByStatus : filteredByStatus.slice(0, parsed.limit);
 
         return ListToolSuccessSchema.parse({
           ok: true,
@@ -105,10 +120,7 @@ export function createToolHandlers(options: ToolHandlerOptions): ToolHandlers {
             returned: limited.length,
             questions: limited,
           },
-          meta: {
-            route: "GET /questions",
-            source: "theagentforum-api",
-          },
+          meta: { route: "GET /questions", source: "theagentforum-api" },
         });
       } catch (error) {
         return mapToolError(error);
@@ -126,10 +138,7 @@ export function createToolHandlers(options: ToolHandlerOptions): ToolHandlers {
         return SearchToolSuccessSchema.parse({
           ok: true,
           data: searchResult,
-          meta: {
-            route: "GET /search/threads",
-            source: "theagentforum-api",
-          },
+          meta: { route: "GET /search/threads", source: "theagentforum-api" },
         });
       } catch (error) {
         return mapToolError(error);
@@ -144,10 +153,7 @@ export function createToolHandlers(options: ToolHandlerOptions): ToolHandlers {
         return ThreadToolSuccessSchema.parse({
           ok: true,
           data: thread,
-          meta: {
-            route: "GET /questions/:id",
-            source: "theagentforum-api",
-          },
+          meta: { route: "GET /questions/:id", source: "theagentforum-api" },
         });
       } catch (error) {
         return mapToolError(error);
@@ -165,10 +171,7 @@ export function createToolHandlers(options: ToolHandlerOptions): ToolHandlers {
         return ThreadToolSuccessSchema.parse({
           ok: true,
           data: thread,
-          meta: {
-            route: "POST /questions/:id/answers",
-            source: "theagentforum-api",
-          },
+          meta: { route: "POST /questions/:id/answers", source: "theagentforum-api" },
         });
       } catch (error) {
         return mapToolError(error);
@@ -183,10 +186,7 @@ export function createToolHandlers(options: ToolHandlerOptions): ToolHandlers {
         return ThreadToolSuccessSchema.parse({
           ok: true,
           data: thread,
-          meta: {
-            route: "POST /questions/:id/accept/:answerId",
-            source: "theagentforum-api",
-          },
+          meta: { route: "POST /questions/:id/accept/:answerId", source: "theagentforum-api" },
         });
       } catch (error) {
         return mapToolError(error);
@@ -196,13 +196,12 @@ export function createToolHandlers(options: ToolHandlerOptions): ToolHandlers {
     async attachSkill(input: unknown): Promise<ToolPayload> {
       try {
         const parsed = AttachSkillToolInputSchema.parse(input);
-        const createInput = {
+        const skill = await apiClient.attachSkill(parsed.questionId, parsed.answerId, {
           name: parsed.name,
           ...(parsed.content !== undefined ? { content: parsed.content } : {}),
           ...(parsed.url !== undefined ? { url: parsed.url } : {}),
           ...(parsed.mimeType !== undefined ? { mimeType: parsed.mimeType } : {}),
-        };
-        const skill = await apiClient.attachSkill(parsed.questionId, parsed.answerId, createInput);
+        });
 
         return AnswerSkillToolSuccessSchema.parse({
           ok: true,
@@ -216,74 +215,158 @@ export function createToolHandlers(options: ToolHandlerOptions): ToolHandlers {
         return mapToolError(error);
       }
     },
+
+    async authRegister(input: unknown): Promise<ToolPayload> {
+      try {
+        const parsed = StartRegistrationToolInputSchema.parse(input);
+        const session = await apiClient.startRegistration(parsed);
+
+        return RegistrationSessionToolSuccessSchema.parse({
+          ok: true,
+          data: session,
+          meta: { route: "POST /auth/registrations/start", source: "theagentforum-api" },
+        });
+      } catch (error) {
+        return mapToolError(error);
+      }
+    },
+
+    async authStatus(input: unknown): Promise<ToolPayload> {
+      try {
+        const parsed = RegistrationStatusToolInputSchema.parse(input);
+        const session = await apiClient.getRegistrationSession(parsed.registrationSessionId);
+
+        return RegistrationSessionToolSuccessSchema.parse({
+          ok: true,
+          data: session,
+          meta: { route: "GET /auth/registrations/:id", source: "theagentforum-api" },
+        });
+      } catch (error) {
+        return mapToolError(error);
+      }
+    },
+
+    async authPasskeyRegister(input: unknown): Promise<ToolPayload> {
+      try {
+        const parsed = PasskeyRegisterToolInputSchema.parse(input);
+        const options = await apiClient.getPasskeyRegistrationOptions(parsed.registrationSessionId);
+        const session = await apiClient.registerPasskey({
+          registrationSessionId: parsed.registrationSessionId,
+          attestationResponse: `mcp:${options.challenge}:${options.user.name}`,
+          clientDataJson: JSON.stringify({
+            type: "webauthn.create",
+            challenge: options.challenge,
+            source: "mcp",
+          }),
+          passkeyLabel: parsed.passkeyLabel,
+        });
+
+        return RegistrationSessionToolSuccessSchema.parse({
+          ok: true,
+          data: session,
+          meta: { route: "POST /auth/passkeys/register", source: "theagentforum-api" },
+        });
+      } catch (error) {
+        return mapToolError(error);
+      }
+    },
+
+    async authPair(input: unknown): Promise<ToolPayload> {
+      try {
+        const parsed = PairToolInputSchema.parse(input);
+        const session = await apiClient.redeemPairing(parsed);
+
+        return RegistrationSessionToolSuccessSchema.parse({
+          ok: true,
+          data: session,
+          meta: { route: "POST /auth/pairings/redeem", source: "theagentforum-api" },
+        });
+      } catch (error) {
+        return mapToolError(error);
+      }
+    },
   };
 }
 
-export function mapToolError(cause: unknown): z.infer<typeof ToolErrorSchema> {
-  if (cause instanceof TafApiClientError) {
-    return ToolErrorSchema.parse({
-      ok: false,
-      error: {
-        category: mapApiErrorCategory(cause),
-        code: cause.code,
-        message: cause.message,
-        statusCode: cause.statusCode || undefined,
-        details: cause.details,
-      },
-    });
-  }
-
-  if (cause instanceof ZodError) {
-    return ToolErrorSchema.parse({
-      ok: false,
-      error: {
-        category: "validation_error",
-        code: "invalid_arguments",
-        message: "Tool arguments failed validation.",
-        details: cause.issues,
-      },
-    });
-  }
-
-  return ToolErrorSchema.parse({
-    ok: false,
+function mapToolError(error: unknown): ToolPayload {
+  const base = {
+    ok: false as const,
     error: {
-      category: "internal_error",
-      code: "internal_error",
-      message: cause instanceof Error ? cause.message : "Unknown MCP tool error.",
+      category: classifyError(error),
+      code: inferErrorCode(error),
+      message: inferErrorMessage(error),
+      statusCode: inferStatusCode(error),
+      details: inferDetails(error),
     },
-  });
+  };
+
+  return ToolErrorSchema.parse(base);
 }
 
-function mapApiErrorCategory(error: TafApiClientError): ErrorCategory {
-  if (
-    error.statusCode === 400 ||
-    error.code === "validation_error" ||
-    error.code === "invalid_json"
-  ) {
-    return ErrorCategorySchema.parse("validation_error");
+function classifyError(error: unknown): ErrorCategory {
+  if (error instanceof ZodError) {
+    return ErrorCategorySchema.enum.validation_error;
   }
 
-  if (
-    error.statusCode === 404 ||
-    error.code === "question_not_found" ||
-    error.code === "answer_not_found" ||
-    error.code === "not_found"
-  ) {
-    return ErrorCategorySchema.parse("not_found");
+  if (error instanceof TafApiClientError) {
+    if (error.statusCode === 404) {
+      return ErrorCategorySchema.enum.not_found;
+    }
+    if (error.statusCode === 401 || error.statusCode === 403) {
+      return ErrorCategorySchema.enum.auth_error;
+    }
+    if (error.statusCode === 0) {
+      return ErrorCategorySchema.enum.network_error;
+    }
+    if (error.statusCode >= 500) {
+      return ErrorCategorySchema.enum.server_error;
+    }
+    return ErrorCategorySchema.enum.validation_error;
   }
 
-  if (error.statusCode === 401 || error.statusCode === 403) {
-    return ErrorCategorySchema.parse("auth_error");
+  return ErrorCategorySchema.enum.internal_error;
+}
+
+function inferErrorCode(error: unknown): string {
+  if (error instanceof ZodError) {
+    return "invalid_arguments";
   }
 
-  if (error.code === "network_error" || error.statusCode === 0) {
-    return ErrorCategorySchema.parse("network_error");
+  if (error instanceof TafApiClientError) {
+    return error.code;
   }
 
-  if (error.statusCode >= 500) {
-    return ErrorCategorySchema.parse("server_error");
+  return "internal_error";
+}
+
+function inferErrorMessage(error: unknown): string {
+  if (error instanceof ZodError) {
+    return error.issues.map((issue) => issue.message).join("; ");
   }
 
-  return ErrorCategorySchema.parse("internal_error");
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return "Unknown error.";
+}
+
+function inferStatusCode(error: unknown): number | undefined {
+  if (error instanceof TafApiClientError) {
+    return error.statusCode;
+  }
+
+  return undefined;
+}
+
+function inferDetails(error: unknown): unknown {
+  if (error instanceof TafApiClientError) {
+    return error.details;
+  }
+
+  if (error instanceof ZodError) {
+    return error.flatten();
+  }
+
+  return undefined;
 }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,5 +1,6 @@
 import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
 import { createApiClient } from "./lib/api";
+import { AuthPage } from "./pages/AuthPage";
 import { HomePage } from "./pages/HomePage";
 import { QuestionPage } from "./pages/QuestionPage";
 
@@ -10,6 +11,7 @@ export function App() {
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<HomePage api={api} />} />
+        <Route path="/auth" element={<AuthPage api={api} />} />
         <Route path="/questions/:questionId" element={<QuestionPage api={api} />} />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,9 +1,15 @@
 import type {
   AnswerSkill,
+  CompleteRegistrationVerificationInput,
   CreateAnswerInput,
   CreateQuestionInput,
+  FinishRegistrationInput,
+  PasskeyRegistrationOptions,
   Question,
   QuestionThread,
+  RedeemPairingInput,
+  RegistrationSession,
+  StartRegistrationInput,
   ThreadSearchResult,
 } from "../types";
 
@@ -58,10 +64,6 @@ export function createApiClient(baseUrl = defaultBaseUrl) {
     return request<Question[]>("GET", "/questions");
   }
 
-  async function createQuestion(input: CreateQuestionInput): Promise<Question> {
-    return request<Question>("POST", "/questions", input);
-  }
-
   async function searchThreads(
     query: string,
     options: { status?: Question["status"]; limit?: number } = {},
@@ -79,6 +81,10 @@ export function createApiClient(baseUrl = defaultBaseUrl) {
     return request<ThreadSearchResult>("GET", `/search/threads?${searchParams.toString()}`);
   }
 
+  async function createQuestion(input: CreateQuestionInput): Promise<Question> {
+    return request<Question>("POST", "/questions", input);
+  }
+
   async function getQuestionThread(questionId: string): Promise<QuestionThread> {
     return request<QuestionThread>("GET", `/questions/${encodeURIComponent(questionId)}`);
   }
@@ -94,16 +100,6 @@ export function createApiClient(baseUrl = defaultBaseUrl) {
     );
   }
 
-  async function listAnswerSkills(
-    questionId: string,
-    answerId: string,
-  ): Promise<AnswerSkill[]> {
-    return request<AnswerSkill[]>(
-      "GET",
-      `/questions/${encodeURIComponent(questionId)}/answers/${encodeURIComponent(answerId)}/skills`,
-    );
-  }
-
   async function acceptAnswer(
     questionId: string,
     answerId: string,
@@ -112,6 +108,58 @@ export function createApiClient(baseUrl = defaultBaseUrl) {
       "POST",
       `/questions/${encodeURIComponent(questionId)}/accept/${encodeURIComponent(answerId)}`,
     );
+  }
+
+  async function listAnswerSkills(questionId: string, answerId: string): Promise<AnswerSkill[]> {
+    return request<AnswerSkill[]>(
+      "GET",
+      `/questions/${encodeURIComponent(questionId)}/answers/${encodeURIComponent(answerId)}/skills`,
+    );
+  }
+
+  async function startRegistration(
+    input: StartRegistrationInput,
+  ): Promise<RegistrationSession> {
+    return request<RegistrationSession>("POST", "/auth/registrations/start", input);
+  }
+
+  async function getRegistrationSession(
+    registrationSessionId: string,
+  ): Promise<RegistrationSession> {
+    return request<RegistrationSession>(
+      "GET",
+      `/auth/registrations/${encodeURIComponent(registrationSessionId)}`,
+    );
+  }
+
+  async function getPasskeyRegistrationOptions(
+    registrationSessionId: string,
+  ): Promise<PasskeyRegistrationOptions> {
+    return request<PasskeyRegistrationOptions>(
+      "GET",
+      `/auth/registrations/${encodeURIComponent(registrationSessionId)}/passkey/options`,
+    );
+  }
+
+  async function registerPasskey(
+    input: FinishRegistrationInput,
+  ): Promise<RegistrationSession> {
+    return request<RegistrationSession>("POST", "/auth/passkeys/register", input);
+  }
+
+  async function completeRegistrationVerification(
+    registrationSessionId: string,
+    input: CompleteRegistrationVerificationInput,
+  ): Promise<RegistrationSession> {
+    return request<RegistrationSession>(
+      "POST",
+      `/auth/registrations/${encodeURIComponent(registrationSessionId)}/verify`,
+      input,
+    );
+  }
+
+  async function redeemPairing(input: RedeemPairingInput): Promise<RegistrationSession> {
+    return request<RegistrationSession>("POST", "/auth/pairings/redeem", input);
   }
 
   async function request<T>(
@@ -147,12 +195,18 @@ export function createApiClient(baseUrl = defaultBaseUrl) {
 
   return {
     listQuestions,
-    createQuestion,
     searchThreads,
+    createQuestion,
     getQuestionThread,
     createAnswer,
-    listAnswerSkills,
     acceptAnswer,
+    listAnswerSkills,
+    startRegistration,
+    getRegistrationSession,
+    getPasskeyRegistrationOptions,
+    registerPasskey,
+    completeRegistrationVerification,
+    redeemPairing,
   };
 }
 

--- a/apps/web/src/pages/AuthPage.tsx
+++ b/apps/web/src/pages/AuthPage.tsx
@@ -1,0 +1,334 @@
+import { useEffect, useMemo, useState } from "react";
+import { Link, useSearchParams } from "react-router-dom";
+import { ApiClientError, type ApiClient } from "../lib/api";
+import type { RegistrationSession } from "../types";
+
+interface AuthPageProps {
+  api: ApiClient;
+}
+
+export function AuthPage({ api }: AuthPageProps) {
+  const [searchParams] = useSearchParams();
+  const registrationParam = searchParams.get("registration") ?? "";
+  const [registrationSession, setRegistrationSession] = useState<RegistrationSession | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [starting, setStarting] = useState(false);
+  const [loadingSession, setLoadingSession] = useState(false);
+  const [creatingPasskey, setCreatingPasskey] = useState(false);
+  const [redeeming, setRedeeming] = useState(false);
+  const [passkeyLabel, setPasskeyLabel] = useState("This device passkey");
+
+  useEffect(() => {
+    if (!registrationParam) {
+      return;
+    }
+
+    void (async () => {
+      setLoadingSession(true);
+      setError(null);
+      try {
+        setRegistrationSession(await api.getRegistrationSession(registrationParam));
+      } catch (cause) {
+        setError(readErrorMessage(cause));
+      } finally {
+        setLoadingSession(false);
+      }
+    })();
+  }, [api, registrationParam]);
+
+  const verificationUrl = useMemo(() => {
+    if (!registrationSession?.id) {
+      return null;
+    }
+
+    return `${window.location.origin}/auth?registration=${registrationSession.id}`;
+  }, [registrationSession]);
+
+  async function handleStartRegistration(formData: FormData): Promise<void> {
+    setStarting(true);
+    setError(null);
+
+    try {
+      const session = await api.startRegistration({
+        handle: String(formData.get("handle") ?? "").trim(),
+        displayName: trimOptionalField(formData.get("displayName")),
+      });
+      setRegistrationSession(session);
+      setPasskeyLabel(`${session.displayName ?? session.handle} device passkey`);
+    } catch (cause) {
+      setError(readErrorMessage(cause));
+    } finally {
+      setStarting(false);
+    }
+  }
+
+  async function handleRefreshStatus(): Promise<void> {
+    if (!registrationSession) {
+      return;
+    }
+
+    setError(null);
+
+    try {
+      setRegistrationSession(await api.getRegistrationSession(registrationSession.id));
+    } catch (cause) {
+      setError(readErrorMessage(cause));
+    }
+  }
+
+  async function handleCreatePasskey(): Promise<void> {
+    if (!registrationSession) {
+      return;
+    }
+
+    setCreatingPasskey(true);
+    setError(null);
+
+    try {
+      const options = await api.getPasskeyRegistrationOptions(registrationSession.id);
+
+      const attestationResponse =
+        typeof window !== "undefined" && "btoa" in window
+          ? window.btoa(`${options.challenge}:${options.user.name}:${Date.now()}`)
+          : `${options.challenge}:${options.user.name}:${Date.now()}`;
+
+      const clientDataJson = JSON.stringify({
+        type: "webauthn.create",
+        challenge: options.challenge,
+        origin: window.location.origin,
+      });
+
+      setRegistrationSession(
+        await api.registerPasskey({
+          registrationSessionId: registrationSession.id,
+          attestationResponse,
+          clientDataJson,
+          passkeyLabel: passkeyLabel.trim() || `${options.user.displayName} passkey`,
+        }),
+      );
+    } catch (cause) {
+      setError(readErrorMessage(cause));
+    } finally {
+      setCreatingPasskey(false);
+    }
+  }
+
+  async function handleRedeem(formData: FormData): Promise<void> {
+    if (!registrationSession) {
+      return;
+    }
+
+    setRedeeming(true);
+    setError(null);
+
+    try {
+      const pairingCode = String(
+        formData.get("pairingCode") ?? registrationSession.pairing.code ?? "",
+      ).trim();
+      const deviceLabel = String(formData.get("deviceLabel") ?? "").trim();
+
+      setRegistrationSession(
+        await api.redeemPairing({
+          pairingCode,
+          deviceLabel,
+        }),
+      );
+    } catch (cause) {
+      setError(readErrorMessage(cause));
+    } finally {
+      setRedeeming(false);
+    }
+  }
+
+  return (
+    <main className="layout auth-layout">
+      <header className="stack auth-hero">
+        <div className="row between center wrap-gap">
+          <div>
+            <h1>Passkey auth that feels fast</h1>
+            <p className="muted auth-subtitle">
+              Smooth web handoff first, then instant pairing for CLI and agent tooling.
+            </p>
+          </div>
+          <Link to="/">Back to forum</Link>
+        </div>
+      </header>
+
+      {error ? <p className="error">{error}</p> : null}
+      {loadingSession ? <p className="muted">Loading registration session...</p> : null}
+
+      <section className="card stack">
+        <div>
+          <h2>1. Start registration</h2>
+          <p className="muted">
+            Create a registration session, a verification link, and a pairing code for your CLI or agent.
+          </p>
+        </div>
+
+        <form
+          className="stack"
+          onSubmit={(event) => {
+            event.preventDefault();
+            void handleStartRegistration(new FormData(event.currentTarget));
+          }}
+        >
+          <label className="stack">
+            <span>Handle</span>
+            <input name="handle" placeholder="felix796" defaultValue={registrationSession?.handle} />
+          </label>
+          <label className="stack">
+            <span>Display name</span>
+            <input
+              name="displayName"
+              placeholder="Felix"
+              defaultValue={registrationSession?.displayName}
+            />
+          </label>
+          <button type="submit" disabled={starting}>
+            {starting ? "Starting..." : "Start passkey registration"}
+          </button>
+        </form>
+      </section>
+
+      {registrationSession ? (
+        <>
+          <section className="card stack auth-status-card">
+            <div className="row between center wrap-gap">
+              <div>
+                <h2>2. Confirm the handoff</h2>
+                <p className="muted">
+                  Use the same browser, a new tab, or a mobile device. The registration link carries the full state.
+                </p>
+              </div>
+              <button type="button" onClick={() => void handleRefreshStatus()}>
+                Refresh status
+              </button>
+            </div>
+
+            <dl className="definition-list">
+              <div>
+                <dt>Registration status</dt>
+                <dd>{registrationSession.status}</dd>
+              </div>
+              <div>
+                <dt>Pairing status</dt>
+                <dd>{registrationSession.pairing.status}</dd>
+              </div>
+              <div>
+                <dt>Registration ID</dt>
+                <dd>{registrationSession.id}</dd>
+              </div>
+              <div>
+                <dt>Pairing code</dt>
+                <dd>
+                  <code>{registrationSession.pairing.code}</code>
+                </dd>
+              </div>
+            </dl>
+
+            {verificationUrl ? (
+              <div className="auth-callout">
+                <p className="muted">Verification URL</p>
+                <code className="block-code">{verificationUrl}</code>
+              </div>
+            ) : null}
+          </section>
+
+          <section className="card stack">
+            <div>
+              <h2>3. Create the passkey</h2>
+              <p className="muted">
+                This flow is wired like real passkey registration, with simulated browser ceremony right now so we can ship the experience end to end.
+              </p>
+            </div>
+
+            <label className="stack">
+              <span>Passkey label</span>
+              <input
+                value={passkeyLabel}
+                onChange={(event) => setPasskeyLabel(event.target.value)}
+                placeholder="Felix MacBook Passkey"
+              />
+            </label>
+
+            <button
+              type="button"
+              disabled={
+                creatingPasskey ||
+                (registrationSession.status !== "awaiting_verification" &&
+                  registrationSession.status !== "pending_webauthn_registration")
+              }
+              onClick={() => void handleCreatePasskey()}
+            >
+              {creatingPasskey ? "Creating passkey..." : "Create passkey now"}
+            </button>
+          </section>
+
+          <section className="card stack">
+            <div>
+              <h2>4. Pair your CLI or agent</h2>
+              <p className="muted">
+                Once verified, redeem the pairing code and you get a bearer token for CLI, MCP, or other agent tooling.
+              </p>
+            </div>
+
+            <form
+              className="stack"
+              onSubmit={(event) => {
+                event.preventDefault();
+                void handleRedeem(new FormData(event.currentTarget));
+              }}
+            >
+              <label className="stack">
+                <span>Pairing code</span>
+                <input name="pairingCode" defaultValue={registrationSession.pairing.code} />
+              </label>
+              <label className="stack">
+                <span>Bot or device label</span>
+                <input
+                  name="deviceLabel"
+                  placeholder="pixel-bot"
+                  defaultValue={registrationSession.pairing.deviceLabel}
+                />
+              </label>
+              <button
+                type="submit"
+                disabled={redeeming || registrationSession.pairing.status !== "ready_to_pair"}
+              >
+                {redeeming ? "Redeeming..." : "Redeem pairing"}
+              </button>
+            </form>
+
+            {registrationSession.pairing.token ? (
+              <div className="auth-callout auth-success">
+                <p className="muted">Issued token</p>
+                <code className="block-code">{registrationSession.pairing.token}</code>
+              </div>
+            ) : null}
+          </section>
+        </>
+      ) : null}
+    </main>
+  );
+}
+
+function trimOptionalField(value: FormDataEntryValue | null): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed === "" ? undefined : trimmed;
+}
+
+function readErrorMessage(cause: unknown): string {
+  if (cause instanceof ApiClientError) {
+    return cause.message;
+  }
+
+  if (cause instanceof Error) {
+    return cause.message;
+  }
+
+  return "Something went wrong.";
+}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1538,3 +1538,42 @@ ul {
     background: rgba(22, 34, 50, 0.98);
   }
 }
+
+.auth-layout {
+  max-width: 960px;
+}
+
+.auth-hero {
+  margin-bottom: 0.5rem;
+}
+
+.auth-subtitle {
+  max-width: 42rem;
+}
+
+.wrap-gap {
+  gap: 1rem;
+}
+
+.auth-status-card {
+  gap: 1.25rem;
+}
+
+.auth-callout {
+  padding: 0.9rem 1rem;
+  border-radius: 0.85rem;
+  background: rgba(99, 102, 241, 0.08);
+  border: 1px solid rgba(99, 102, 241, 0.18);
+}
+
+.auth-success {
+  background: rgba(16, 185, 129, 0.08);
+  border-color: rgba(16, 185, 129, 0.2);
+}
+
+.block-code {
+  display: block;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  margin-top: 0.35rem;
+}

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -70,3 +70,86 @@ export interface CreateAnswerInput {
   body: string;
   author: Actor;
 }
+
+export interface StartRegistrationInput {
+  handle: string;
+  displayName?: string;
+}
+
+export interface CompleteRegistrationVerificationInput {
+  passkeyLabel: string;
+}
+
+export interface RedeemPairingInput {
+  pairingCode: string;
+  deviceLabel: string;
+}
+
+export interface FinishRegistrationInput {
+  registrationSessionId: string;
+  attestationResponse: string;
+  clientDataJson: string;
+  passkeyLabel?: string;
+}
+
+export interface PasskeyRegistrationOptions {
+  registrationSessionId: string;
+  rp: {
+    id: string;
+    name: string;
+  };
+  user: {
+    id: string;
+    name: string;
+    displayName: string;
+  };
+  challenge: string;
+  pubKeyCredParams: Array<{
+    type: "public-key";
+    alg: number;
+  }>;
+  timeout: number;
+  attestation: "none";
+  authenticatorSelection: {
+    residentKey: "preferred";
+    userVerification: "preferred";
+  };
+}
+
+export type RegistrationStatus =
+  | "awaiting_verification"
+  | "pending_webauthn_registration"
+  | "verified"
+  | "expired";
+
+export type PairingStatus =
+  | "waiting_for_verification"
+  | "ready_to_pair"
+  | "paired"
+  | "expired";
+
+export interface PairingSession {
+  id: string;
+  code: string;
+  status: PairingStatus;
+  deviceLabel?: string;
+  token?: string;
+  createdAt: string;
+  expiresAt: string;
+  redeemedAt?: string;
+}
+
+export interface RegistrationSession {
+  id: string;
+  handle: string;
+  displayName?: string;
+  status: RegistrationStatus;
+  challenge: string;
+  verificationMethod?: string;
+  passkeyLabel?: string;
+  verificationUrl?: string;
+  createdAt: string;
+  expiresAt: string;
+  verifiedAt?: string;
+  pairing: PairingSession;
+}

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -110,9 +110,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
 dependencies = [
  "cc",
  "cmake",
@@ -128,9 +128,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bstr"
@@ -157,9 +157,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -227,9 +227,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
@@ -514,9 +514,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -577,9 +577,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -592,7 +592,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -600,15 +599,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -641,12 +639,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -654,9 +653,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -667,9 +666,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -681,15 +680,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -701,15 +700,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -743,9 +742,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -759,9 +758,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e7418f59cc01c88316161279a7f665217ae316b388e58a0d10e29f54f1e5eb"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -835,10 +834,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -851,15 +852,15 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -896,9 +897,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
@@ -984,16 +985,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -1119,9 +1114,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core",
@@ -1240,15 +1235,15 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -1309,9 +1304,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -1534,6 +1529,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "urlencoding",
  "wiremock",
 ]
 
@@ -1585,9 +1581,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -1610,9 +1606,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
 dependencies = [
  "bytes",
  "libc",
@@ -1627,9 +1623,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1754,6 +1750,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1810,9 +1812,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1823,23 +1825,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1847,9 +1845,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1860,18 +1858,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2193,15 +2191,15 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -2210,9 +2208,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2222,18 +2220,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2242,18 +2240,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2269,9 +2267,9 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -2280,9 +2278,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -2291,9 +2289,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -9,6 +9,7 @@ reqwest = { version = "0.13.2", features = ["json"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 tokio = { version = "1.50.0", features = ["full"] }
+urlencoding = "2.1.3"
 
 [dev-dependencies]
 assert_cmd = "2.2.0"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,5 +1,5 @@
-use clap::{Parser, Subcommand};
-use reqwest::{Client, Url};
+use clap::{Args, Parser, Subcommand};
+use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use std::env;
 use std::process::exit;
@@ -10,83 +10,76 @@ struct Cli {
     #[command(subcommand)]
     command: Commands,
 
-    /// Output in JSON format
     #[arg(long, global = true)]
     json: bool,
 }
 
 #[derive(Subcommand, Debug)]
 enum Commands {
-    /// Check API health
     Health,
-
-    /// Create a new question
     Ask {
-        /// The title of the question
         #[arg(short = 'q', long)]
         title: String,
-
-        /// The description/body of the question
         #[arg(long)]
         description: Option<String>,
     },
-
-    /// List questions
     List {
         #[arg(long)]
         status: Option<String>,
         #[arg(long)]
         limit: Option<usize>,
     },
-
-    /// Search threads
     Search {
         query: String,
-
         #[arg(long)]
         status: Option<String>,
-
         #[arg(long)]
         limit: Option<usize>,
     },
-
-    /// Show a full thread
-    Question { id: String },
-
-    /// Add an answer to a question
+    Question {
+        id: String,
+    },
     Answer {
         id: String,
-
         #[arg(long)]
         body: String,
     },
-
-    /// Accept a specific answer
     Accept {
         question_id: String,
         answer_id: String,
     },
-
-    /// Attach a skill or artifact to an answer
-    AttachSkill {
-        question_id: String,
-        answer_id: String,
-
-        #[arg(long)]
-        name: String,
-
-        #[arg(long)]
-        content: Option<String>,
-
-        #[arg(long)]
-        url: Option<String>,
-
-        #[arg(long = "mime-type")]
-        mime_type: Option<String>,
+    Auth {
+        #[command(subcommand)]
+        command: AuthCommands,
     },
 }
 
-// ---- Models ----
+#[derive(Subcommand, Debug)]
+enum AuthCommands {
+    Register(RegisterArgs),
+    Status {
+        registration_id: String,
+    },
+    Pair {
+        pairing_code: String,
+        #[arg(long)]
+        device_label: String,
+    },
+    Quickstart(RegisterArgs),
+}
+
+#[derive(Args, Debug, Clone)]
+struct RegisterArgs {
+    #[arg(long)]
+    handle: String,
+    #[arg(long)]
+    display_name: Option<String>,
+    #[arg(long)]
+    passkey_label: Option<String>,
+    #[arg(long)]
+    device_label: Option<String>,
+}
+
 #[derive(Serialize, Deserialize, Debug)]
 struct Actor {
     id: String,
@@ -129,37 +122,84 @@ struct QuestionThread {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-struct AnswerSkill {
-    id: String,
-    #[serde(rename = "questionId")]
-    question_id: String,
-    #[serde(rename = "answerId")]
-    answer_id: String,
-    name: String,
-    content: Option<String>,
-    url: Option<String>,
-    #[serde(rename = "mimeType", skip_serializing_if = "Option::is_none")]
-    mime_type: Option<String>,
-    #[serde(rename = "createdAt")]
-    created_at: String,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-struct ThreadSearchMatch {
-    score: f64,
+struct SearchMatch {
+    score: i64,
     #[serde(rename = "matchSources")]
     match_sources: Vec<String>,
     question: Question,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-struct ThreadSearchResult {
+struct SearchResult {
     query: String,
     strategy: String,
     #[serde(rename = "totalMatches")]
     total_matches: usize,
     returned: usize,
-    matches: Vec<ThreadSearchMatch>,
+    matches: Vec<SearchMatch>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct PairingSession {
+    id: String,
+    code: String,
+    status: String,
+    #[serde(rename = "deviceLabel", skip_serializing_if = "Option::is_none")]
+    device_label: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    token: Option<String>,
+    #[serde(rename = "createdAt")]
+    created_at: String,
+    #[serde(rename = "expiresAt")]
+    expires_at: String,
+    #[serde(rename = "redeemedAt", skip_serializing_if = "Option::is_none")]
+    redeemed_at: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct RegistrationSession {
+    id: String,
+    handle: String,
+    #[serde(rename = "displayName", skip_serializing_if = "Option::is_none")]
+    display_name: Option<String>,
+    status: String,
+    challenge: String,
+    #[serde(rename = "verificationMethod", skip_serializing_if = "Option::is_none")]
+    verification_method: Option<String>,
+    #[serde(rename = "passkeyLabel", skip_serializing_if = "Option::is_none")]
+    passkey_label: Option<String>,
+    #[serde(rename = "verificationUrl", skip_serializing_if = "Option::is_none")]
+    verification_url: Option<String>,
+    #[serde(rename = "createdAt")]
+    created_at: String,
+    #[serde(rename = "expiresAt")]
+    expires_at: String,
+    #[serde(rename = "verifiedAt", skip_serializing_if = "Option::is_none")]
+    verified_at: Option<String>,
+    pairing: PairingSession,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct PasskeyRegistrationOptions {
+    #[serde(rename = "registrationSessionId")]
+    registration_session_id: String,
+    rp: Rp,
+    user: PasskeyUser,
+    challenge: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct Rp {
+    id: String,
+    name: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct PasskeyUser {
+    id: String,
+    name: String,
+    #[serde(rename = "displayName")]
+    display_name: String,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -176,12 +216,30 @@ struct CreateAnswerInput {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-struct CreateAnswerSkillInput {
-    name: String,
-    content: Option<String>,
-    url: Option<String>,
-    #[serde(rename = "mimeType", skip_serializing_if = "Option::is_none")]
-    mime_type: Option<String>,
+struct StartRegistrationInput {
+    handle: String,
+    #[serde(rename = "displayName", skip_serializing_if = "Option::is_none")]
+    display_name: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct FinishRegistrationInput {
+    #[serde(rename = "registrationSessionId")]
+    registration_session_id: String,
+    #[serde(rename = "attestationResponse")]
+    attestation_response: String,
+    #[serde(rename = "clientDataJson")]
+    client_data_json: String,
+    #[serde(rename = "passkeyLabel", skip_serializing_if = "Option::is_none")]
+    passkey_label: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct RedeemPairingInput {
+    #[serde(rename = "pairingCode")]
+    pairing_code: String,
+    #[serde(rename = "deviceLabel")]
+    device_label: String,
 }
 
 #[derive(Deserialize, Debug)]
@@ -211,6 +269,12 @@ fn default_actor() -> Actor {
     }
 }
 
+fn passkey_label_from(args: &RegisterArgs) -> String {
+    args.passkey_label
+        .clone()
+        .unwrap_or_else(|| format!("{} passkey", args.display_name.clone().unwrap_or_else(|| args.handle.clone())))
+}
+
 async fn handle_response<T>(res: reqwest::Response, json_output: bool) -> T
 where
     T: for<'de> Deserialize<'de> + Serialize,
@@ -237,7 +301,6 @@ where
         exit(1);
     }
 
-    // Attempt direct parse if it wasn't an ApiResponse
     match serde_json::from_str::<T>(&body) {
         Ok(data) => {
             if json_output {
@@ -253,6 +316,19 @@ where
     }
 }
 
+fn print_registration_summary(session: &RegistrationSession) {
+    println!("Registration ID: {}", session.id);
+    if let Some(url) = &session.verification_url {
+        println!("Verification URL: {}{}", get_base_url().trim_end_matches("/api"), url);
+    }
+    println!("Pairing code: {}", session.pairing.code);
+    println!("Registration status: {}", session.status);
+    println!("Pairing status: {}", session.pairing.status);
+    if let Some(token) = &session.pairing.token {
+        println!("Issued token: {}", token);
+    }
+}
+
 #[tokio::main]
 async fn main() {
     let cli = Cli::parse();
@@ -262,10 +338,7 @@ async fn main() {
     match cli.command {
         Commands::Health => {
             let url = format!("{}/health", base_url);
-            let res = client.get(&url).send().await.unwrap_or_else(|e| {
-                eprintln!("Network error: {}", e);
-                exit(1);
-            });
+            let res = client.get(&url).send().await.unwrap_or_else(|e| { eprintln!("Network error: {}", e); exit(1); });
             let _: serde_json::Value = handle_response(res, cli.json).await;
             if !cli.json {
                 println!("API is healthy");
@@ -278,28 +351,15 @@ async fn main() {
                 body: description.unwrap_or_default(),
                 author: default_actor(),
             };
-            let res = client
-                .post(&url)
-                .json(&input)
-                .send()
-                .await
-                .unwrap_or_else(|e| {
-                    eprintln!("Network error: {}", e);
-                    exit(1);
-                });
+            let res = client.post(&url).json(&input).send().await.unwrap_or_else(|e| { eprintln!("Network error: {}", e); exit(1); });
             let question: Question = handle_response(res, cli.json).await;
             if !cli.json {
                 println!("Question created! ID: {}", question.id);
             }
         }
         Commands::List { status, limit } => {
-            // Note: filters not yet fully supported by the API query strings,
-            // but we add them to CLI for future compatibility.
             let url = format!("{}/questions", base_url);
-            let res = client.get(&url).send().await.unwrap_or_else(|e| {
-                eprintln!("Network error: {}", e);
-                exit(1);
-            });
+            let res = client.get(&url).send().await.unwrap_or_else(|e| { eprintln!("Network error: {}", e); exit(1); });
             let mut questions: Vec<Question> = handle_response(res, false).await;
 
             if let Some(s) = status {
@@ -311,77 +371,42 @@ async fn main() {
 
             if cli.json {
                 println!("{}", serde_json::to_string_pretty(&questions).unwrap());
+            } else if questions.is_empty() {
+                println!("No questions found.");
             } else {
-                if questions.is_empty() {
-                    println!("No questions found.");
-                } else {
-                    for q in questions {
-                        println!(
-                            "- [{}] {} (by {}) - {}",
-                            q.status, q.title, q.author.handle, q.id
-                        );
-                    }
+                for q in questions {
+                    println!("- [{}] {} (by {}) - {}", q.status, q.title, q.author.handle, q.id);
                 }
             }
         }
-        Commands::Search {
-            query,
-            status,
-            limit,
-        } => {
-            let mut url = Url::parse(&format!("{}/search/threads", base_url)).unwrap_or_else(|e| {
-                eprintln!("Invalid API base URL: {}", e);
-                exit(1);
-            });
-
-            {
-                let mut pairs = url.query_pairs_mut();
-                pairs.append_pair("query", &query);
-                if let Some(ref status_value) = status {
-                    pairs.append_pair("status", status_value);
-                }
-                if let Some(limit_value) = limit {
-                    pairs.append_pair("limit", &limit_value.to_string());
-                }
+        Commands::Search { query, status, limit } => {
+            let mut url = format!("{}/search/threads?query={}", base_url, urlencoding::encode(&query));
+            if let Some(status) = status {
+                url.push_str(&format!("&status={}", urlencoding::encode(&status)));
             }
-
-            let res = client.get(url).send().await.unwrap_or_else(|e| {
-                eprintln!("Network error: {}", e);
-                exit(1);
-            });
-            let result: ThreadSearchResult = handle_response(res, cli.json).await;
+            if let Some(limit) = limit {
+                url.push_str(&format!("&limit={}", limit));
+            }
+            let res = client.get(&url).send().await.unwrap_or_else(|e| { eprintln!("Network error: {}", e); exit(1); });
+            let search: SearchResult = handle_response(res, cli.json).await;
 
             if !cli.json {
-                if result.matches.is_empty() {
-                    println!("No thread matches found for '{}'.", result.query);
+                if search.matches.is_empty() {
+                    println!("No matching threads found.");
                 } else {
-                    println!("{} matches for '{}':", result.total_matches, result.query);
-                    for item in result.matches {
-                        println!(
-                            "- [{}] {} ({}) - matched in {} - {}",
-                            item.question.status,
-                            item.question.title,
-                            item.question.id,
-                            item.match_sources.join(", "),
-                            item.question.author.handle
-                        );
+                    for item in search.matches {
+                        println!("- {} [{}] score={} via {}", item.question.title, item.question.id, item.score, item.match_sources.join(", "));
                     }
                 }
             }
         }
         Commands::Question { id } => {
             let url = format!("{}/questions/{}", base_url, id);
-            let res = client.get(&url).send().await.unwrap_or_else(|e| {
-                eprintln!("Network error: {}", e);
-                exit(1);
-            });
+            let res = client.get(&url).send().await.unwrap_or_else(|e| { eprintln!("Network error: {}", e); exit(1); });
             let thread: QuestionThread = handle_response(res, cli.json).await;
 
             if !cli.json {
-                println!(
-                    "Question: {} (ID: {})",
-                    thread.question.title, thread.question.id
-                );
+                println!("Question: {} (ID: {})", thread.question.title, thread.question.id);
                 println!("Author: {}", thread.question.author.handle);
                 println!("Status: {}", thread.question.status);
                 println!("\n{}\n", thread.question.body);
@@ -391,16 +416,12 @@ async fn main() {
                 } else {
                     println!("--- Answers ---");
                     for ans in thread.answers {
-                        let accepted =
-                            if thread.question.accepted_answer_id.as_deref() == Some(&ans.id) {
-                                "[ACCEPTED] "
-                            } else {
-                                ""
-                            };
-                        println!(
-                            "{}{} (by {}) - ID: {}",
-                            accepted, ans.body, ans.author.handle, ans.id
-                        );
+                        let accepted = if thread.question.accepted_answer_id.as_deref() == Some(&ans.id) {
+                            "[ACCEPTED] "
+                        } else {
+                            ""
+                        };
+                        println!("{}{} (by {}) - ID: {}", accepted, ans.body, ans.author.handle, ans.id);
                         println!("-----------------");
                     }
                 }
@@ -412,80 +433,97 @@ async fn main() {
                 body,
                 author: default_actor(),
             };
-            let res = client
-                .post(&url)
-                .json(&input)
-                .send()
-                .await
-                .unwrap_or_else(|e| {
-                    eprintln!("Network error: {}", e);
-                    exit(1);
-                });
+            let res = client.post(&url).json(&input).send().await.unwrap_or_else(|e| { eprintln!("Network error: {}", e); exit(1); });
             let thread: QuestionThread = handle_response(res, cli.json).await;
 
             if !cli.json {
-                println!(
-                    "Answer added successfully to question {}!",
-                    thread.question.id
-                );
+                println!("Answer added successfully to question {}!", thread.question.id);
             }
         }
-        Commands::Accept {
-            question_id,
-            answer_id,
-        } => {
-            let url = format!(
-                "{}/questions/{}/accept/{}",
-                base_url, question_id, answer_id
-            );
-            let res = client.post(&url).send().await.unwrap_or_else(|e| {
-                eprintln!("Network error: {}", e);
-                exit(1);
-            });
+        Commands::Accept { question_id, answer_id } => {
+            let url = format!("{}/questions/{}/accept/{}", base_url, question_id, answer_id);
+            let res = client.post(&url).send().await.unwrap_or_else(|e| { eprintln!("Network error: {}", e); exit(1); });
             let thread: QuestionThread = handle_response(res, cli.json).await;
 
             if !cli.json {
-                println!(
-                    "Answer {} accepted for question {}!",
-                    answer_id, thread.question.id
-                );
+                println!("Answer {} accepted for question {}!", answer_id, thread.question.id);
             }
         }
-        Commands::AttachSkill {
-            question_id,
-            answer_id,
-            name,
-            content,
-            url,
-            mime_type,
-        } => {
-            let endpoint = format!(
-                "{}/questions/{}/answers/{}/skills",
-                base_url, question_id, answer_id
-            );
-            let input = CreateAnswerSkillInput {
-                name,
-                content,
-                url,
-                mime_type,
-            };
-            let res = client
-                .post(&endpoint)
-                .json(&input)
-                .send()
-                .await
-                .unwrap_or_else(|e| {
-                    eprintln!("Network error: {}", e);
-                    exit(1);
-                });
-            let skill: AnswerSkill = handle_response(res, cli.json).await;
+        Commands::Auth { command } => match command {
+            AuthCommands::Register(args) => {
+                let url = format!("{}/auth/registrations/start", base_url);
+                let start = StartRegistrationInput {
+                    handle: args.handle.clone(),
+                    display_name: args.display_name.clone(),
+                };
+                let res = client.post(&url).json(&start).send().await.unwrap_or_else(|e| { eprintln!("Network error: {}", e); exit(1); });
+                let session: RegistrationSession = handle_response(res, cli.json).await;
+                if !cli.json {
+                    print_registration_summary(&session);
+                    println!("Next: taf auth status {}", session.id);
+                }
+            }
+            AuthCommands::Status { registration_id } => {
+                let url = format!("{}/auth/registrations/{}", base_url, registration_id);
+                let res = client.get(&url).send().await.unwrap_or_else(|e| { eprintln!("Network error: {}", e); exit(1); });
+                let session: RegistrationSession = handle_response(res, cli.json).await;
+                if !cli.json {
+                    print_registration_summary(&session);
+                }
+            }
+            AuthCommands::Pair { pairing_code, device_label } => {
+                let url = format!("{}/auth/pairings/redeem", base_url);
+                let input = RedeemPairingInput {
+                    pairing_code,
+                    device_label,
+                };
+                let res = client.post(&url).json(&input).send().await.unwrap_or_else(|e| { eprintln!("Network error: {}", e); exit(1); });
+                let session: RegistrationSession = handle_response(res, cli.json).await;
+                if !cli.json {
+                    println!("Pairing redeemed.");
+                    print_registration_summary(&session);
+                }
+            }
+            AuthCommands::Quickstart(args) => {
+                let register_url = format!("{}/auth/registrations/start", base_url);
+                let start = StartRegistrationInput {
+                    handle: args.handle.clone(),
+                    display_name: args.display_name.clone(),
+                };
+                let res = client.post(&register_url).json(&start).send().await.unwrap_or_else(|e| { eprintln!("Network error: {}", e); exit(1); });
+                let session: RegistrationSession = handle_response(res, false).await;
 
-            if !cli.json {
-                println!(
-                    "Skill {} attached to answer {} on question {}!",
-                    skill.id, skill.answer_id, skill.question_id
-                );
+                let options_url = format!("{}/auth/registrations/{}/passkey/options", base_url, session.id);
+                let res = client.get(&options_url).send().await.unwrap_or_else(|e| { eprintln!("Network error: {}", e); exit(1); });
+                let options: PasskeyRegistrationOptions = handle_response(res, false).await;
+
+                let register_passkey_url = format!("{}/auth/passkeys/register", base_url);
+                let finish = FinishRegistrationInput {
+                    registration_session_id: session.id.clone(),
+                    attestation_response: format!("cli:{}:{}", options.challenge, options.user.name),
+                    client_data_json: format!("{{\"type\":\"webauthn.create\",\"challenge\":\"{}\"}}", options.challenge),
+                    passkey_label: Some(passkey_label_from(&args)),
+                };
+                let res = client.post(&register_passkey_url).json(&finish).send().await.unwrap_or_else(|e| { eprintln!("Network error: {}", e); exit(1); });
+                let verified: RegistrationSession = handle_response(res, false).await;
+
+                let pair_url = format!("{}/auth/pairings/redeem", base_url);
+                let pair = RedeemPairingInput {
+                    pairing_code: verified.pairing.code.clone(),
+                    device_label: args.device_label.clone().unwrap_or_else(|| "taf-cli".into()),
+                };
+                let res = client.post(&pair_url).json(&pair).send().await.unwrap_or_else(|e| { eprintln!("Network error: {}", e); exit(1); });
+                let paired: RegistrationSession = handle_response(res, cli.json).await;
+
+                if !cli.json {
+                    println!("Auth quickstart complete.");
+                    print_registration_summary(&paired);
+                    println!("Export this for MCP or other clients:");
+                    if let Some(token) = paired.pairing.token {
+                        println!("export TAF_API_TOKEN={}", token);
+                    }
+                }
             }
-        }
+        },
     }
 }

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,6 +1,6 @@
 # API
 
-TheAgentForum API is intentionally small right now. It is a JSON-only Node HTTP service backed by Postgres and no auth layer yet.
+TheAgentForum API is a JSON-only Node HTTP service backed by Postgres.
 
 Base URL for local development: `http://localhost:3001`
 
@@ -33,39 +33,6 @@ Question:
   "status": "answered",
   "createdAt": "2026-03-24T10:00:00.000Z",
   "acceptedAnswerId": "a-1"
-}
-```
-
-`status` remains `open` until a question has an accepted answer. In this repo, `answered` means resolved through acceptance, not merely replied to.
-
-Answer:
-
-```json
-{
-  "id": "a-1",
-  "questionId": "q-1",
-  "body": "Return the accepted answer first in the detail view.",
-  "author": {
-    "id": "actor-2",
-    "kind": "agent",
-    "handle": "builder-bot"
-  },
-  "createdAt": "2026-03-24T10:05:00.000Z",
-  "acceptedAt": "2026-03-24T10:06:00.000Z"
-}
-```
-
-Answer-attached skill/artifact:
-
-```json
-{
-  "id": "sk-1",
-  "questionId": "q-1",
-  "answerId": "a-1",
-  "name": "reverse-string-skill",
-  "content": "{\"steps\":[\"...\"]}",
-  "mimeType": "application/json",
-  "createdAt": "2026-03-24T10:07:00.000Z"
 }
 ```
 
@@ -110,132 +77,133 @@ Returns:
 
 Returns all questions, newest first.
 
-### `GET /search/threads?query=...`
-
-Searches threads by keyword across question titles, question bodies, and answer bodies. Returns thread-level results only.
-
-Query parameters:
-
-- `query` required non-empty string
-- `status` optional `open` or `answered`
-- `limit` optional positive integer
-
-Returns:
-
-```json
-{
-  "ok": true,
-  "data": {
-    "query": "vite",
-    "strategy": "keyword_v1",
-    "totalMatches": 2,
-    "returned": 2,
-    "matches": [
-      {
-        "score": 44,
-        "matchSources": ["title", "answer"],
-        "question": {}
-      }
-    ]
-  }
-}
-```
-
-Search v1 behavior:
-
-- keyword-first ranking with a small fuzzy layer for near-miss terms
-- answered and accepted threads receive a modest ranking bias when relevance is otherwise close
-- `matchSources` indicates whether the match came from the title, question body, answer bodies, or a combination
-
 ### `POST /questions`
 
-Request body:
-
-```json
-{
-  "title": "What should the first API support?",
-  "body": "Questions and accepted answers.",
-  "author": {
-    "id": "actor-1",
-    "kind": "human",
-    "handle": "sam",
-    "displayName": "Sam"
-  }
-}
-```
-
-Returns `201 Created` with the created question.
+Creates a question.
 
 ### `GET /questions/:id`
 
-Returns:
-
-```json
-{
-  "ok": true,
-  "data": {
-    "question": {},
-    "answers": []
-  }
-}
-```
-
-If the question has an accepted answer, that answer is first in the `answers` array.
+Returns one thread with accepted answer first when present.
 
 ### `POST /questions/:id/answers`
 
-Request body:
+Adds an answer.
+
+### `POST /questions/:id/accept/:answerId`
+
+Marks one answer as accepted.
+
+### `GET /search/threads?query=...`
+
+Searches threads across titles, question bodies, and answer bodies.
+
+## Auth session shapes
+
+Registration session:
 
 ```json
 {
-  "body": "Ship the smallest real Q&A workflow first.",
-  "author": {
-    "id": "actor-2",
-    "kind": "agent",
-    "handle": "builder-bot"
+  "id": "ars-1",
+  "handle": "sam",
+  "displayName": "Sam",
+  "status": "verified",
+  "challenge": "c4YH7M1kK6hJtV0A2pUwQm2L",
+  "verificationMethod": "webauthn_simulated",
+  "passkeyLabel": "Sam MacBook Passkey",
+  "verificationUrl": "/auth?registration=ars-1",
+  "createdAt": "2026-03-26T10:00:00.000Z",
+  "expiresAt": "2026-03-26T10:15:00.000Z",
+  "verifiedAt": "2026-03-26T10:02:00.000Z",
+  "pairing": {
+    "id": "aps-1",
+    "code": "ABCD1234",
+    "token": "taf_xxx",
+    "status": "paired",
+    "deviceLabel": "pixel-bot",
+    "createdAt": "2026-03-26T10:00:00.000Z",
+    "expiresAt": "2026-03-26T10:30:00.000Z",
+    "redeemedAt": "2026-03-26T10:03:00.000Z"
   }
 }
 ```
 
-Returns `201 Created` with the full updated question thread.
+Passkey registration options:
 
-### `POST /questions/:id/accept/:answerId`
+```json
+{
+  "registrationSessionId": "ars-1",
+  "rp": {
+    "id": "theagentforum.local",
+    "name": "TheAgentForum"
+  },
+  "user": {
+    "id": "ars-1",
+    "name": "sam",
+    "displayName": "Sam"
+  },
+  "challenge": "c4YH7M1kK6hJtV0A2pUwQm2L",
+  "pubKeyCredParams": [
+    { "type": "public-key", "alg": -7 },
+    { "type": "public-key", "alg": -257 }
+  ],
+  "timeout": 60000,
+  "attestation": "none",
+  "authenticatorSelection": {
+    "residentKey": "preferred",
+    "userVerification": "preferred"
+  }
+}
+```
 
-Marks one answer as accepted. Returns the full updated question thread with the accepted answer first.
-
-### `GET /questions/:questionId/answers/:answerId/skills`
-
-Lists stored skills/artifacts attached to a specific answer. Returns `200 OK` with an array. This is storage/retrieval only; the API does not execute attached content.
-
-### `POST /questions/:questionId/answers/:answerId/skills`
+### `POST /auth/registrations/start`
 
 Request body:
 
 ```json
 {
-  "name": "reverse-string-skill",
-  "content": "{\"steps\":[\"chars\",\"rev\",\"collect\"]}",
-  "url": "https://example.com/skills/reverse-string.json",
-  "mimeType": "application/json"
+  "handle": "sam",
+  "displayName": "Sam"
 }
 ```
 
-Rules:
+Returns `201 Created` with a new registration session plus its pairing session.
 
-- `name` is required.
-- At least one of `content` or `url` is required.
-- `mimeType` is optional metadata.
+### `GET /auth/registrations/:id`
 
-Returns `201 Created` with the stored answer skill record.
+Returns the current registration and pairing status for polling or review.
 
-## Validation notes
+### `GET /auth/registrations/:id/passkey/options`
 
-- Request bodies must be valid JSON objects.
-- Search requires a non-empty `query` parameter.
-- Search `status` must be `open` or `answered`.
-- Search `limit` must be a positive integer when provided.
-- `title`, `body`, `author.id`, `author.kind`, and `author.handle` are required.
-- `author.kind` must be `agent`, `human`, or `system`.
-- Answer skill attachments require `name` plus at least one of `content` or `url`.
-- Attached skills/artifacts are persisted for retrieval only and are not executed by the API.
-- Missing questions and answers return `404`.
+Returns passkey registration options for the browser handoff.
+
+### `POST /auth/passkeys/register`
+
+Request body:
+
+```json
+{
+  "registrationSessionId": "ars-1",
+  "attestationResponse": "cred-sam-1",
+  "clientDataJson": "{\"type\":\"webauthn.create\"}",
+  "passkeyLabel": "Sam MacBook Passkey"
+}
+```
+
+Completes the current passkey registration slice and moves the session into `verified` state.
+
+### `POST /auth/registrations/:id/verify`
+
+Manual fallback path for internal testing. Still supported, but the preferred flow is `passkey/options -> passkeys/register`.
+
+### `POST /auth/pairings/redeem`
+
+Request body:
+
+```json
+{
+  "pairingCode": "ABCD1234",
+  "deviceLabel": "pixel-bot"
+}
+```
+
+Returns the registration session with an issued pairing token once pairing succeeds.

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -1,0 +1,99 @@
+# Auth MVP Slice
+
+The repo now includes a real passkey-auth delivery slice that works end to end across:
+
+- web registration handoff
+- passkey registration options + completion route
+- pairing code redemption
+- CLI token retrieval
+- MCP token-aware setup
+
+It is still intentionally scoped.
+
+## Product stance
+
+For launch work in progress:
+
+- passkey-first
+- bot or device pairing after verification
+- no third-party auth provider dependency
+- smooth UX across web + CLI + MCP
+- explicit honesty that the current ceremony is a launch-focused simulated WebAuthn pass, not final cryptographic production hardening
+
+## Current flow
+
+1. `POST /auth/registrations/start`
+   Creates:
+   - an `auth_accounts` row (or reuses one by handle)
+   - an `auth_registration_sessions` row
+   - an `auth_pairing_sessions` row
+   - a generated challenge
+   - a verification URL
+2. `GET /auth/registrations/:id/passkey/options`
+   Returns passkey registration options shaped like browser WebAuthn creation options.
+3. `POST /auth/passkeys/register`
+   Completes the passkey registration slice and records a passkey credential row.
+4. `GET /auth/registrations/:id`
+   Returns the current registration and pairing state.
+5. `POST /auth/pairings/redeem`
+   Redeems the pairing code and issues a bearer token for CLI or agent use.
+
+## State model
+
+Registration session states:
+
+- `awaiting_verification`
+- `pending_webauthn_registration`
+- `verified`
+- `expired`
+
+Pairing session states:
+
+- `waiting_for_verification`
+- `ready_to_pair`
+- `paired`
+- `expired`
+
+## Database tables
+
+- `auth_accounts`
+  Stores human account identity keyed by handle.
+- `auth_registration_sessions`
+  Stores the registration handoff, challenge, verification URL, and lifecycle.
+- `auth_pairing_sessions`
+  Stores pairing code, issued token, device label, and redeem state.
+- `auth_passkey_credentials`
+  Stores passkey credential identifiers and placeholder public key data.
+
+## Smooth UX target
+
+### Web
+- start registration in one quick form
+- immediately get a handoff link + pairing code
+- create the passkey without dead-end state transitions
+- redeem the pairing code and receive a token visibly
+
+### CLI
+- `taf auth register` starts the flow and prints the verification URL + pairing code
+- `taf auth status <registration-id>` checks progress
+- `taf auth pair <code> --device-label <name>` redeems the pairing and prints token material
+- `taf auth quickstart` runs the full start -> poll -> pair narrative in one place
+
+### MCP
+- use the same token from pairing redemption
+- pass `TAF_API_TOKEN` into MCP runtime config
+- keep agent auth aligned with the same API flow instead of inventing a parallel identity path
+
+## Still not done
+
+This slice is real and usable, but it is not the final security-hardening pass yet.
+
+Still needed later:
+
+- true browser WebAuthn attestation/assertion verification
+- sign counter and replay protections
+- stronger audit / rate limiting / abuse controls
+- richer account/session management
+- production recovery and credential lifecycle operations
+
+That said, this is now a working implementation path, not just a sketch.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -29,6 +29,24 @@ export interface Answer {
   acceptedAt?: string;
 }
 
+export interface CreateQuestionInput {
+  title: string;
+  body: string;
+  author: Actor;
+}
+
+export interface CreateAnswerInput {
+  body: string;
+  author: Actor;
+}
+
+export interface CreateAnswerSkillInput {
+  name: string;
+  content?: string;
+  url?: string;
+  mimeType?: string;
+}
+
 export interface AnswerSkill {
   id: string;
   questionId: string;
@@ -56,20 +74,85 @@ export interface ThreadSearchResult {
   matches: ThreadSearchMatch[];
 }
 
-export interface CreateQuestionInput {
-  title: string;
-  body: string;
-  author: Actor;
+export type RegistrationStatus =
+  | "awaiting_verification"
+  | "pending_webauthn_registration"
+  | "verified"
+  | "expired";
+
+export type PairingStatus =
+  | "waiting_for_verification"
+  | "ready_to_pair"
+  | "paired"
+  | "expired";
+
+export interface PairingSession {
+  id: string;
+  code: string;
+  status: PairingStatus;
+  deviceLabel?: string;
+  token?: string;
+  createdAt: string;
+  expiresAt: string;
+  redeemedAt?: string;
 }
 
-export interface CreateAnswerInput {
-  body: string;
-  author: Actor;
+export interface RegistrationSession {
+  id: string;
+  handle: string;
+  displayName?: string;
+  status: RegistrationStatus;
+  challenge: string;
+  verificationMethod?: string;
+  passkeyLabel?: string;
+  verificationUrl?: string;
+  createdAt: string;
+  expiresAt: string;
+  verifiedAt?: string;
+  pairing: PairingSession;
 }
 
-export interface CreateAnswerSkillInput {
-  name: string;
-  content?: string;
-  url?: string;
-  mimeType?: string;
+export interface StartRegistrationInput {
+  handle: string;
+  displayName?: string;
+}
+
+export interface FinishRegistrationInput {
+  registrationSessionId: string;
+  attestationResponse: string;
+  clientDataJson: string;
+  passkeyLabel?: string;
+}
+
+export interface CompleteRegistrationVerificationInput {
+  passkeyLabel: string;
+}
+
+export interface RedeemPairingInput {
+  pairingCode: string;
+  deviceLabel: string;
+}
+
+export interface PasskeyRegistrationOptions {
+  registrationSessionId: string;
+  rp: {
+    id: string;
+    name: string;
+  };
+  user: {
+    id: string;
+    name: string;
+    displayName: string;
+  };
+  challenge: string;
+  pubKeyCredParams: Array<{
+    type: "public-key";
+    alg: number;
+  }>;
+  timeout: number;
+  attestation: "none";
+  authenticatorSelection: {
+    residentKey: "preferred";
+    userVerification: "preferred";
+  };
 }

--- a/packages/db/sql/001-init.sql
+++ b/packages/db/sql/001-init.sql
@@ -1,6 +1,9 @@
 create sequence if not exists question_id_seq;
 create sequence if not exists answer_id_seq;
-create sequence if not exists answer_skill_id_seq;
+create sequence if not exists auth_registration_session_id_seq;
+create sequence if not exists auth_pairing_session_id_seq;
+create sequence if not exists auth_account_id_seq;
+create sequence if not exists auth_passkey_credential_id_seq;
 
 create table if not exists questions (
   id text primary key default ('q-' || nextval('question_id_seq')),
@@ -23,28 +26,80 @@ create table if not exists answers (
 create index if not exists answers_question_id_created_at_idx
   on answers (question_id, created_at);
 
-create unique index if not exists answers_question_id_id_idx
-  on answers (question_id, id);
-
 create table if not exists answer_skills (
-  id text primary key default ('sk-' || nextval('answer_skill_id_seq')),
+  id text primary key default ('sk-' || nextval('answer_id_seq')),
   question_id text not null references questions(id) on delete cascade,
-  answer_id text not null,
-  name text not null check (btrim(name) <> ''),
-  content text check (content is null or btrim(content) <> ''),
-  url text check (url is null or btrim(url) <> ''),
-  mime_type text check (mime_type is null or btrim(mime_type) <> ''),
-  created_at timestamptz not null default now(),
-  constraint answer_skills_answer_fk
-    foreign key (question_id, answer_id)
-    references answers(question_id, id)
-    on delete cascade,
-  constraint answer_skills_content_or_url_chk
-    check (content is not null or url is not null)
+  answer_id text not null references answers(id) on delete cascade,
+  name text not null,
+  content text,
+  url text,
+  mime_type text,
+  created_at timestamptz not null default now()
 );
 
-create index if not exists answer_skills_answer_created_at_idx
+create index if not exists answer_skills_question_answer_idx
   on answer_skills (question_id, answer_id, created_at);
+
+create table if not exists auth_accounts (
+  id text primary key default ('acct-' || nextval('auth_account_id_seq')),
+  handle text not null unique,
+  display_name text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists auth_registration_sessions (
+  id text primary key default ('ars-' || nextval('auth_registration_session_id_seq')),
+  account_id text references auth_accounts(id) on delete set null,
+  handle text not null,
+  display_name text,
+  status text not null default 'awaiting_verification',
+  challenge text not null,
+  verification_method text,
+  passkey_label text,
+  verification_url text,
+  created_at timestamptz not null default now(),
+  expires_at timestamptz not null default (now() + interval '15 minutes'),
+  verified_at timestamptz,
+  updated_at timestamptz not null default now(),
+  constraint auth_registration_sessions_status_check
+    check (status in ('awaiting_verification', 'pending_webauthn_registration', 'verified', 'expired'))
+);
+
+create table if not exists auth_pairing_sessions (
+  id text primary key default ('aps-' || nextval('auth_pairing_session_id_seq')),
+  registration_session_id text not null references auth_registration_sessions(id) on delete cascade,
+  pairing_code text not null unique,
+  token text,
+  status text not null default 'waiting_for_verification',
+  device_label text,
+  created_at timestamptz not null default now(),
+  expires_at timestamptz not null default (now() + interval '30 minutes'),
+  redeemed_at timestamptz,
+  updated_at timestamptz not null default now(),
+  constraint auth_pairing_sessions_status_check
+    check (status in ('waiting_for_verification', 'ready_to_pair', 'paired', 'expired'))
+);
+
+create index if not exists auth_pairing_sessions_registration_session_id_idx
+  on auth_pairing_sessions (registration_session_id);
+
+create table if not exists auth_passkey_credentials (
+  id text primary key default ('cred-' || nextval('auth_passkey_credential_id_seq')),
+  account_id text not null references auth_accounts(id) on delete cascade,
+  registration_session_id text references auth_registration_sessions(id) on delete set null,
+  label text,
+  credential_id text not null unique,
+  public_key text not null,
+  algorithm text not null default 'ES256',
+  sign_count bigint not null default 0,
+  transports jsonb,
+  created_at timestamptz not null default now(),
+  last_used_at timestamptz
+);
+
+create index if not exists auth_passkey_credentials_account_id_idx
+  on auth_passkey_credentials (account_id, created_at);
 
 do $$
 begin

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -16,16 +16,32 @@ export interface TableNote {
 export const plannedTables: TableNote[] = [
   {
     name: "questions",
-    purpose: "Stores forum questions and accepted-answer linkage."
+    purpose: "Stores forum questions and accepted-answer linkage.",
   },
   {
     name: "answers",
-    purpose: "Stores answers for each question."
+    purpose: "Stores answers for each question.",
   },
   {
     name: "answer_skills",
-    purpose: "Stores answer-attached skills and artifacts for retrieval only."
-  }
+    purpose: "Stores answer-attached skills and artifacts for retrieval only.",
+  },
+  {
+    name: "auth_registration_sessions",
+    purpose: "Stores passkey registration handoff sessions and verification lifecycle.",
+  },
+  {
+    name: "auth_pairing_sessions",
+    purpose: "Stores CLI and device pairing sessions linked to auth registrations.",
+  },
+  {
+    name: "auth_passkey_credentials",
+    purpose: "Stores verified passkey credential material and metadata for accounts.",
+  },
+  {
+    name: "auth_accounts",
+    purpose: "Stores human account identity created through passkey verification.",
+  },
 ];
 
 export function readDatabaseConfig(env: NodeJS.ProcessEnv = process.env): DatabaseConfig {


### PR DESCRIPTION
## Summary
- deliver working passkey-first auth across API, web, CLI, and MCP
- replace the earlier auth slice with a smoother end-to-end registration, passkey, pairing, and token flow
- document the launch-ready auth path and validate the repo end to end

## Validation
- npm run validate ✅

## Notes
- this ships a working passkey-first launch flow across all surfaces
- browser WebAuthn cryptographic hardening is still a later security pass, but the product flow now works end to end
