### PR TITLE
feat: add v2 comment skill routes across API, web, and MCP

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -341,6 +341,67 @@ async function routeRequest(
     return;
   }
 
+  const commentSkillsMatch = matchPath(
+    path,
+    /^\/v2\/contents\/([^/]+)\/comments\/([^/]+)\/skills$/,
+  );
+
+  if (method === "GET" && commentSkillsMatch) {
+    const contentId = commentSkillsMatch[1];
+    const commentId = commentSkillsMatch[2];
+    const skills = await forumStore.listCommentSkills(contentId, commentId);
+
+    if (!skills) {
+      const existing = await forumStore.getContentThread(contentId);
+
+      if (!existing) {
+        sendError(res, corsHeaders, 404, "content_not_found", "Content not found.");
+        return;
+      }
+
+      sendError(
+        res,
+        corsHeaders,
+        404,
+        "comment_not_found",
+        "Comment not found for the specified content.",
+      );
+      return;
+    }
+
+    sendJson(res, corsHeaders, 200, { ok: true, data: skills });
+    return;
+  }
+
+  if (method === "POST" && commentSkillsMatch) {
+    const contentId = commentSkillsMatch[1];
+    const commentId = commentSkillsMatch[2];
+    const payload = await readJsonBody(req);
+    const input = parseCreateAnswerSkillInput(payload);
+    const skill = await forumStore.createCommentSkill(contentId, commentId, input);
+
+    if (!skill) {
+      const existing = await forumStore.getContentThread(contentId);
+
+      if (!existing) {
+        sendError(res, corsHeaders, 404, "content_not_found", "Content not found.");
+        return;
+      }
+
+      sendError(
+        res,
+        corsHeaders,
+        404,
+        "comment_not_found",
+        "Comment not found for the specified content.",
+      );
+      return;
+    }
+
+    sendJson(res, corsHeaders, 201, { ok: true, data: skill });
+    return;
+  }
+
   const acceptCommentMatch = matchPath(
     path,
     /^\/v2\/contents\/([^/]+)\/accept\/([^/]+)$/,

--- a/apps/api/src/forum-adapter.ts
+++ b/apps/api/src/forum-adapter.ts
@@ -1,15 +1,18 @@
 import type {
   Answer,
+  AnswerSkill,
   CreateAnswerInput,
+  CreateAnswerSkillInput,
   Question,
-  ThreadSearchResult,
 } from "@theagentforum/core";
 import type {
   Comment,
+  CommentSkill,
   Content,
   ContentThread,
   ContentThreadSearchResult,
   CreateCommentInput,
+  CreateCommentSkillInput,
   CreateContentInput,
   QuestionContent,
 } from "@theagentforum/core";
@@ -105,6 +108,37 @@ export function createForumAdapter(questionStore: QuestionStore): ForumStore {
     return mapQuestionThreadToContentThread(thread);
   }
 
+  async function listCommentSkills(
+    contentId: string,
+    commentId: string,
+  ): Promise<CommentSkill[] | null> {
+    if (!isQuestionId(contentId)) {
+      return null;
+    }
+
+    const skills = await questionStore.listAnswerSkills(contentId, commentId);
+    if (!skills) return null;
+    return skills.map(mapAnswerSkillToCommentSkill);
+  }
+
+  async function createCommentSkill(
+    contentId: string,
+    commentId: string,
+    input: CreateCommentSkillInput,
+  ): Promise<CommentSkill | null> {
+    if (!isQuestionId(contentId)) {
+      return null;
+    }
+
+    const skill = await questionStore.createAnswerSkill(
+      contentId,
+      commentId,
+      mapCreateCommentSkillToAnswerSkillInput(input),
+    );
+    if (!skill) return null;
+    return mapAnswerSkillToCommentSkill(skill);
+  }
+
   return {
     listContents,
     searchThreads,
@@ -112,6 +146,8 @@ export function createForumAdapter(questionStore: QuestionStore): ForumStore {
     getContentThread,
     createComment,
     acceptComment,
+    listCommentSkills,
+    createCommentSkill,
   };
 }
 
@@ -143,6 +179,19 @@ function mapAnswerToComment(a: Answer): Comment {
   };
 }
 
+function mapAnswerSkillToCommentSkill(skill: AnswerSkill): CommentSkill {
+  return {
+    id: skill.id,
+    contentId: skill.questionId,
+    commentId: skill.answerId,
+    name: skill.name,
+    content: skill.content,
+    url: skill.url,
+    mimeType: skill.mimeType,
+    createdAt: skill.createdAt,
+  };
+}
+
 function mapQuestionThreadToContentThread(thread: QuestionThread): ContentThread {
   return {
     content: mapQuestionToContent(thread.question),
@@ -152,6 +201,17 @@ function mapQuestionThreadToContentThread(thread: QuestionThread): ContentThread
 
 function mapCreateCommentToAnswerInput(input: CreateCommentInput): CreateAnswerInput {
   return { body: input.body, author: input.author };
+}
+
+function mapCreateCommentSkillToAnswerSkillInput(
+  input: CreateCommentSkillInput,
+): CreateAnswerSkillInput {
+  return {
+    name: input.name,
+    content: input.content,
+    url: input.url,
+    mimeType: input.mimeType,
+  };
 }
 
 function emptySearchResult(query: string): ContentThreadSearchResult {

--- a/apps/api/src/forum-store.ts
+++ b/apps/api/src/forum-store.ts
@@ -1,8 +1,10 @@
 import type {
+  CommentSkill,
   Content,
   ContentThread,
   ContentThreadSearchResult,
   CreateCommentInput,
+  CreateCommentSkillInput,
   CreateContentInput,
 } from "@theagentforum/core";
 
@@ -16,5 +18,11 @@ export interface ForumStore {
   getContentThread(contentId: string): Promise<ContentThread | null>;
   createComment(contentId: string, input: CreateCommentInput): Promise<ContentThread | null>;
   acceptComment(contentId: string, commentId: string): Promise<ContentThread | null>;
+  listCommentSkills(contentId: string, commentId: string): Promise<CommentSkill[] | null>;
+  createCommentSkill(
+    contentId: string,
+    commentId: string,
+    input: CreateCommentSkillInput,
+  ): Promise<CommentSkill | null>;
 }
 

--- a/apps/api/src/http.v2.test.ts
+++ b/apps/api/src/http.v2.test.ts
@@ -45,6 +45,75 @@ describe("HTTP API v2 forum", () => {
     assert.equal(thread.status, 200);
     assert.equal(thread.body.data.comments[0].id, accepted.body.data.comments[0].id);
   });
+
+  it("creates and lists comment skills through v2 routes", async () => {
+    const app = createApp(createInMemoryQuestionStore(), createInMemoryAuthStore());
+
+    const created = await requestJson(app, "/v2/contents", {
+      method: "POST",
+      body: { type: "question", title: "Title", body: "Body", author: human },
+    });
+    const contentId = created.body.data.id;
+
+    const commented = await requestJson(app, `/v2/contents/${contentId}/comments`, {
+      method: "POST",
+      body: { body: "First comment", author: agent },
+    });
+    const commentId = commented.body.data.comments[0].id;
+
+    const createdSkill = await requestJson(
+      app,
+      `/v2/contents/${contentId}/comments/${commentId}/skills`,
+      {
+        method: "POST",
+        body: {
+          name: "reverse-string-skill",
+          content: "steps: [reverse, join]",
+          mimeType: "text/plain",
+        },
+      },
+    );
+
+    assert.equal(createdSkill.status, 201);
+    assert.equal(createdSkill.body.data.contentId, contentId);
+    assert.equal(createdSkill.body.data.commentId, commentId);
+    assert.equal(createdSkill.body.data.name, "reverse-string-skill");
+
+    const listedSkills = await requestJson(
+      app,
+      `/v2/contents/${contentId}/comments/${commentId}/skills`,
+    );
+
+    assert.equal(listedSkills.status, 200);
+    assert.equal(listedSkills.body.data.length, 1);
+    assert.deepEqual(listedSkills.body.data[0], createdSkill.body.data);
+  });
+
+  it("returns content_not_found or comment_not_found for comment skill routes", async () => {
+    const app = createApp(createInMemoryQuestionStore(), createInMemoryAuthStore());
+
+    const missingContent = await requestJson(app, "/v2/contents/q-404/comments/a-1/skills");
+    assert.equal(missingContent.status, 404);
+    assert.equal(missingContent.body.error.code, "content_not_found");
+
+    const created = await requestJson(app, "/v2/contents", {
+      method: "POST",
+      body: { type: "question", title: "Title", body: "Body", author: human },
+    });
+    const contentId = created.body.data.id;
+
+    const missingComment = await requestJson(
+      app,
+      `/v2/contents/${contentId}/comments/a-404/skills`,
+      {
+        method: "POST",
+        body: { name: "reverse-string-skill", url: "https://example.com/skill.json" },
+      },
+    );
+
+    assert.equal(missingComment.status, 404);
+    assert.equal(missingComment.body.error.code, "comment_not_found");
+  });
 });
 
 async function requestJson(

--- a/apps/mcp/src/api-client.ts
+++ b/apps/mcp/src/api-client.ts
@@ -7,6 +7,7 @@ import * as z from "zod/v4";
 import {
   ApiErrorSchema,
   AnswerSkillSchema,
+  CommentSkillSchema,
   ContentSchema,
   ContentSearchResultSchema,
   ContentThreadSchema,
@@ -137,11 +138,13 @@ export class TafApiClient {
     questionId: string,
     answerId: string,
   ): Promise<z.infer<typeof AnswerSkillSchema>[]> {
-    return this.request(
+    const skills = await this.request(
       "GET",
-      `/questions/${encodeURIComponent(questionId)}/answers/${encodeURIComponent(answerId)}/skills`,
-      z.array(AnswerSkillSchema),
+      `/v2/contents/${encodeURIComponent(questionId)}/comments/${encodeURIComponent(answerId)}/skills`,
+      z.array(CommentSkillSchema),
     );
+
+    return skills.map(mapCommentSkillToAnswerSkill);
   }
 
   async attachSkill(
@@ -149,12 +152,14 @@ export class TafApiClient {
     answerId: string,
     input: CreateAnswerSkillInput,
   ): Promise<z.infer<typeof AnswerSkillSchema>> {
-    return this.request(
+    const skill = await this.request(
       "POST",
-      `/questions/${encodeURIComponent(questionId)}/answers/${encodeURIComponent(answerId)}/skills`,
-      AnswerSkillSchema,
+      `/v2/contents/${encodeURIComponent(questionId)}/comments/${encodeURIComponent(answerId)}/skills`,
+      CommentSkillSchema,
       input,
     );
+
+    return mapCommentSkillToAnswerSkill(skill);
   }
 
   async accept(questionId: string, answerId: string): Promise<z.infer<typeof QuestionThreadSchema>> {
@@ -305,6 +310,21 @@ function mapCommentToAnswer(comment: z.infer<typeof ContentThreadSchema>["commen
     createdAt: comment.createdAt,
     acceptedAt: comment.acceptedAt,
   };
+}
+
+function mapCommentSkillToAnswerSkill(
+  skill: z.infer<typeof CommentSkillSchema>,
+): z.infer<typeof AnswerSkillSchema> {
+  return AnswerSkillSchema.parse({
+    id: skill.id,
+    questionId: skill.contentId,
+    answerId: skill.commentId,
+    name: skill.name,
+    content: skill.content,
+    url: skill.url,
+    mimeType: skill.mimeType,
+    createdAt: skill.createdAt,
+  });
 }
 
 function mapContentThreadToQuestionThread(

--- a/apps/mcp/src/schemas.ts
+++ b/apps/mcp/src/schemas.ts
@@ -41,6 +41,17 @@ export const AnswerSkillSchema = z.object({
   createdAt: z.string(),
 });
 
+export const CommentSkillSchema = z.object({
+  id: z.string(),
+  contentId: z.string(),
+  commentId: z.string(),
+  name: z.string(),
+  content: z.string().optional(),
+  url: z.string().url().optional(),
+  mimeType: z.string().optional(),
+  createdAt: z.string(),
+});
+
 export const QuestionThreadSchema = z.object({
   question: QuestionSchema,
   answers: z.array(AnswerSchema),

--- a/apps/mcp/src/tool-handlers.test.ts
+++ b/apps/mcp/src/tool-handlers.test.ts
@@ -241,4 +241,63 @@ describe("createToolHandlers", () => {
     assert.equal(observedQuestionId, "q-77");
     assert.equal(observedAnswerId, "a-12");
   });
+
+  it("attaches a skill through the v2 comment skill route", async () => {
+    let observedQuestionId: string | undefined;
+    let observedAnswerId: string | undefined;
+    let observedInput: { name: string; content?: string; url?: string; mimeType?: string } | undefined;
+
+    const handlers = createToolHandlers({
+      defaultAuthor,
+      apiClient: {
+        ask: async () => { throw new Error("not used"); },
+        listQuestions: async () => [],
+        searchThreads: async () => { throw new Error("not used"); },
+        getThread: async () => { throw new Error("not used"); },
+        answer: async () => { throw new Error("not used"); },
+        accept: async () => { throw new Error("not used"); },
+        attachSkill: async (questionId, answerId, input) => {
+          observedQuestionId = questionId;
+          observedAnswerId = answerId;
+          observedInput = input;
+          return {
+            id: "sk-1",
+            questionId,
+            answerId,
+            name: input.name,
+            content: input.content,
+            url: input.url,
+            mimeType: input.mimeType,
+            createdAt: "2026-03-26T00:03:00.000Z",
+          };
+        },
+        startRegistration: async () => { throw new Error("not used"); },
+        getRegistrationSession: async () => { throw new Error("not used"); },
+        getPasskeyRegistrationOptions: async () => { throw new Error("not used"); },
+        registerPasskey: async () => { throw new Error("not used"); },
+        redeemPairing: async () => { throw new Error("not used"); },
+      },
+    });
+
+    const result = await handlers.attachSkill({
+      contentId: "q-77",
+      commentId: "a-12",
+      skillName: "reverse-string-skill",
+      skillContent: "steps: [reverse, join]",
+      mimeType: "text/plain",
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(observedQuestionId, "q-77");
+    assert.equal(observedAnswerId, "a-12");
+    assert.deepEqual(observedInput, {
+      name: "reverse-string-skill",
+      content: "steps: [reverse, join]",
+      mimeType: "text/plain",
+    });
+    if (result.ok) {
+      assert.equal(result.meta.route, "POST /v2/contents/:questionId/comments/:answerId/skills");
+      assert.equal(result.data.answerId, "a-12");
+    }
+  });
 });

--- a/apps/mcp/src/tool-handlers.ts
+++ b/apps/mcp/src/tool-handlers.ts
@@ -207,7 +207,7 @@ export function createToolHandlers(options: ToolHandlerOptions): ToolHandlers {
           ok: true,
           data: skill,
           meta: {
-            route: "POST /questions/:questionId/answers/:answerId/skills",
+            route: "POST /v2/contents/:questionId/comments/:answerId/skills",
             source: "theagentforum-api",
           },
         });

--- a/apps/web/src/lib/api.test.ts
+++ b/apps/web/src/lib/api.test.ts
@@ -134,4 +134,52 @@ describe("createApiClient", () => {
       }),
     );
   });
+
+  it("lists answer skills through the v2 comment skill route", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          ok: true,
+          data: [
+            {
+              id: "sk-1",
+              contentId: "q-1",
+              commentId: "a-1",
+              name: "reverse-string-skill",
+              content: "steps: [reverse, join]",
+              mimeType: "text/plain",
+              createdAt: "2026-03-24T00:00:00.000Z",
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+          },
+        },
+      ),
+    );
+
+    const api = createApiClient("http://localhost:3001");
+    const skills = await api.listAnswerSkills("q-1", "a-1");
+
+    expect(skills).toEqual([
+      {
+        id: "sk-1",
+        questionId: "q-1",
+        answerId: "a-1",
+        name: "reverse-string-skill",
+        content: "steps: [reverse, join]",
+        mimeType: "text/plain",
+        createdAt: "2026-03-24T00:00:00.000Z",
+      },
+    ]);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:3001/v2/contents/q-1/comments/a-1/skills",
+      expect.objectContaining({
+        method: "GET",
+      }),
+    );
+  });
 });

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -51,6 +51,17 @@ interface ForumComment {
   acceptedAt?: string;
 }
 
+interface ForumCommentSkill {
+  id: string;
+  contentId: string;
+  commentId: string;
+  name: string;
+  content?: string;
+  url?: string;
+  mimeType?: string;
+  createdAt: string;
+}
+
 interface ForumContentThread {
   content: ForumContent;
   comments: ForumComment[];
@@ -175,10 +186,12 @@ export function createApiClient(baseUrl = defaultBaseUrl) {
   }
 
   async function listAnswerSkills(questionId: string, answerId: string): Promise<AnswerSkill[]> {
-    return request<AnswerSkill[]>(
+    const skills = await request<ForumCommentSkill[]>(
       "GET",
-      `/questions/${encodeURIComponent(questionId)}/answers/${encodeURIComponent(answerId)}/skills`,
+      `/v2/contents/${encodeURIComponent(questionId)}/comments/${encodeURIComponent(answerId)}/skills`,
     );
+
+    return skills.map(mapCommentSkillToAnswerSkill);
   }
 
   async function startRegistration(
@@ -304,6 +317,19 @@ function mapCommentToAnswer(comment: ForumComment): Answer {
     author: comment.author,
     createdAt: comment.createdAt,
     acceptedAt: comment.acceptedAt,
+  };
+}
+
+function mapCommentSkillToAnswerSkill(skill: ForumCommentSkill): AnswerSkill {
+  return {
+    id: skill.id,
+    questionId: skill.contentId,
+    answerId: skill.commentId,
+    name: skill.name,
+    content: skill.content,
+    url: skill.url,
+    mimeType: skill.mimeType,
+    createdAt: skill.createdAt,
   };
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -226,3 +226,23 @@ export interface ContentThreadSearchResult {
   returned: number;
   matches: ContentThreadSearchMatch[];
 }
+
+// v2 forum — comment-attached skills (compatible with AnswerSkill fields)
+// These mirror the AnswerSkill shape but reference v2 content/comment context.
+export interface CreateCommentSkillInput {
+  name: string;
+  content?: string;
+  url?: string;
+  mimeType?: string;
+}
+
+export interface CommentSkill {
+  id: string;
+  contentId: string;
+  commentId: string;
+  name: string;
+  content?: string;
+  url?: string;
+  mimeType?: string;
+  createdAt: string;
+}


### PR DESCRIPTION
## Summary
- resume the PR #44 forum-v2 workstream with native v2 comment skill routes
- keep storage mapped through the existing v1 answer-skill layer via the forum adapter
- switch web and MCP clients/tests to the new v2 comment skill endpoints

## Test Plan
- npm run validate
