### PR TITLE
fix: improve auth handoff and web pairing UX

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -277,6 +277,31 @@ async function routeRequest(
     return;
   }
 
+  if (method === "GET" && path === "/auth/resolve") {
+    const verificationToken = readRequiredQueryString(
+      url.searchParams.get("registration"),
+      "registration",
+    );
+    const session = await authStore.getRegistrationSessionByVerificationToken(verificationToken);
+
+    if (!session) {
+      sendError(
+        res,
+        corsHeaders,
+        404,
+        "registration_session_not_found",
+        "Registration session not found.",
+      );
+      return;
+    }
+
+    sendJson(res, corsHeaders, 200, {
+      ok: true,
+      data: session,
+    });
+    return;
+  }
+
   const passkeyOptionsMatch = matchPath(
     path,
     /^\/auth\/registrations\/([^/]+)\/passkey\/options$/,

--- a/apps/api/src/auth-store.ts
+++ b/apps/api/src/auth-store.ts
@@ -10,6 +10,9 @@ import type {
 export interface AuthStore {
   startRegistration(input: StartRegistrationInput): Promise<RegistrationSession>;
   getRegistrationSession(registrationSessionId: string): Promise<RegistrationSession | null>;
+  getRegistrationSessionByVerificationToken(
+    verificationToken: string,
+  ): Promise<RegistrationSession | null>;
   getPasskeyRegistrationOptions(
     registrationSessionId: string,
   ): Promise<PasskeyRegistrationOptions | null>;

--- a/apps/api/src/http.test.ts
+++ b/apps/api/src/http.test.ts
@@ -92,6 +92,8 @@ describe("HTTP API", () => {
     assert.equal(started.body.data.status, "awaiting_verification");
     assert.equal(started.body.data.pairing.status, "waiting_for_verification");
     assert.match(started.body.data.challenge, /^[A-Za-z0-9_-]+$/);
+    assert.match(started.body.data.verificationUrl, /^\/auth\?registration=/);
+    assert.match(started.body.data.verificationToken, /^[a-f0-9]{12}$/);
 
     const registrationId = started.body.data.id;
     const pairingCode = started.body.data.pairing.code;
@@ -127,6 +129,26 @@ describe("HTTP API", () => {
     assert.equal(redeemed.body.data.pairing.status, "paired");
     assert.equal(redeemed.body.data.pairing.deviceLabel, "pixel-bot");
     assert.match(redeemed.body.data.pairing.token, /^taf_/);
+  });
+
+  it("resolves a registration session from the public verification token", async () => {
+    const app = createTestApp();
+
+    const started = await requestJson(app, "/auth/registrations/start", {
+      method: "POST",
+      body: {
+        handle: "pixel-resolve",
+        displayName: "Pixel Resolve",
+      },
+    });
+
+    const resolved = await requestJson(
+      app,
+      `/auth/resolve?registration=${started.body.data.verificationToken}`,
+    );
+
+    assert.equal(resolved.status, 200);
+    assert.equal(resolved.body.data.id, started.body.data.id);
   });
 
   it("returns validation errors for invalid auth payloads", async () => {

--- a/apps/api/src/memory-auth-store.ts
+++ b/apps/api/src/memory-auth-store.ts
@@ -25,6 +25,7 @@ interface StoredRegistrationSession {
   verificationMethod?: string;
   passkeyLabel?: string;
   verificationUrl?: string;
+  verificationToken?: string;
   createdAt: string;
   expiresAt: string;
   verifiedAt?: string;
@@ -42,6 +43,7 @@ export function createInMemoryAuthStore(): AuthStore {
     const expiresAt = new Date(Date.now() + 15 * 60 * 1000).toISOString();
     const pairingExpiresAt = new Date(Date.now() + 30 * 60 * 1000).toISOString();
     const id = `ars-${registrationSequence++}`;
+    const verificationToken = randomBytes(6).toString("hex");
 
     const session: StoredRegistrationSession = {
       id,
@@ -49,7 +51,8 @@ export function createInMemoryAuthStore(): AuthStore {
       displayName: input.displayName,
       status: "awaiting_verification",
       challenge: createChallenge(),
-      verificationUrl: `/auth?registration=${id}`,
+      verificationToken,
+      verificationUrl: `/auth?registration=${verificationToken}`,
       createdAt,
       expiresAt,
       pairing: {
@@ -69,6 +72,21 @@ export function createInMemoryAuthStore(): AuthStore {
     registrationSessionId: string,
   ): Promise<RegistrationSession | null> {
     const session = registrationSessions.get(registrationSessionId);
+
+    if (!session) {
+      return null;
+    }
+
+    expireSessionIfNeeded(session);
+    return cloneRegistrationSession(session);
+  }
+
+  async function getRegistrationSessionByVerificationToken(
+    verificationToken: string,
+  ): Promise<RegistrationSession | null> {
+    const session = Array.from(registrationSessions.values()).find(
+      (candidate) => candidate.verificationToken === verificationToken,
+    );
 
     if (!session) {
       return null;
@@ -193,6 +211,7 @@ export function createInMemoryAuthStore(): AuthStore {
   return {
     startRegistration,
     getRegistrationSession,
+    getRegistrationSessionByVerificationToken,
     getPasskeyRegistrationOptions,
     finishPasskeyRegistration,
     completeRegistrationVerification,

--- a/apps/api/src/postgres-auth-store.ts
+++ b/apps/api/src/postgres-auth-store.ts
@@ -14,6 +14,7 @@ export function createPostgresAuthStore(): AuthStore {
   return {
     startRegistration,
     getRegistrationSession,
+    getRegistrationSessionByVerificationToken,
     getPasskeyRegistrationOptions,
     finishPasskeyRegistration,
     completeRegistrationVerification,
@@ -22,6 +23,7 @@ export function createPostgresAuthStore(): AuthStore {
 }
 
 async function startRegistration(input: StartRegistrationInput): Promise<RegistrationSession> {
+  const verificationToken = randomBytes(6).toString("hex");
   const registrationSession = await queryJson<RegistrationSession>(
     `
       with ensured_account as (
@@ -65,7 +67,7 @@ async function startRegistration(input: StartRegistrationInput): Promise<Registr
       handle: input.handle,
       display_name: input.displayName ?? "",
       challenge: createChallenge(),
-      verification_url: `/auth?registration=${randomBytes(6).toString("hex")}`,
+      verification_url: `/auth?registration=${verificationToken}`,
       pairing_code: createPairingCode(),
     },
   );
@@ -78,6 +80,25 @@ async function getRegistrationSession(
 ): Promise<RegistrationSession | null> {
   await expireRegistrationSession(registrationSessionId);
   const output = await selectRegistrationSession(registrationSessionId);
+  return output ? (JSON.parse(output) as RegistrationSession) : null;
+}
+
+async function getRegistrationSessionByVerificationToken(
+  verificationToken: string,
+): Promise<RegistrationSession | null> {
+  await expireRegistrationSessionByVerificationToken(verificationToken);
+
+  const output = await runSql(
+    `
+      select ${registrationSessionSelect("r", "p", ":'verification_token'")} :: text
+      from auth_registration_sessions r
+      join auth_pairing_sessions p
+        on p.registration_session_id = r.id
+      where r.verification_url = concat('/auth?registration=', :'verification_token');
+    `,
+    { verification_token: verificationToken },
+  );
+
   return output ? (JSON.parse(output) as RegistrationSession) : null;
 }
 
@@ -314,6 +335,23 @@ async function expireRegistrationByPairingCode(pairingCode: string): Promise<voi
   );
 }
 
+async function expireRegistrationSessionByVerificationToken(
+  verificationToken: string,
+): Promise<void> {
+  await runSql(
+    `
+      update auth_registration_sessions
+      set
+        status = 'expired',
+        updated_at = now()
+      where verification_url = concat('/auth?registration=', :'verification_token')
+        and status <> 'verified'
+        and expires_at <= now();
+    `,
+    { verification_token: verificationToken },
+  );
+}
+
 async function selectRegistrationSession(registrationSessionId: string): Promise<string> {
   return runSql(
     `
@@ -330,6 +368,7 @@ async function selectRegistrationSession(registrationSessionId: string): Promise
 function registrationSessionSelect(
   registrationAlias: string,
   pairingAlias: string,
+  verificationTokenExpression = `regexp_replace(${registrationAlias}.verification_url, '^/auth\\?registration=', '')`,
 ): string {
   return `json_build_object(
     'id', ${registrationAlias}.id,
@@ -340,6 +379,7 @@ function registrationSessionSelect(
     'verificationMethod', ${registrationAlias}.verification_method,
     'passkeyLabel', ${registrationAlias}.passkey_label,
     'verificationUrl', ${registrationAlias}.verification_url,
+    'verificationToken', ${verificationTokenExpression},
     'createdAt', to_char(${registrationAlias}.created_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
     'expiresAt', to_char(${registrationAlias}.expires_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
     'verifiedAt', case

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -132,6 +132,15 @@ export function createApiClient(baseUrl = defaultBaseUrl) {
     );
   }
 
+  async function resolveRegistrationSession(
+    verificationToken: string,
+  ): Promise<RegistrationSession> {
+    return request<RegistrationSession>(
+      "GET",
+      `/auth/resolve?registration=${encodeURIComponent(verificationToken)}`,
+    );
+  }
+
   async function getPasskeyRegistrationOptions(
     registrationSessionId: string,
   ): Promise<PasskeyRegistrationOptions> {
@@ -203,6 +212,7 @@ export function createApiClient(baseUrl = defaultBaseUrl) {
     listAnswerSkills,
     startRegistration,
     getRegistrationSession,
+    resolveRegistrationSession,
     getPasskeyRegistrationOptions,
     registerPasskey,
     completeRegistrationVerification,

--- a/apps/web/src/pages/AuthPage.tsx
+++ b/apps/web/src/pages/AuthPage.tsx
@@ -17,6 +17,7 @@ export function AuthPage({ api }: AuthPageProps) {
   const [creatingPasskey, setCreatingPasskey] = useState(false);
   const [redeeming, setRedeeming] = useState(false);
   const [passkeyLabel, setPasskeyLabel] = useState("This device passkey");
+  const [copiedField, setCopiedField] = useState<string | null>(null);
 
   useEffect(() => {
     if (!registrationParam) {
@@ -27,7 +28,16 @@ export function AuthPage({ api }: AuthPageProps) {
       setLoadingSession(true);
       setError(null);
       try {
-        setRegistrationSession(await api.getRegistrationSession(registrationParam));
+        try {
+          setRegistrationSession(await api.getRegistrationSession(registrationParam));
+        } catch (cause) {
+          if (cause instanceof ApiClientError && cause.code === "registration_session_not_found") {
+            setRegistrationSession(await api.resolveRegistrationSession(registrationParam));
+            return;
+          }
+
+          throw cause;
+        }
       } catch (cause) {
         setError(readErrorMessage(cause));
       } finally {
@@ -37,12 +47,33 @@ export function AuthPage({ api }: AuthPageProps) {
   }, [api, registrationParam]);
 
   const verificationUrl = useMemo(() => {
-    if (!registrationSession?.id) {
+    if (!registrationSession?.verificationToken) {
       return null;
     }
 
-    return `${window.location.origin}/auth?registration=${registrationSession.id}`;
+    return `${window.location.origin}/auth?registration=${registrationSession.verificationToken}`;
   }, [registrationSession]);
+
+  const canCreatePasskey =
+    registrationSession !== null &&
+    !creatingPasskey &&
+    (registrationSession.status === "awaiting_verification" ||
+      registrationSession.status === "pending_webauthn_registration");
+
+  const canRedeemPairing =
+    registrationSession !== null &&
+    !redeeming &&
+    registrationSession.pairing.status === "ready_to_pair";
+
+  const currentStep = registrationSession
+    ? registrationSession.pairing.status === "paired"
+      ? 4
+      : registrationSession.status === "verified"
+        ? 4
+        : registrationSession.status === "pending_webauthn_registration"
+          ? 3
+          : 2
+    : 1;
 
   async function handleStartRegistration(formData: FormData): Promise<void> {
     setStarting(true);
@@ -140,6 +171,16 @@ export function AuthPage({ api }: AuthPageProps) {
     }
   }
 
+  async function copyValue(value: string, field: string): Promise<void> {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopiedField(field);
+      window.setTimeout(() => setCopiedField((current) => (current === field ? null : current)), 1500);
+    } catch {
+      setError("Could not copy to clipboard.");
+    }
+  }
+
   return (
     <main className="layout auth-layout">
       <header className="stack auth-hero">
@@ -156,6 +197,23 @@ export function AuthPage({ api }: AuthPageProps) {
 
       {error ? <p className="error">{error}</p> : null}
       {loadingSession ? <p className="muted">Loading registration session...</p> : null}
+
+      <section className="card stack auth-guide-card">
+        <div>
+          <p className="eyebrow">How this works</p>
+          <h2>Browser verifies you, agent gets paired afterward</h2>
+          <p className="muted">
+            Start in the CLI or here, complete the browser passkey step, then redeem the pairing code to issue an agent token.
+          </p>
+        </div>
+
+        <ol className="auth-steps" aria-label="Authentication steps">
+          <li className={currentStep >= 1 ? "active" : undefined}>Start registration</li>
+          <li className={currentStep >= 2 ? "active" : undefined}>Open verification link</li>
+          <li className={currentStep >= 3 ? "active" : undefined}>Create passkey</li>
+          <li className={currentStep >= 4 ? "active" : undefined}>Redeem pairing for token</li>
+        </ol>
+      </section>
 
       <section className="card stack">
         <div>
@@ -188,6 +246,10 @@ export function AuthPage({ api }: AuthPageProps) {
             {starting ? "Starting..." : "Start passkey registration"}
           </button>
         </form>
+
+        <p className="field-hint">
+          If you already started from the CLI, you can skip this form and just open the verification link you were given.
+        </p>
       </section>
 
       {registrationSession ? (
@@ -197,12 +259,19 @@ export function AuthPage({ api }: AuthPageProps) {
               <div>
                 <h2>2. Confirm the handoff</h2>
                 <p className="muted">
-                  Use the same browser, a new tab, or a mobile device. The registration link carries the full state.
+                  Open the verification link in any browser. That link is the handoff between CLI and web.
                 </p>
               </div>
               <button type="button" onClick={() => void handleRefreshStatus()}>
                 Refresh status
               </button>
+            </div>
+
+            <div className="auth-callout auth-tip">
+              <strong>What you should do next</strong>
+              <p className="muted">
+                Copy the verification URL, open it in a browser, then click <strong>Create passkey</strong>. Once the status changes to verified, come back and redeem pairing.
+              </p>
             </div>
 
             <dl className="definition-list">
@@ -228,17 +297,33 @@ export function AuthPage({ api }: AuthPageProps) {
 
             {verificationUrl ? (
               <div className="auth-callout">
-                <p className="muted">Verification URL</p>
-                <code className="block-code">{verificationUrl}</code>
+                <div className="row between center wrap-gap">
+                  <div>
+                    <p className="muted">Verification URL</p>
+                    <code className="block-code">{verificationUrl}</code>
+                  </div>
+                  <button type="button" className="button button--ghost" onClick={() => void copyValue(verificationUrl, "verification-url")}>
+                    {copiedField === "verification-url" ? "Copied" : "Copy link"}
+                  </button>
+                </div>
               </div>
             ) : null}
+
+            <div className="status-pills-row" aria-label="Current auth status">
+              <span className={`status-chip ${registrationSession.status === "verified" ? "status-chip--done" : ""}`}>
+                Registration: {registrationSession.status}
+              </span>
+              <span className={`status-chip ${registrationSession.pairing.status === "ready_to_pair" || registrationSession.pairing.status === "paired" ? "status-chip--done" : ""}`}>
+                Pairing: {registrationSession.pairing.status}
+              </span>
+            </div>
           </section>
 
           <section className="card stack">
             <div>
               <h2>3. Create the passkey</h2>
               <p className="muted">
-                This flow is wired like real passkey registration, with simulated browser ceremony right now so we can ship the experience end to end.
+                Click once. If it works, this section should move the registration to <strong>verified</strong> and unlock pairing.
               </p>
             </div>
 
@@ -253,15 +338,24 @@ export function AuthPage({ api }: AuthPageProps) {
 
             <button
               type="button"
-              disabled={
-                creatingPasskey ||
-                (registrationSession.status !== "awaiting_verification" &&
-                  registrationSession.status !== "pending_webauthn_registration")
-              }
+              disabled={!canCreatePasskey}
               onClick={() => void handleCreatePasskey()}
             >
               {creatingPasskey ? "Creating passkey..." : "Create passkey now"}
             </button>
+
+            {registrationSession.status === "verified" ? (
+              <div className="auth-callout auth-success">
+                <strong>Passkey step complete</strong>
+                <p className="muted">
+                  Nice, the registration is verified. You can redeem the pairing code now.
+                </p>
+              </div>
+            ) : (
+              <p className="field-hint">
+                Expected result: registration status becomes <strong>verified</strong> and pairing becomes <strong>ready_to_pair</strong>.
+              </p>
+            )}
           </section>
 
           <section className="card stack">
@@ -293,16 +387,30 @@ export function AuthPage({ api }: AuthPageProps) {
               </label>
               <button
                 type="submit"
-                disabled={redeeming || registrationSession.pairing.status !== "ready_to_pair"}
+                disabled={!canRedeemPairing}
               >
                 {redeeming ? "Redeeming..." : "Redeem pairing"}
               </button>
             </form>
 
+            {registrationSession.pairing.status !== "ready_to_pair" && registrationSession.pairing.status !== "paired" ? (
+              <p className="field-hint">
+                Pairing stays locked until the browser passkey step verifies successfully.
+              </p>
+            ) : null}
+
             {registrationSession.pairing.token ? (
               <div className="auth-callout auth-success">
-                <p className="muted">Issued token</p>
-                <code className="block-code">{registrationSession.pairing.token}</code>
+                <div className="row between center wrap-gap">
+                  <div>
+                    <p className="muted">Issued token</p>
+                    <code className="block-code">{registrationSession.pairing.token}</code>
+                  </div>
+                  <button type="button" className="button button--ghost" onClick={() => void copyValue(registrationSession.pairing.token ?? "", "issued-token")}>
+                    {copiedField === "issued-token" ? "Copied" : "Copy token"}
+                  </button>
+                </div>
+                <p className="field-hint">This is the token the CLI or MCP client should use next.</p>
               </div>
             ) : null}
           </section>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1559,6 +1559,76 @@ ul {
   gap: 1.25rem;
 }
 
+.auth-guide-card {
+  gap: 1rem;
+}
+
+.auth-steps {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.75rem;
+  list-style: none;
+  counter-reset: auth-steps;
+}
+
+.auth-steps li {
+  counter-increment: auth-steps;
+  padding: 0.9rem 1rem;
+  border-radius: 1rem;
+  border: 1px solid var(--border-strong);
+  background: var(--surface-elevated);
+  color: var(--text-muted);
+  font-weight: 700;
+}
+
+.auth-steps li::before {
+  content: counter(auth-steps);
+  display: inline-grid;
+  place-items: center;
+  width: 1.6rem;
+  height: 1.6rem;
+  margin-right: 0.6rem;
+  border-radius: 999px;
+  background: var(--artifact-soft);
+  color: var(--text-strong);
+  font-size: 0.85rem;
+}
+
+.auth-steps li.active {
+  border-color: rgba(15, 118, 110, 0.28);
+  background: rgba(15, 118, 110, 0.08);
+  color: var(--text-strong);
+}
+
+.auth-tip {
+  background: rgba(234, 122, 65, 0.08);
+  border-color: rgba(234, 122, 65, 0.18);
+}
+
+.status-pills-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.status-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.55rem 0.8rem;
+  border-radius: 999px;
+  border: 1px solid var(--border-strong);
+  background: var(--surface-elevated);
+  color: var(--text-muted);
+  font-weight: 700;
+}
+
+.status-chip--done {
+  border-color: rgba(31, 122, 71, 0.24);
+  background: rgba(31, 122, 71, 0.1);
+  color: var(--accepted);
+}
+
 .auth-callout {
   padding: 0.9rem 1rem;
   border-radius: 0.85rem;
@@ -1576,4 +1646,16 @@ ul {
   white-space: pre-wrap;
   overflow-wrap: anywhere;
   margin-top: 0.35rem;
+}
+
+@media (max-width: 900px) {
+  .auth-steps {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+@media (max-width: 560px) {
+  .auth-steps {
+    grid-template-columns: 1fr;
+  }
 }

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -148,6 +148,7 @@ export interface RegistrationSession {
   verificationMethod?: string;
   passkeyLabel?: string;
   verificationUrl?: string;
+  verificationToken?: string;
   createdAt: string;
   expiresAt: string;
   verifiedAt?: string;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -170,6 +170,8 @@ struct RegistrationSession {
     passkey_label: Option<String>,
     #[serde(rename = "verificationUrl", skip_serializing_if = "Option::is_none")]
     verification_url: Option<String>,
+    #[serde(rename = "verificationToken", skip_serializing_if = "Option::is_none")]
+    verification_token: Option<String>,
     #[serde(rename = "createdAt")]
     created_at: String,
     #[serde(rename = "expiresAt")]
@@ -320,6 +322,9 @@ fn print_registration_summary(session: &RegistrationSession) {
     println!("Registration ID: {}", session.id);
     if let Some(url) = &session.verification_url {
         println!("Verification URL: {}{}", get_base_url().trim_end_matches("/api"), url);
+    }
+    if let Some(token) = &session.verification_token {
+        println!("Verification token: {}", token);
     }
     println!("Pairing code: {}", session.pairing.code);
     println!("Registration status: {}", session.status);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -106,6 +106,7 @@ export interface RegistrationSession {
   verificationMethod?: string;
   passkeyLabel?: string;
   verificationUrl?: string;
+  verificationToken?: string;
   createdAt: string;
   expiresAt: string;
   verifiedAt?: string;


### PR DESCRIPTION
## Summary
- fix the public auth handoff so verification links resolve to the correct registration session
- improve the auth web UX with clearer steps, stronger status feedback, and copy actions for link and token
- expose verification token metadata consistently across API, web, and CLI

## Validation
- npm run validate ✅
- live resolve path smoke-tested after rebuilding api/web ✅

## Notes
- this is still moving toward the larger agent-first one-click connect flow
- public read-only access remains the intended model, with auth reserved for writes and pairing
