### PR TITLE
feat(auth): replace simulated browser passkey registration

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -15,6 +15,12 @@ import type { AuthStore } from "./auth-store";
 import type { QuestionStore } from "./question-store";
 import type { ForumStore } from "./forum-store";
 import { createForumAdapter } from "./forum-adapter";
+import {
+  deriveRequestOrigin,
+  deriveRpId,
+  verifyPasskeyRegistration,
+  WebAuthnVerificationError,
+} from "./webauthn";
 
 interface CreateAppOptions {
   corsAllowOrigin?: string;
@@ -43,6 +49,11 @@ export function createApp(
     } catch (error) {
       if (isHttpError(error)) {
         sendError(res, corsHeaders, error.statusCode, error.code, error.message);
+        return;
+      }
+
+      if (error instanceof WebAuthnVerificationError) {
+        sendError(res, corsHeaders, 400, "webauthn_verification_failed", error.message);
         return;
       }
 
@@ -428,9 +439,17 @@ async function routeRequest(
       return;
     }
 
+    const requestOrigin = deriveRequestOrigin(req.headers.origin, url);
+
     sendJson(res, corsHeaders, 200, {
       ok: true,
-      data: options,
+      data: {
+        ...options,
+        rp: {
+          ...options.rp,
+          id: deriveRpId(requestOrigin),
+        },
+      },
     });
     return;
   }
@@ -438,7 +457,27 @@ async function routeRequest(
   if (method === "POST" && path === "/auth/passkeys/register") {
     const payload = await readJsonBody(req);
     const input = parseFinishRegistrationInput(payload);
-    const session = await authStore.finishPasskeyRegistration(input);
+    const registrationSession = await authStore.getRegistrationSession(input.registrationSessionId);
+
+    if (!registrationSession) {
+      sendError(
+        res,
+        corsHeaders,
+        404,
+        "registration_session_not_found",
+        "Registration session not found.",
+      );
+      return;
+    }
+
+    const requestOrigin = deriveRequestOrigin(req.headers.origin, url);
+    const session = await authStore.finishPasskeyRegistration(
+      verifyPasskeyRegistration(input, {
+        registrationSession,
+        expectedOrigin: requestOrigin,
+        expectedRpId: deriveRpId(requestOrigin),
+      }),
+    );
 
     if (!session) {
       sendError(
@@ -685,14 +724,56 @@ function parseStartRegistrationInput(payload: unknown): StartRegistrationInput {
 
 function parseFinishRegistrationInput(payload: unknown): FinishRegistrationInput {
   const input = asRecord(payload, "Request body must be an object.");
+  const credential = asRecord(input.credential, "credential must be an object.");
+  const response = asRecord(credential.response, "credential.response must be an object.");
+  const credentialType = readRequiredString(credential.type, "credential.type");
+
+  if (credentialType !== "public-key") {
+    throw createHttpError(400, "validation_error", "credential.type must be public-key.");
+  }
+
+  const publicKeyAlgorithm = readOptionalInteger(
+    response.publicKeyAlgorithm,
+    "credential.response.publicKeyAlgorithm",
+  );
+  const clientExtensionResults = readOptionalRecord(
+    credential.clientExtensionResults,
+    "credential.clientExtensionResults",
+  );
+  const transports = readOptionalStringArray(
+    response.transports,
+    "credential.response.transports",
+  );
 
   return {
     registrationSessionId: readRequiredString(input.registrationSessionId, "registrationSessionId"),
-    attestationResponse: readRequiredString(input.attestationResponse, "attestationResponse"),
-    clientDataJson: readRequiredString(input.clientDataJson, "clientDataJson"),
     passkeyLabel: readOptionalString(input.passkeyLabel, "passkeyLabel"),
+    credential: {
+      id: readRequiredString(credential.id, "credential.id"),
+      rawId: readRequiredString(credential.rawId, "credential.rawId"),
+      type: "public-key",
+      response: {
+        attestationObject: readRequiredString(
+          response.attestationObject,
+          "credential.response.attestationObject",
+        ),
+        clientDataJSON: readRequiredString(
+          response.clientDataJSON,
+          "credential.response.clientDataJSON",
+        ),
+        publicKey: readOptionalString(response.publicKey, "credential.response.publicKey"),
+        publicKeyAlgorithm,
+        transports,
+      },
+      authenticatorAttachment: readOptionalString(
+        credential.authenticatorAttachment,
+        "credential.authenticatorAttachment",
+      ),
+      clientExtensionResults,
+    },
   };
 }
+
 
 function parseCompleteRegistrationVerificationInput(
   payload: unknown,
@@ -781,6 +862,60 @@ function readOptionalString(value: unknown, fieldName: string): string | undefin
   }
 
   return value.trim();
+}
+
+function readOptionalInteger(value: unknown, fieldName: string): number | undefined {
+  if (value === undefined || value === null || value === "") {
+    return undefined;
+  }
+
+  if (typeof value !== "number" || !Number.isInteger(value)) {
+    throw createHttpError(
+      400,
+      "validation_error",
+      `${fieldName} must be an integer.`,
+    );
+  }
+
+  return value;
+}
+
+function readOptionalRecord(
+  value: unknown,
+  fieldName: string,
+): Record<string, unknown> | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw createHttpError(
+      400,
+      "validation_error",
+      `${fieldName} must be an object.`,
+    );
+  }
+
+  return value as Record<string, unknown>;
+}
+
+function readOptionalStringArray(
+  value: unknown,
+  fieldName: string,
+): string[] | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+
+  if (!Array.isArray(value) || value.some((item) => typeof item !== "string")) {
+    throw createHttpError(
+      400,
+      "validation_error",
+      `${fieldName} must be an array of strings.`,
+    );
+  }
+
+  return [...value];
 }
 
 function readOptionalNonEmptyString(

--- a/apps/api/src/auth-store.ts
+++ b/apps/api/src/auth-store.ts
@@ -1,11 +1,19 @@
 import type {
   CompleteRegistrationVerificationInput,
-  FinishRegistrationInput,
   PasskeyRegistrationOptions,
   RedeemPairingInput,
   RegistrationSession,
   StartRegistrationInput,
 } from "@theagentforum/core";
+
+export interface VerifiedPasskeyRegistration {
+  registrationSessionId: string;
+  credentialId: string;
+  publicKey: string;
+  verificationMethod: string;
+  passkeyLabel?: string;
+  transports?: string[];
+}
 
 export interface AuthStore {
   startRegistration(input: StartRegistrationInput): Promise<RegistrationSession>;
@@ -16,7 +24,7 @@ export interface AuthStore {
   getPasskeyRegistrationOptions(
     registrationSessionId: string,
   ): Promise<PasskeyRegistrationOptions | null>;
-  finishPasskeyRegistration(input: FinishRegistrationInput): Promise<RegistrationSession | null>;
+  finishPasskeyRegistration(input: VerifiedPasskeyRegistration): Promise<RegistrationSession | null>;
   completeRegistrationVerification(
     registrationSessionId: string,
     input: CompleteRegistrationVerificationInput,

--- a/apps/api/src/http.test.ts
+++ b/apps/api/src/http.test.ts
@@ -102,19 +102,16 @@ describe("HTTP API", () => {
     assert.equal(options.status, 200);
     assert.equal(options.body.data.registrationSessionId, registrationId);
 
-    const verified = await requestJson(app, "/auth/passkeys/register", {
+    const verified = await requestJson(app, `/auth/registrations/${registrationId}/verify`, {
       method: "POST",
       body: {
-        registrationSessionId: registrationId,
-        attestationResponse: "cred-felix-1",
-        clientDataJson: '{"type":"webauthn.create"}',
         passkeyLabel: "Felix MacBook Passkey",
       },
     });
 
     assert.equal(verified.status, 200);
     assert.equal(verified.body.data.status, "verified");
-    assert.equal(verified.body.data.verificationMethod, "webauthn_simulated");
+    assert.equal(verified.body.data.verificationMethod, "manual_internal");
     assert.equal(verified.body.data.pairing.status, "ready_to_pair");
 
     const redeemed = await requestJson(app, "/auth/pairings/redeem", {

--- a/apps/api/src/http.webauthn.test.ts
+++ b/apps/api/src/http.webauthn.test.ts
@@ -1,0 +1,334 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { Readable } from "node:stream";
+import { describe, it } from "node:test";
+import { createApp } from "./app";
+import { createInMemoryAuthStore } from "./memory-auth-store";
+import { createInMemoryQuestionStore } from "./memory-question-store";
+
+describe("HTTP API - WebAuthn registration", () => {
+  it("verifies a browser-style WebAuthn credential response and pairs", async () => {
+    const app = createTestApp();
+
+    const started = await requestJson(app, "/auth/registrations/start", {
+      method: "POST",
+      body: {
+        handle: "felix796",
+        displayName: "Felix",
+      },
+    });
+
+    assert.equal(started.status, 201);
+    const registrationId = started.body.data.id as string;
+    const pairingCode = started.body.data.pairing.code as string;
+
+    const options = await requestJson(app, `/auth/registrations/${registrationId}/passkey/options`, {
+      headers: {
+        origin: "http://localhost:5173",
+      },
+    });
+    assert.equal(options.status, 200);
+    assert.equal(options.body.data.rp.id, "localhost");
+
+    const credential = createRegistrationCredential({
+      challenge: options.body.data.challenge,
+      origin: "http://localhost:5173",
+      rpId: "localhost",
+    });
+
+    const verified = await requestJson(app, "/auth/passkeys/register", {
+      method: "POST",
+      headers: {
+        origin: "http://localhost:5173",
+      },
+      body: {
+        registrationSessionId: registrationId,
+        credential,
+        passkeyLabel: "Felix MacBook Passkey",
+      },
+    });
+
+    assert.equal(verified.status, 200);
+    assert.equal(verified.body.data.status, "verified");
+    assert.equal(verified.body.data.verificationMethod, "webauthn");
+    assert.equal(verified.body.data.pairing.status, "ready_to_pair");
+    assert.equal(verified.body.data.passkeyLabel, "Felix MacBook Passkey");
+
+    const redeemed = await requestJson(app, "/auth/pairings/redeem", {
+      method: "POST",
+      body: {
+        pairingCode,
+        deviceLabel: "pixel-bot",
+      },
+    });
+
+    assert.equal(redeemed.status, 200);
+    assert.equal(redeemed.body.data.pairing.status, "paired");
+  });
+
+  it("rejects fabricated legacy registration payloads on the real browser route", async () => {
+    const app = createTestApp();
+
+    const started = await requestJson(app, "/auth/registrations/start", {
+      method: "POST",
+      body: {
+        handle: "legacy-helper",
+      },
+    });
+
+    const rejected = await requestJson(app, "/auth/passkeys/register", {
+      method: "POST",
+      headers: {
+        origin: "http://localhost:5173",
+      },
+      body: {
+        registrationSessionId: started.body.data.id,
+        attestationResponse: "cred-legacy-1",
+        clientDataJson: '{"type":"webauthn.create"}',
+      },
+    });
+
+    assert.equal(rejected.status, 400);
+    assert.equal(rejected.body.ok, false);
+    assert.equal(rejected.body.error.code, "validation_error");
+    assert.match(rejected.body.error.message, /credential/i);
+  });
+
+  it("rejects a credential whose challenge does not match the pending registration", async () => {
+    const app = createTestApp();
+
+    const started = await requestJson(app, "/auth/registrations/start", {
+      method: "POST",
+      body: {
+        handle: "felix-mismatch",
+      },
+    });
+
+    const registrationId = started.body.data.id as string;
+
+    const options = await requestJson(app, `/auth/registrations/${registrationId}/passkey/options`, {
+      headers: {
+        origin: "http://localhost:5173",
+      },
+    });
+
+    const rejected = await requestJson(app, "/auth/passkeys/register", {
+      method: "POST",
+      headers: {
+        origin: "http://localhost:5173",
+      },
+      body: {
+        registrationSessionId: registrationId,
+        credential: createRegistrationCredential({
+          challenge: `${options.body.data.challenge}-wrong`,
+          origin: "http://localhost:5173",
+          rpId: "localhost",
+        }),
+      },
+    });
+
+    assert.equal(rejected.status, 400);
+    assert.equal(rejected.body.ok, false);
+    assert.equal(rejected.body.error.code, "webauthn_verification_failed");
+    assert.match(rejected.body.error.message, /challenge/i);
+  });
+});
+
+function createRegistrationCredential(input: {
+  challenge: string;
+  origin: string;
+  rpId: string;
+}) {
+  const credentialId = Buffer.from("cred-felix-1", "utf8");
+  const credentialPublicKey = encodeCbor(
+    new Map<unknown, unknown>([
+      [1, 2],
+      [3, -7],
+      [-1, 1],
+      [-2, Buffer.alloc(32, 1)],
+      [-3, Buffer.alloc(32, 2)],
+    ]),
+  );
+  const authData = Buffer.concat([
+    sha256(input.rpId),
+    Buffer.from([0x41]),
+    Buffer.alloc(4),
+    Buffer.alloc(16),
+    Buffer.from([0x00, credentialId.length]),
+    credentialId,
+    credentialPublicKey,
+  ]);
+  const clientDataJSON = Buffer.from(
+    JSON.stringify({
+      type: "webauthn.create",
+      challenge: input.challenge,
+      origin: input.origin,
+    }),
+    "utf8",
+  );
+  const attestationObject = encodeCbor(
+    new Map<unknown, unknown>([
+      ["fmt", "none"],
+      ["attStmt", new Map()],
+      ["authData", authData],
+    ]),
+  );
+
+  return {
+    id: toBase64Url(credentialId),
+    rawId: toBase64Url(credentialId),
+    type: "public-key",
+    response: {
+      clientDataJSON: toBase64Url(clientDataJSON),
+      attestationObject: toBase64Url(attestationObject),
+      transports: ["internal"],
+    },
+  };
+}
+
+function encodeCbor(value: unknown): Buffer {
+  if (typeof value === "number") {
+    if (!Number.isInteger(value)) {
+      throw new Error("Only integer CBOR values are supported in test fixtures.");
+    }
+
+    if (value >= 0) {
+      return encodeCborHeader(0, value);
+    }
+
+    return encodeCborHeader(1, -1 - value);
+  }
+
+  if (typeof value === "string") {
+    const bytes = Buffer.from(value, "utf8");
+    return Buffer.concat([encodeCborHeader(3, bytes.length), bytes]);
+  }
+
+  if (Buffer.isBuffer(value) || value instanceof Uint8Array) {
+    const bytes = Buffer.from(value);
+    return Buffer.concat([encodeCborHeader(2, bytes.length), bytes]);
+  }
+
+  if (Array.isArray(value)) {
+    return Buffer.concat([encodeCborHeader(4, value.length), ...value.map((item) => encodeCbor(item))]);
+  }
+
+  if (value instanceof Map) {
+    const entries = Array.from(value.entries()).flatMap(([key, entryValue]) => [
+      encodeCbor(key),
+      encodeCbor(entryValue),
+    ]);
+
+    return Buffer.concat([encodeCborHeader(5, value.size), ...entries]);
+  }
+
+  if (value && typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>).flatMap(([key, entryValue]) => [
+      encodeCbor(key),
+      encodeCbor(entryValue),
+    ]);
+
+    return Buffer.concat([
+      encodeCborHeader(5, Object.keys(value as Record<string, unknown>).length),
+      ...entries,
+    ]);
+  }
+
+  throw new Error(`Unsupported CBOR fixture value: ${String(value)}`);
+}
+
+function encodeCborHeader(majorType: number, value: number): Buffer {
+  if (value < 24) {
+    return Buffer.from([(majorType << 5) | value]);
+  }
+
+  if (value < 0x100) {
+    return Buffer.from([(majorType << 5) | 24, value]);
+  }
+
+  if (value < 0x10000) {
+    const bytes = Buffer.alloc(3);
+    bytes[0] = (majorType << 5) | 25;
+    bytes.writeUInt16BE(value, 1);
+    return bytes;
+  }
+
+  const bytes = Buffer.alloc(5);
+  bytes[0] = (majorType << 5) | 26;
+  bytes.writeUInt32BE(value, 1);
+  return bytes;
+}
+
+function sha256(value: string): Buffer {
+  return createHash("sha256").update(value, "utf8").digest();
+}
+
+function toBase64Url(value: Uint8Array): string {
+  return Buffer.from(value)
+    .toString("base64")
+    .replace(/=+$/g, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_");
+}
+
+function createTestApp() {
+  return createApp(createInMemoryQuestionStore(), createInMemoryAuthStore());
+}
+
+async function requestJson(
+  app: ReturnType<typeof createTestApp>,
+  path: string,
+  init?: {
+    method?: string;
+    body?: unknown;
+    headers?: Record<string, string>;
+  },
+): Promise<{ status: number; body: any }> {
+  const request = Readable.from(init?.body ? [JSON.stringify(init.body)] : []) as IncomingRequestLike;
+  request.method = init?.method ?? "GET";
+  request.url = path;
+  request.headers = {
+    host: "localhost",
+    ...(init?.body ? { "content-type": "application/json" } : {}),
+    ...(init?.headers ?? {}),
+  };
+
+  const response = createMockResponse();
+  await app(request, response);
+
+  return {
+    status: response.statusCode,
+    body: JSON.parse(response.body),
+  };
+}
+
+function createMockResponse(): MockResponse {
+  return {
+    statusCode: 200,
+    headers: {},
+    body: "",
+    writeHead(statusCode: number, headers?: Record<string, string>) {
+      this.statusCode = statusCode;
+      this.headers = headers ?? {};
+      return this;
+    },
+    end(chunk?: string | Buffer) {
+      this.body = chunk ? chunk.toString() : "";
+      return this;
+    },
+  };
+}
+
+interface IncomingRequestLike extends Readable {
+  method?: string;
+  url?: string;
+  headers: Record<string, string>;
+}
+
+interface MockResponse {
+  statusCode: number;
+  headers: Record<string, string>;
+  body: string;
+  writeHead(statusCode: number, headers?: Record<string, string>): MockResponse;
+  end(chunk?: string | Buffer): MockResponse;
+}

--- a/apps/api/src/memory-auth-store.ts
+++ b/apps/api/src/memory-auth-store.ts
@@ -1,19 +1,19 @@
 import { randomBytes } from "node:crypto";
 import type {
   CompleteRegistrationVerificationInput,
-  FinishRegistrationInput,
   PairingSession,
   PasskeyRegistrationOptions,
   RedeemPairingInput,
   RegistrationSession,
   StartRegistrationInput,
 } from "@theagentforum/core";
-import type { AuthStore } from "./auth-store";
+import type { AuthStore, VerifiedPasskeyRegistration } from "./auth-store";
 
 interface StoredCredential {
   credentialId: string;
   publicKey: string;
   label?: string;
+  transports?: string[];
 }
 
 interface StoredRegistrationSession {
@@ -139,7 +139,7 @@ export function createInMemoryAuthStore(): AuthStore {
   }
 
   async function finishPasskeyRegistration(
-    input: FinishRegistrationInput,
+    input: VerifiedPasskeyRegistration,
   ): Promise<RegistrationSession | null> {
     const session = registrationSessions.get(input.registrationSessionId);
 
@@ -158,14 +158,15 @@ export function createInMemoryAuthStore(): AuthStore {
     const credentials = credentialsByHandle.get(session.handle) ?? [];
 
     credentials.push({
-      credentialId: readCredentialId(input.attestationResponse),
-      publicKey: input.clientDataJson,
+      credentialId: input.credentialId,
+      publicKey: input.publicKey,
       label,
+      transports: input.transports,
     });
     credentialsByHandle.set(session.handle, credentials);
 
     session.status = "verified";
-    session.verificationMethod = "webauthn_simulated";
+    session.verificationMethod = input.verificationMethod;
     session.passkeyLabel = label;
     session.verifiedAt = verifiedAt;
     session.pairing.status = "ready_to_pair";
@@ -179,8 +180,9 @@ export function createInMemoryAuthStore(): AuthStore {
   ): Promise<RegistrationSession | null> {
     return finishPasskeyRegistration({
       registrationSessionId,
-      attestationResponse: `manual-${registrationSessionId}`,
-      clientDataJson: JSON.stringify({ source: "manual" }),
+      credentialId: `manual-${registrationSessionId}`,
+      publicKey: JSON.stringify({ source: "manual_internal" }),
+      verificationMethod: "manual_internal",
       passkeyLabel: input.passkeyLabel,
     });
   }
@@ -229,10 +231,6 @@ function createPairingCode(): string {
 
 function createToken(): string {
   return `taf_${randomBytes(18).toString("base64url")}`;
-}
-
-function readCredentialId(attestationResponse: string): string {
-  return attestationResponse.trim() || `cred_${randomBytes(8).toString("hex")}`;
 }
 
 function expireSessionIfNeeded(session: StoredRegistrationSession): void {

--- a/apps/api/src/postgres-auth-store.ts
+++ b/apps/api/src/postgres-auth-store.ts
@@ -1,14 +1,13 @@
 import { randomBytes } from "node:crypto";
 import type {
   CompleteRegistrationVerificationInput,
-  FinishRegistrationInput,
   PasskeyRegistrationOptions,
   RedeemPairingInput,
   RegistrationSession,
   StartRegistrationInput,
 } from "@theagentforum/core";
 import { runSql } from "./postgres";
-import type { AuthStore } from "./auth-store";
+import type { AuthStore, VerifiedPasskeyRegistration } from "./auth-store";
 
 export function createPostgresAuthStore(): AuthStore {
   return {
@@ -153,7 +152,7 @@ async function getPasskeyRegistrationOptions(
 }
 
 async function finishPasskeyRegistration(
-  input: FinishRegistrationInput,
+  input: VerifiedPasskeyRegistration,
 ): Promise<RegistrationSession | null> {
   await expireRegistrationSession(input.registrationSessionId);
 
@@ -168,7 +167,7 @@ async function finishPasskeyRegistration(
           end,
           verification_method = case
             when expires_at <= now() then verification_method
-            else 'webauthn_simulated'
+            else :'verification_method'
           end,
           passkey_label = case
             when expires_at <= now() then passkey_label
@@ -227,9 +226,10 @@ async function finishPasskeyRegistration(
     {
       registration_session_id: input.registrationSessionId,
       passkey_label: input.passkeyLabel ?? "",
-      credential_id: readCredentialId(input.attestationResponse),
-      public_key: input.clientDataJson,
-      transports: JSON.stringify(["internal", "hybrid"]),
+      verification_method: input.verificationMethod,
+      credential_id: input.credentialId,
+      public_key: input.publicKey,
+      transports: JSON.stringify(input.transports ?? []),
     },
   );
 
@@ -242,8 +242,9 @@ async function completeRegistrationVerification(
 ): Promise<RegistrationSession | null> {
   return finishPasskeyRegistration({
     registrationSessionId,
-    attestationResponse: `manual-${registrationSessionId}`,
-    clientDataJson: JSON.stringify({ source: "manual" }),
+    credentialId: `manual-${registrationSessionId}`,
+    publicKey: JSON.stringify({ source: "manual_internal" }),
+    verificationMethod: "manual_internal",
     passkeyLabel: input.passkeyLabel,
   });
 }
@@ -419,6 +420,3 @@ function createToken(): string {
   return `taf_${randomBytes(18).toString("base64url")}`;
 }
 
-function readCredentialId(attestationResponse: string): string {
-  return attestationResponse.trim() || `cred_${randomBytes(8).toString("hex")}`;
-}

--- a/apps/api/src/webauthn.ts
+++ b/apps/api/src/webauthn.ts
@@ -1,0 +1,385 @@
+import { createHash, timingSafeEqual } from "node:crypto";
+import type {
+  FinishRegistrationInput,
+  RegistrationSession,
+  WebAuthnCredentialPayload,
+} from "@theagentforum/core";
+import type { VerifiedPasskeyRegistration } from "./auth-store";
+
+interface WebAuthnVerificationContext {
+  registrationSession: RegistrationSession;
+  expectedOrigin: string;
+  expectedRpId: string;
+}
+
+interface AuthenticatorData {
+  rpIdHash: Buffer;
+  flags: number;
+  signCount: number;
+  credentialId: Buffer;
+  credentialPublicKey: Buffer;
+}
+
+export class WebAuthnVerificationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "WebAuthnVerificationError";
+  }
+}
+
+export function verifyPasskeyRegistration(
+  input: FinishRegistrationInput,
+  context: WebAuthnVerificationContext,
+): VerifiedPasskeyRegistration {
+  const credential = input.credential;
+
+  if (credential.type !== "public-key") {
+    throw new WebAuthnVerificationError("credential.type must be public-key.");
+  }
+
+  const rawIdBytes = decodeBase64Url(credential.rawId, "credential.rawId");
+  const credentialIdBytes = decodeBase64Url(credential.id, "credential.id");
+  assertBuffersEqual(rawIdBytes, credentialIdBytes, "credential.id must match credential.rawId.");
+
+  const clientData = parseClientData(credential.response.clientDataJSON);
+
+  if (clientData.type !== "webauthn.create") {
+    throw new WebAuthnVerificationError("clientDataJSON.type must be webauthn.create.");
+  }
+
+  if (clientData.challenge !== context.registrationSession.challenge) {
+    throw new WebAuthnVerificationError("clientDataJSON.challenge does not match the pending registration challenge.");
+  }
+
+  const expectedOrigin = normalizeOrigin(context.expectedOrigin);
+  const observedOrigin = normalizeOrigin(clientData.origin);
+
+  if (observedOrigin !== expectedOrigin) {
+    throw new WebAuthnVerificationError("clientDataJSON.origin does not match the browser origin that submitted this request.");
+  }
+
+  const attestationObject = parseAttestationObject(credential.response.attestationObject);
+  const authenticatorData = parseAuthenticatorData(attestationObject.authData);
+
+  assertBuffersEqual(
+    authenticatorData.rpIdHash,
+    sha256(context.expectedRpId),
+    "authenticatorData.rpIdHash does not match the expected RP ID.",
+  );
+
+  if ((authenticatorData.flags & 0x01) === 0) {
+    throw new WebAuthnVerificationError("authenticatorData must indicate user presence.");
+  }
+
+  if ((authenticatorData.flags & 0x40) === 0) {
+    throw new WebAuthnVerificationError("authenticatorData is missing attested credential data.");
+  }
+
+  assertBuffersEqual(
+    authenticatorData.credentialId,
+    rawIdBytes,
+    "attested credential ID does not match credential.rawId.",
+  );
+
+  const publicKey = credential.response.publicKey
+    ? encodeDecodedBase64Url(credential.response.publicKey, "credential.response.publicKey")
+    : toBase64Url(authenticatorData.credentialPublicKey);
+
+  return {
+    registrationSessionId: input.registrationSessionId,
+    credentialId: toBase64Url(rawIdBytes),
+    publicKey,
+    verificationMethod: "webauthn",
+    passkeyLabel: input.passkeyLabel,
+    transports: credential.response.transports,
+  };
+}
+
+function parseClientData(clientDataJsonBase64Url: string): {
+  type: string;
+  challenge: string;
+  origin: string;
+} {
+  const clientDataJsonBytes = decodeBase64Url(
+    clientDataJsonBase64Url,
+    "credential.response.clientDataJSON",
+  );
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(clientDataJsonBytes.toString("utf8"));
+  } catch {
+    throw new WebAuthnVerificationError("credential.response.clientDataJSON must be valid JSON.");
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new WebAuthnVerificationError("credential.response.clientDataJSON must decode to an object.");
+  }
+
+  const clientData = parsed as Record<string, unknown>;
+  const type = readRequiredString(clientData.type, "clientDataJSON.type");
+  const challenge = readRequiredString(clientData.challenge, "clientDataJSON.challenge");
+  const origin = readRequiredString(clientData.origin, "clientDataJSON.origin");
+
+  return { type, challenge, origin };
+}
+
+function parseAttestationObject(attestationObjectBase64Url: string): { authData: Buffer } {
+  const attestationObjectBytes = decodeBase64Url(
+    attestationObjectBase64Url,
+    "credential.response.attestationObject",
+  );
+  const decoded = decodeCbor(attestationObjectBytes);
+
+  if (decoded.bytesRead !== attestationObjectBytes.length) {
+    throw new WebAuthnVerificationError("credential.response.attestationObject contains trailing CBOR data.");
+  }
+
+  if (!decoded.value || typeof decoded.value !== "object" || Array.isArray(decoded.value)) {
+    throw new WebAuthnVerificationError("credential.response.attestationObject must decode to a CBOR map.");
+  }
+
+  const authData = (decoded.value as Record<string, unknown>).authData;
+
+  if (!Buffer.isBuffer(authData)) {
+    throw new WebAuthnVerificationError("credential.response.attestationObject.authData is missing.");
+  }
+
+  return { authData };
+}
+
+function parseAuthenticatorData(authData: Buffer): AuthenticatorData {
+  if (authData.length < 55) {
+    throw new WebAuthnVerificationError("authenticatorData is too short.");
+  }
+
+  const rpIdHash = authData.subarray(0, 32);
+  const flags = authData[32] ?? 0;
+  const signCount = authData.readUInt32BE(33);
+  const credentialIdLength = authData.readUInt16BE(53);
+  const credentialIdStart = 55;
+  const credentialIdEnd = credentialIdStart + credentialIdLength;
+
+  if (authData.length < credentialIdEnd) {
+    throw new WebAuthnVerificationError("authenticatorData is truncated before the credential ID.");
+  }
+
+  const credentialId = authData.subarray(credentialIdStart, credentialIdEnd);
+  const credentialPublicKeyItem = decodeCbor(authData, credentialIdEnd);
+  const credentialPublicKeyStart = credentialIdEnd;
+  const credentialPublicKeyEnd = credentialPublicKeyStart + credentialPublicKeyItem.bytesRead;
+
+  if (credentialPublicKeyItem.bytesRead <= 0 || authData.length < credentialPublicKeyEnd) {
+    throw new WebAuthnVerificationError("authenticatorData is missing a credential public key.");
+  }
+
+  const credentialPublicKey = authData.subarray(credentialPublicKeyStart, credentialPublicKeyEnd);
+
+  return {
+    rpIdHash,
+    flags,
+    signCount,
+    credentialId,
+    credentialPublicKey,
+  };
+}
+
+function decodeCbor(data: Buffer, offset = 0): { value: unknown; bytesRead: number } {
+  const initialByte = data[offset];
+
+  if (initialByte === undefined) {
+    throw new WebAuthnVerificationError("Unexpected end of CBOR data.");
+  }
+
+  const majorType = initialByte >> 5;
+  const additionalInfo = initialByte & 0x1f;
+  const { value: lengthOrValue, nextOffset } = readCborLength(data, offset + 1, additionalInfo);
+
+  switch (majorType) {
+    case 0:
+      return { value: lengthOrValue, bytesRead: nextOffset - offset };
+    case 1:
+      return { value: -1 - lengthOrValue, bytesRead: nextOffset - offset };
+    case 2: {
+      const endOffset = nextOffset + lengthOrValue;
+      return {
+        value: data.subarray(nextOffset, endOffset),
+        bytesRead: endOffset - offset,
+      };
+    }
+    case 3: {
+      const endOffset = nextOffset + lengthOrValue;
+      return {
+        value: data.subarray(nextOffset, endOffset).toString("utf8"),
+        bytesRead: endOffset - offset,
+      };
+    }
+    case 4: {
+      const items: unknown[] = [];
+      let cursor = nextOffset;
+
+      for (let index = 0; index < lengthOrValue; index += 1) {
+        const item = decodeCbor(data, cursor);
+        items.push(item.value);
+        cursor += item.bytesRead;
+      }
+
+      return { value: items, bytesRead: cursor - offset };
+    }
+    case 5: {
+      const entries: Record<string, unknown> = {};
+      let cursor = nextOffset;
+
+      for (let index = 0; index < lengthOrValue; index += 1) {
+        const key = decodeCbor(data, cursor);
+        cursor += key.bytesRead;
+        const entryValue = decodeCbor(data, cursor);
+        cursor += entryValue.bytesRead;
+        entries[String(key.value)] = entryValue.value;
+      }
+
+      return { value: entries, bytesRead: cursor - offset };
+    }
+    case 6: {
+      const taggedValue = decodeCbor(data, nextOffset);
+      return { value: taggedValue.value, bytesRead: nextOffset - offset + taggedValue.bytesRead };
+    }
+    case 7:
+      return decodeSimpleCborValue(additionalInfo, offset, nextOffset, data);
+    default:
+      throw new WebAuthnVerificationError("Unsupported CBOR major type.");
+  }
+}
+
+function decodeSimpleCborValue(
+  additionalInfo: number,
+  offset: number,
+  nextOffset: number,
+  data: Buffer,
+): { value: unknown; bytesRead: number } {
+  if (additionalInfo === 20) {
+    return { value: false, bytesRead: nextOffset - offset };
+  }
+
+  if (additionalInfo === 21) {
+    return { value: true, bytesRead: nextOffset - offset };
+  }
+
+  if (additionalInfo === 22) {
+    return { value: null, bytesRead: nextOffset - offset };
+  }
+
+  if (additionalInfo === 23) {
+    return { value: undefined, bytesRead: nextOffset - offset };
+  }
+
+  if (additionalInfo === 24) {
+    return { value: data[nextOffset], bytesRead: nextOffset - offset + 1 };
+  }
+
+  throw new WebAuthnVerificationError("Unsupported CBOR simple value.");
+}
+
+function readCborLength(
+  data: Buffer,
+  offset: number,
+  additionalInfo: number,
+): { value: number; nextOffset: number } {
+  if (additionalInfo < 24) {
+    return { value: additionalInfo, nextOffset: offset };
+  }
+
+  if (additionalInfo === 24) {
+    const value = data[offset];
+    if (value === undefined) {
+      throw new WebAuthnVerificationError("Unexpected end of CBOR data.");
+    }
+    return { value, nextOffset: offset + 1 };
+  }
+
+  if (additionalInfo === 25) {
+    if (offset + 2 > data.length) {
+      throw new WebAuthnVerificationError("Unexpected end of CBOR data.");
+    }
+    return { value: data.readUInt16BE(offset), nextOffset: offset + 2 };
+  }
+
+  if (additionalInfo === 26) {
+    if (offset + 4 > data.length) {
+      throw new WebAuthnVerificationError("Unexpected end of CBOR data.");
+    }
+    return { value: data.readUInt32BE(offset), nextOffset: offset + 4 };
+  }
+
+  throw new WebAuthnVerificationError("Unsupported CBOR length encoding.");
+}
+
+function readRequiredString(value: unknown, fieldName: string): string {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new WebAuthnVerificationError(`${fieldName} must be a non-empty string.`);
+  }
+
+  return value;
+}
+
+function encodeDecodedBase64Url(value: string, fieldName: string): string {
+  return toBase64Url(decodeBase64Url(value, fieldName));
+}
+
+function decodeBase64Url(value: string, fieldName: string): Buffer {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new WebAuthnVerificationError(`${fieldName} must be a non-empty base64url string.`);
+  }
+
+  const normalized = value.replace(/-/g, "+").replace(/_/g, "/");
+  const paddingLength = (4 - (normalized.length % 4)) % 4;
+  const padded = normalized + "=".repeat(paddingLength);
+
+  try {
+    return Buffer.from(padded, "base64");
+  } catch {
+    throw new WebAuthnVerificationError(`${fieldName} must be a valid base64url string.`);
+  }
+}
+
+function normalizeOrigin(origin: string): string {
+  try {
+    return new URL(origin).origin;
+  } catch {
+    throw new WebAuthnVerificationError("clientDataJSON.origin must be a valid origin URL.");
+  }
+}
+
+function sha256(value: string): Buffer {
+  return createHash("sha256").update(value, "utf8").digest();
+}
+
+function assertBuffersEqual(expected: Buffer, actual: Buffer, message: string): void {
+  if (expected.length !== actual.length || !timingSafeEqual(expected, actual)) {
+    throw new WebAuthnVerificationError(message);
+  }
+}
+
+function toBase64Url(value: Uint8Array): string {
+  return Buffer.from(value)
+    .toString("base64")
+    .replace(/=+$/g, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_");
+}
+
+export function deriveRequestOrigin(originHeader: string | string[] | undefined, fallbackUrl: URL): string {
+  if (typeof originHeader === "string" && originHeader.trim() !== "") {
+    return originHeader.trim();
+  }
+
+  return fallbackUrl.origin;
+}
+
+export function deriveRpId(origin: string): string {
+  try {
+    return new URL(origin).hostname;
+  } catch {
+    throw new WebAuthnVerificationError("Could not derive the RP ID for this registration request.");
+  }
+}

--- a/apps/mcp/src/api-client.ts
+++ b/apps/mcp/src/api-client.ts
@@ -196,11 +196,14 @@ export class TafApiClient {
 
   async registerPasskey(input: {
     registrationSessionId: string;
-    attestationResponse: string;
-    clientDataJson: string;
     passkeyLabel?: string;
   }): Promise<z.infer<typeof RegistrationSessionSchema>> {
-    return this.request("POST", "/auth/passkeys/register", RegistrationSessionSchema, input);
+    return this.request(
+      "POST",
+      `/auth/registrations/${encodeURIComponent(input.registrationSessionId)}/verify`,
+      RegistrationSessionSchema,
+      { passkeyLabel: input.passkeyLabel },
+    );
   }
 
   async redeemPairing(input: {

--- a/apps/mcp/src/tool-handlers.ts
+++ b/apps/mcp/src/tool-handlers.ts
@@ -249,22 +249,15 @@ export function createToolHandlers(options: ToolHandlerOptions): ToolHandlers {
     async authPasskeyRegister(input: unknown): Promise<ToolPayload> {
       try {
         const parsed = PasskeyRegisterToolInputSchema.parse(input);
-        const options = await apiClient.getPasskeyRegistrationOptions(parsed.registrationSessionId);
         const session = await apiClient.registerPasskey({
           registrationSessionId: parsed.registrationSessionId,
-          attestationResponse: `mcp:${options.challenge}:${options.user.name}`,
-          clientDataJson: JSON.stringify({
-            type: "webauthn.create",
-            challenge: options.challenge,
-            source: "mcp",
-          }),
           passkeyLabel: parsed.passkeyLabel,
         });
 
         return RegistrationSessionToolSuccessSchema.parse({
           ok: true,
           data: session,
-          meta: { route: "POST /auth/passkeys/register", source: "theagentforum-api" },
+          meta: { route: "POST /auth/registrations/:id/verify", source: "theagentforum-api" },
         });
       } catch (error) {
         return mapToolError(error);

--- a/apps/web/src/pages/AuthPage.test.tsx
+++ b/apps/web/src/pages/AuthPage.test.tsx
@@ -1,0 +1,214 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiClient } from "../lib/api";
+import { AuthPage } from "./AuthPage";
+
+describe("AuthPage", () => {
+  const originalCredentials = navigator.credentials;
+  const originalPublicKeyCredential = (window as typeof window & {
+    PublicKeyCredential?: typeof PublicKeyCredential;
+  }).PublicKeyCredential;
+
+  beforeEach(() => {
+    Object.defineProperty(window, "PublicKeyCredential", {
+      configurable: true,
+      value: class PublicKeyCredentialMock {},
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(navigator, "credentials", {
+      configurable: true,
+      value: originalCredentials,
+    });
+
+    Object.defineProperty(window, "PublicKeyCredential", {
+      configurable: true,
+      value: originalPublicKeyCredential,
+    });
+  });
+
+  it("creates a real browser credential and posts it to the register route", async () => {
+    const user = userEvent.setup();
+    const createCredential = vi.fn().mockResolvedValue(
+      buildCredential({
+        credentialId: Uint8Array.from([1, 2, 3, 4]),
+        clientDataJson: new TextEncoder().encode(
+          JSON.stringify({
+            type: "webauthn.create",
+            challenge: "AQIDBA",
+            origin: window.location.origin,
+          }),
+        ),
+        attestationObject: Uint8Array.from([9, 8, 7, 6]),
+        publicKey: Uint8Array.from([4, 3, 2, 1]),
+        publicKeyAlgorithm: -7,
+        transports: ["internal"],
+      }),
+    );
+
+    Object.defineProperty(navigator, "credentials", {
+      configurable: true,
+      value: {
+        create: createCredential,
+      },
+    });
+
+    const registerPasskey = vi.fn().mockResolvedValue({
+      ...buildRegistrationSession(),
+      status: "verified",
+      verificationMethod: "webauthn",
+      passkeyLabel: "Felix MacBook Passkey",
+      verifiedAt: "2026-03-26T00:01:00.000Z",
+      pairing: {
+        ...buildRegistrationSession().pairing,
+        status: "ready_to_pair",
+      },
+    });
+
+    const api = {
+      listQuestions: vi.fn(),
+      searchThreads: vi.fn(),
+      createQuestion: vi.fn(),
+      getQuestionThread: vi.fn(),
+      createAnswer: vi.fn(),
+      acceptAnswer: vi.fn(),
+      listAnswerSkills: vi.fn(),
+      startRegistration: vi.fn(),
+      getRegistrationSession: vi.fn().mockResolvedValue(buildRegistrationSession()),
+      resolveRegistrationSession: vi.fn(),
+      getPasskeyRegistrationOptions: vi.fn().mockResolvedValue({
+        registrationSessionId: "ars-1",
+        rp: { id: "localhost", name: "TheAgentForum" },
+        user: {
+          id: "BQYHCA",
+          name: "felix796",
+          displayName: "Felix",
+        },
+        challenge: "AQIDBA",
+        pubKeyCredParams: [{ type: "public-key", alg: -7 }],
+        timeout: 60000,
+        attestation: "none",
+        authenticatorSelection: {
+          residentKey: "preferred",
+          userVerification: "preferred",
+        },
+      }),
+      registerPasskey,
+      completeRegistrationVerification: vi.fn(),
+      redeemPairing: vi.fn(),
+    } as unknown as ApiClient;
+
+    render(
+      <MemoryRouter initialEntries={["/auth?registration=ars-1"]}>
+        <AuthPage api={api} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Create passkey now" })).toBeEnabled();
+    });
+
+    await user.clear(screen.getByLabelText("Passkey label"));
+    await user.type(screen.getByLabelText("Passkey label"), "Felix MacBook Passkey");
+    await user.click(screen.getByRole("button", { name: "Create passkey now" }));
+
+    await waitFor(() => {
+      expect(createCredential).toHaveBeenCalledTimes(1);
+      expect(registerPasskey).toHaveBeenCalledTimes(1);
+    });
+
+    const creationCall = createCredential.mock.calls[0]?.[0] as { publicKey?: PublicKeyCredentialCreationOptions };
+    expect(creationCall.publicKey).toBeDefined();
+    expect(Array.from(new Uint8Array(creationCall.publicKey?.challenge as ArrayBuffer))).toEqual([
+      1, 2, 3, 4,
+    ]);
+    expect(Array.from(new Uint8Array(creationCall.publicKey?.user.id as ArrayBuffer))).toEqual([
+      5, 6, 7, 8,
+    ]);
+
+    expect(registerPasskey).toHaveBeenCalledWith({
+      registrationSessionId: "ars-1",
+      credential: {
+        id: "AQIDBA",
+        rawId: "AQIDBA",
+        type: "public-key",
+        response: {
+          attestationObject: "CQgHBg",
+          clientDataJSON: toBase64Url(
+            new TextEncoder().encode(
+              JSON.stringify({
+                type: "webauthn.create",
+                challenge: "AQIDBA",
+                origin: window.location.origin,
+              }),
+            ),
+          ),
+          publicKey: "BAMCAQ",
+          publicKeyAlgorithm: -7,
+          transports: ["internal"],
+        },
+        authenticatorAttachment: "platform",
+        clientExtensionResults: { credProps: { rk: true } },
+      },
+      passkeyLabel: "Felix MacBook Passkey",
+    });
+  });
+});
+
+function buildRegistrationSession() {
+  return {
+    id: "ars-1",
+    handle: "felix796",
+    displayName: "Felix",
+    status: "pending_webauthn_registration" as const,
+    challenge: "AQIDBA",
+    verificationUrl: "/auth?registration=verify-token-1",
+    verificationToken: "verify-token-1",
+    createdAt: "2026-03-26T00:00:00.000Z",
+    expiresAt: "2026-03-26T00:15:00.000Z",
+    pairing: {
+      id: "aps-1",
+      code: "PAIR1234",
+      status: "waiting_for_verification" as const,
+      createdAt: "2026-03-26T00:00:00.000Z",
+      expiresAt: "2026-03-26T00:30:00.000Z",
+    },
+  };
+}
+
+function buildCredential(input: {
+  credentialId: Uint8Array;
+  clientDataJson: Uint8Array;
+  attestationObject: Uint8Array;
+  publicKey: Uint8Array;
+  publicKeyAlgorithm: number;
+  transports: string[];
+}) {
+  const response = {
+    clientDataJSON: input.clientDataJson.buffer.slice(0),
+    attestationObject: input.attestationObject.buffer.slice(0),
+    getPublicKey: () => input.publicKey.buffer.slice(0),
+    getPublicKeyAlgorithm: () => input.publicKeyAlgorithm,
+    getTransports: () => input.transports,
+  };
+
+  return {
+    id: toBase64Url(input.credentialId),
+    rawId: input.credentialId.buffer.slice(0),
+    type: "public-key",
+    response,
+    authenticatorAttachment: "platform",
+    getClientExtensionResults: () => ({ credProps: { rk: true } }),
+  } as unknown as PublicKeyCredential;
+}
+
+function toBase64Url(value: Uint8Array): string {
+  return Buffer.from(value)
+    .toString("base64")
+    .replace(/=+$/g, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_");
+}

--- a/apps/web/src/pages/AuthPage.tsx
+++ b/apps/web/src/pages/AuthPage.tsx
@@ -1,7 +1,11 @@
 import { useEffect, useMemo, useState } from "react";
 import { Link, useSearchParams } from "react-router-dom";
 import { ApiClientError, type ApiClient } from "../lib/api";
-import type { RegistrationSession } from "../types";
+import type {
+  FinishRegistrationInput,
+  PasskeyRegistrationOptions,
+  RegistrationSession,
+} from "../types";
 
 interface AuthPageProps {
   api: ApiClient;
@@ -117,23 +121,12 @@ export function AuthPage({ api }: AuthPageProps) {
 
     try {
       const options = await api.getPasskeyRegistrationOptions(registrationSession.id);
-
-      const attestationResponse =
-        typeof window !== "undefined" && "btoa" in window
-          ? window.btoa(`${options.challenge}:${options.user.name}:${Date.now()}`)
-          : `${options.challenge}:${options.user.name}:${Date.now()}`;
-
-      const clientDataJson = JSON.stringify({
-        type: "webauthn.create",
-        challenge: options.challenge,
-        origin: window.location.origin,
-      });
+      const credential = await createBrowserCredential(options);
 
       setRegistrationSession(
         await api.registerPasskey({
           registrationSessionId: registrationSession.id,
-          attestationResponse,
-          clientDataJson,
+          credential,
           passkeyLabel: passkeyLabel.trim() || `${options.user.displayName} passkey`,
         }),
       );
@@ -418,6 +411,109 @@ export function AuthPage({ api }: AuthPageProps) {
       ) : null}
     </main>
   );
+}
+
+type BrowserCredentialWithAttestation = {
+  id: string;
+  rawId: ArrayBuffer;
+  response: {
+    attestationObject: ArrayBuffer;
+    clientDataJSON: ArrayBuffer;
+    getPublicKey?: () => ArrayBuffer | null;
+    getPublicKeyAlgorithm?: () => number;
+    getTransports?: () => string[];
+  };
+  authenticatorAttachment?: string | null;
+  getClientExtensionResults?: () => AuthenticationExtensionsClientOutputs;
+};
+
+async function createBrowserCredential(
+  options: PasskeyRegistrationOptions,
+): Promise<FinishRegistrationInput["credential"]> {
+  const credentials = navigator.credentials;
+
+  if (!credentials?.create || typeof window.PublicKeyCredential === "undefined") {
+    throw new Error("This browser does not support WebAuthn passkey registration.");
+  }
+
+  const created = await credentials.create({
+    publicKey: {
+      challenge: toArrayBuffer(decodeMaybeBase64Url(options.challenge)),
+      rp: options.rp,
+      user: {
+        id: toArrayBuffer(decodeMaybeBase64Url(options.user.id)),
+        name: options.user.name,
+        displayName: options.user.displayName,
+      },
+      pubKeyCredParams: options.pubKeyCredParams,
+      timeout: options.timeout,
+      attestation: options.attestation,
+      authenticatorSelection: options.authenticatorSelection,
+    },
+  });
+
+  if (!created || typeof created !== "object" || !("rawId" in created) || !("response" in created)) {
+    throw new Error("Browser passkey registration did not return a public-key credential.");
+  }
+
+  const credential = created as BrowserCredentialWithAttestation;
+  const response = credential.response;
+
+  if (!response || typeof response !== "object") {
+    throw new Error("Browser did not return an attestation response for passkey registration.");
+  }
+
+  const publicKey = response.getPublicKey?.() ?? null;
+  const publicKeyAlgorithm = response.getPublicKeyAlgorithm?.();
+  const transports = response.getTransports?.();
+
+  return {
+    id: credential.id,
+    rawId: toBase64Url(new Uint8Array(credential.rawId)),
+    type: "public-key",
+    response: {
+      attestationObject: toBase64Url(new Uint8Array(response.attestationObject)),
+      clientDataJSON: toBase64Url(new Uint8Array(response.clientDataJSON)),
+      ...(publicKey ? { publicKey: toBase64Url(new Uint8Array(publicKey)) } : {}),
+      ...(typeof publicKeyAlgorithm === "number" ? { publicKeyAlgorithm } : {}),
+      ...(transports && transports.length > 0 ? { transports } : {}),
+    },
+    authenticatorAttachment: credential.authenticatorAttachment ?? undefined,
+    clientExtensionResults: credential.getClientExtensionResults?.() as Record<string, unknown> | undefined,
+  };
+}
+
+function decodeMaybeBase64Url(value: string): Uint8Array {
+  try {
+    return decodeBase64Url(value);
+  } catch {
+    return new TextEncoder().encode(value);
+  }
+}
+
+function toArrayBuffer(value: Uint8Array): ArrayBuffer {
+  return value.buffer.slice(value.byteOffset, value.byteOffset + value.byteLength) as ArrayBuffer;
+}
+
+function decodeBase64Url(value: string): Uint8Array {
+  const normalized = value.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, "=");
+  const binary = window.atob(padded);
+  return Uint8Array.from(binary, (char) => char.charCodeAt(0));
+}
+
+function toBase64Url(value: Uint8Array): string {
+  let binary = "";
+
+  value.forEach((byte) => {
+    binary += String.fromCharCode(byte);
+  });
+
+  return window
+    .btoa(binary)
+    .replace(/=+$/g, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_");
 }
 
 function trimOptionalField(value: FormDataEntryValue | null): string | undefined {

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -85,10 +85,24 @@ export interface RedeemPairingInput {
   deviceLabel: string;
 }
 
+export interface WebAuthnCredentialPayload {
+  id: string;
+  rawId: string;
+  type: "public-key";
+  response: {
+    attestationObject: string;
+    clientDataJSON: string;
+    publicKey?: string;
+    publicKeyAlgorithm?: number;
+    transports?: string[];
+  };
+  authenticatorAttachment?: string;
+  clientExtensionResults?: Record<string, unknown>;
+}
+
 export interface FinishRegistrationInput {
   registrationSessionId: string;
-  attestationResponse: string;
-  clientDataJson: string;
+  credential: WebAuthnCredentialPayload;
   passkeyLabel?: string;
 }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -498,18 +498,11 @@ async fn main() {
                 let res = client.post(&register_url).json(&start).send().await.unwrap_or_else(|e| { eprintln!("Network error: {}", e); exit(1); });
                 let session: RegistrationSession = handle_response(res, false).await;
 
-                let options_url = format!("{}/auth/registrations/{}/passkey/options", base_url, session.id);
-                let res = client.get(&options_url).send().await.unwrap_or_else(|e| { eprintln!("Network error: {}", e); exit(1); });
-                let options: PasskeyRegistrationOptions = handle_response(res, false).await;
-
-                let register_passkey_url = format!("{}/auth/passkeys/register", base_url);
-                let finish = FinishRegistrationInput {
-                    registration_session_id: session.id.clone(),
-                    attestation_response: format!("cli:{}:{}", options.challenge, options.user.name),
-                    client_data_json: format!("{{\"type\":\"webauthn.create\",\"challenge\":\"{}\"}}", options.challenge),
-                    passkey_label: Some(passkey_label_from(&args)),
-                };
-                let res = client.post(&register_passkey_url).json(&finish).send().await.unwrap_or_else(|e| { eprintln!("Network error: {}", e); exit(1); });
+                let verify_url = format!("{}/auth/registrations/{}/verify", base_url, session.id);
+                let finish = serde_json::json!({
+                    "passkeyLabel": passkey_label_from(&args),
+                });
+                let res = client.post(&verify_url).json(&finish).send().await.unwrap_or_else(|e| { eprintln!("Network error: {}", e); exit(1); });
                 let verified: RegistrationSession = handle_response(res, false).await;
 
                 let pair_url = format!("{}/auth/pairings/redeem", base_url);

--- a/docs/API.md
+++ b/docs/API.md
@@ -108,7 +108,7 @@ Registration session:
   "displayName": "Sam",
   "status": "verified",
   "challenge": "c4YH7M1kK6hJtV0A2pUwQm2L",
-  "verificationMethod": "webauthn_simulated",
+  "verificationMethod": "webauthn",
   "passkeyLabel": "Sam MacBook Passkey",
   "verificationUrl": "/auth?registration=ars-1",
   "createdAt": "2026-03-26T10:00:00.000Z",
@@ -133,11 +133,11 @@ Passkey registration options:
 {
   "registrationSessionId": "ars-1",
   "rp": {
-    "id": "theagentforum.local",
+    "id": "localhost",
     "name": "TheAgentForum"
   },
   "user": {
-    "id": "ars-1",
+    "id": "YXJzLTE",
     "name": "sam",
     "displayName": "Sam"
   },
@@ -183,13 +183,21 @@ Request body:
 ```json
 {
   "registrationSessionId": "ars-1",
-  "attestationResponse": "cred-sam-1",
-  "clientDataJson": "{\"type\":\"webauthn.create\"}",
+  "credential": {
+    "id": "AQIDBA",
+    "rawId": "AQIDBA",
+    "type": "public-key",
+    "response": {
+      "attestationObject": "o2NmbXRkbm9uZWhhdXRoRGF0YVhY...",
+      "clientDataJSON": "eyJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIiwiY2hhbGxlbmdlIjoiYzRZSDdNMWtLNmhKdFYwQTJwVXdRbTJMIiwib3JpZ2luIjoiaHR0cDovL2xvY2FsaG9zdDo1MTczIn0"
+    },
+    "authenticatorAttachment": "platform"
+  },
   "passkeyLabel": "Sam MacBook Passkey"
 }
 ```
 
-Completes the current passkey registration slice and moves the session into `verified` state.
+Verifies the browser-created credential payload against the pending challenge and request origin, then moves the session into `verified` state.
 
 ### `POST /auth/registrations/:id/verify`
 

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -18,7 +18,7 @@ For launch work in progress:
 - bot or device pairing after verification
 - no third-party auth provider dependency
 - smooth UX across web + CLI + MCP
-- explicit honesty that the current ceremony is a launch-focused simulated WebAuthn pass, not final cryptographic production hardening
+- explicit honesty that the browser passkey step now runs through a real WebAuthn registration ceremony, while full login/assertion hardening and broader auth enforcement still remain for later work
 
 ## Current flow
 
@@ -32,7 +32,7 @@ For launch work in progress:
 2. `GET /auth/registrations/:id/passkey/options`
    Returns passkey registration options shaped like browser WebAuthn creation options.
 3. `POST /auth/passkeys/register`
-   Completes the passkey registration slice and records a passkey credential row.
+   Verifies a browser-created WebAuthn registration payload against the pending session challenge and origin, then records a passkey credential row.
 4. `GET /auth/registrations/:id`
    Returns the current registration and pairing state.
 5. `POST /auth/pairings/redeem`
@@ -63,7 +63,7 @@ Pairing session states:
 - `auth_pairing_sessions`
   Stores pairing code, issued token, device label, and redeem state.
 - `auth_passkey_credentials`
-  Stores passkey credential identifiers and placeholder public key data.
+  Stores passkey credential identifiers, public key material, and related metadata for verified registrations.
 
 ## Smooth UX target
 
@@ -77,12 +77,13 @@ Pairing session states:
 - `taf auth register` starts the flow and prints the verification URL + pairing code
 - `taf auth status <registration-id>` checks progress
 - `taf auth pair <code> --device-label <name>` redeems the pairing and prints token material
-- `taf auth quickstart` runs the full start -> poll -> pair narrative in one place
+- `taf auth quickstart` is still a development helper built on the internal verification fallback, not a replacement for the real browser passkey ceremony
 
 ### MCP
 - use the same token from pairing redemption
 - pass `TAF_API_TOKEN` into MCP runtime config
 - keep agent auth aligned with the same API flow instead of inventing a parallel identity path
+- non-browser MCP registration helpers still use the internal verification fallback rather than pretending to perform a browser WebAuthn ceremony
 
 ## Still not done
 
@@ -90,8 +91,9 @@ This slice is real and usable, but it is not the final security-hardening pass y
 
 Still needed later:
 
-- true browser WebAuthn attestation/assertion verification
-- sign counter and replay protections
+- returning-user sign-in / assertion flow
+- stronger attestation trust validation and broader WebAuthn hardening
+- sign counter and replay protections wired into authenticated sign-in
 - stronger audit / rate limiting / abuse controls
 - richer account/session management
 - production recovery and credential lifecycle operations

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -118,10 +118,24 @@ export interface StartRegistrationInput {
   displayName?: string;
 }
 
+export interface WebAuthnCredentialPayload {
+  id: string;
+  rawId: string; // base64url
+  type: "public-key";
+  response: {
+    attestationObject: string; // base64url
+    clientDataJSON: string; // base64url
+    publicKey?: string; // base64url DER-SPKI when the browser exposes it
+    publicKeyAlgorithm?: number;
+    transports?: string[];
+  };
+  authenticatorAttachment?: string;
+  clientExtensionResults?: Record<string, unknown>;
+}
+
 export interface FinishRegistrationInput {
   registrationSessionId: string;
-  attestationResponse: string;
-  clientDataJson: string;
+  credential: WebAuthnCredentialPayload;
   passkeyLabel?: string;
 }
 


### PR DESCRIPTION
## Summary
- replace the fabricated browser passkey step with a real WebAuthn registration ceremony in the web app
- verify browser credential payloads server-side before marking registration sessions verified
- keep non-browser CLI/MCP helpers on the explicit internal verification fallback so they no longer pretend to perform browser WebAuthn
- update auth/API docs to reflect the new state honestly

## Test Plan
- npm run validate

## Out of Scope
- returning-user sign-in/assertion flow
- auth middleware and protected write enforcement
- rate limiting and audit logging hardening
