### PR TITLE
fix(auth): derive passkey RP ID from forwarded public origin

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -439,7 +439,11 @@ async function routeRequest(
       return;
     }
 
-    const requestOrigin = deriveRequestOrigin(req.headers.origin, url);
+    const requestOrigin = deriveRequestOrigin(req.headers.origin, url, {
+      forwardedHost: req.headers["x-forwarded-host"],
+      forwardedProto: req.headers["x-forwarded-proto"],
+      referer: req.headers.referer,
+    });
 
     sendJson(res, corsHeaders, 200, {
       ok: true,
@@ -470,7 +474,11 @@ async function routeRequest(
       return;
     }
 
-    const requestOrigin = deriveRequestOrigin(req.headers.origin, url);
+    const requestOrigin = deriveRequestOrigin(req.headers.origin, url, {
+      forwardedHost: req.headers["x-forwarded-host"],
+      forwardedProto: req.headers["x-forwarded-proto"],
+      referer: req.headers.referer,
+    });
     const session = await authStore.finishPasskeyRegistration(
       verifyPasskeyRegistration(input, {
         registrationSession,

--- a/apps/api/src/http.webauthn.test.ts
+++ b/apps/api/src/http.webauthn.test.ts
@@ -66,6 +66,30 @@ describe("HTTP API - WebAuthn registration", () => {
     assert.equal(redeemed.body.data.pairing.status, "paired");
   });
 
+  it("derives the WebAuthn RP ID from forwarded public headers when origin is missing", async () => {
+    const app = createTestApp();
+
+    const started = await requestJson(app, "/auth/registrations/start", {
+      method: "POST",
+      body: {
+        handle: "forwarded-origin",
+        displayName: "Forwarded Origin",
+      },
+    });
+
+    const registrationId = started.body.data.id as string;
+    const options = await requestJson(app, `/auth/registrations/${registrationId}/passkey/options`, {
+      headers: {
+        host: "api",
+        "x-forwarded-host": "app.theagentforum.com",
+        "x-forwarded-proto": "https",
+      },
+    });
+
+    assert.equal(options.status, 200);
+    assert.equal(options.body.data.rp.id, "app.theagentforum.com");
+  });
+
   it("rejects fabricated legacy registration payloads on the real browser route", async () => {
     const app = createTestApp();
 

--- a/apps/api/src/webauthn.ts
+++ b/apps/api/src/webauthn.ts
@@ -368,12 +368,60 @@ function toBase64Url(value: Uint8Array): string {
     .replace(/\//g, "_");
 }
 
-export function deriveRequestOrigin(originHeader: string | string[] | undefined, fallbackUrl: URL): string {
-  if (typeof originHeader === "string" && originHeader.trim() !== "") {
-    return originHeader.trim();
+interface RequestOriginFallbackHeaders {
+  forwardedHost?: string | string[];
+  forwardedProto?: string | string[];
+  referer?: string | string[];
+}
+
+export function deriveRequestOrigin(
+  originHeader: string | string[] | undefined,
+  fallbackUrl: URL,
+  headers: RequestOriginFallbackHeaders = {},
+): string {
+  const explicitOrigin = readFirstHeaderValue(originHeader);
+  if (explicitOrigin) {
+    return explicitOrigin;
+  }
+
+  const forwardedHost = readFirstHeaderValue(headers.forwardedHost);
+  if (forwardedHost) {
+    const forwardedProto = readFirstHeaderValue(headers.forwardedProto)
+      ?? fallbackUrl.protocol.replace(/:$/, "")
+      ?? "http";
+    return `${forwardedProto}://${forwardedHost}`;
+  }
+
+  const referer = readFirstHeaderValue(headers.referer);
+  if (referer) {
+    try {
+      return new URL(referer).origin;
+    } catch {
+      // Fall back to the request URL origin when referer is malformed.
+    }
   }
 
   return fallbackUrl.origin;
+}
+
+function readFirstHeaderValue(value: string | string[] | undefined): string | undefined {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const normalized = readFirstHeaderValue(item);
+      if (normalized) {
+        return normalized;
+      }
+    }
+    return undefined;
+  }
+
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const [first] = value.split(",", 1);
+  const normalized = first?.trim();
+  return normalized ? normalized : undefined;
 }
 
 export function deriveRpId(origin: string): string {

--- a/apps/web/server.mjs
+++ b/apps/web/server.mjs
@@ -3,6 +3,7 @@ import { access, stat } from "node:fs/promises";
 import { createServer } from "node:http";
 import { extname, join, normalize } from "node:path";
 import { Readable } from "node:stream";
+import { createProxyHeaders } from "./src/lib/proxy-headers.js";
 
 const port = Number(process.env.PORT ?? 5173);
 const apiProxyTarget = process.env.API_PROXY_TARGET ?? "http://127.0.0.1:3001";
@@ -104,32 +105,6 @@ async function proxyApiRequest(req, res, requestUrl, method) {
   }
 
   Readable.fromWeb(upstreamResponse.body).pipe(res);
-}
-
-function createProxyHeaders(requestHeaders) {
-  const headers = new Headers();
-
-  for (const [key, value] of Object.entries(requestHeaders)) {
-    if (value === undefined) {
-      continue;
-    }
-
-    const headerName = key.toLowerCase();
-
-    if (headerName === "host" || headerName === "content-length" || headerName === "connection") {
-      continue;
-    }
-
-    if (Array.isArray(value)) {
-      for (const item of value) {
-        headers.append(key, item);
-      }
-    } else {
-      headers.set(key, value);
-    }
-  }
-
-  return headers;
 }
 
 async function readRequestBody(req) {

--- a/apps/web/src/lib/proxy-headers.js
+++ b/apps/web/src/lib/proxy-headers.js
@@ -1,0 +1,55 @@
+export function createProxyHeaders(requestHeaders) {
+  const headers = new Headers();
+
+  for (const [key, value] of Object.entries(requestHeaders)) {
+    if (value === undefined) {
+      continue;
+    }
+
+    const headerName = key.toLowerCase();
+
+    if (headerName === "host" || headerName === "content-length" || headerName === "connection") {
+      continue;
+    }
+
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        headers.append(key, item);
+      }
+    } else {
+      headers.set(key, value);
+    }
+  }
+
+  const forwardedHost = readFirstHeaderValue(requestHeaders["x-forwarded-host"]) ?? readFirstHeaderValue(requestHeaders.host);
+  if (forwardedHost && !headers.has("x-forwarded-host")) {
+    headers.set("x-forwarded-host", forwardedHost);
+  }
+
+  const forwardedProto = readFirstHeaderValue(requestHeaders["x-forwarded-proto"]) ?? "http";
+  if (forwardedProto && !headers.has("x-forwarded-proto")) {
+    headers.set("x-forwarded-proto", forwardedProto);
+  }
+
+  return headers;
+}
+
+function readFirstHeaderValue(value) {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const normalized = readFirstHeaderValue(item);
+      if (normalized) {
+        return normalized;
+      }
+    }
+    return undefined;
+  }
+
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const [first] = value.split(",", 1);
+  const normalized = first?.trim();
+  return normalized ? normalized : undefined;
+}

--- a/apps/web/src/lib/proxy-headers.test.ts
+++ b/apps/web/src/lib/proxy-headers.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { createProxyHeaders } from "./proxy-headers.js";
+
+describe("createProxyHeaders", () => {
+  it("adds forwarded public host and proto for upstream API requests", () => {
+    const headers = createProxyHeaders({
+      host: "app.theagentforum.com",
+      "x-forwarded-proto": "https",
+      connection: "keep-alive",
+      accept: "application/json",
+    });
+
+    expect(headers.get("host")).toBeNull();
+    expect(headers.get("x-forwarded-host")).toBe("app.theagentforum.com");
+    expect(headers.get("x-forwarded-proto")).toBe("https");
+    expect(headers.get("accept")).toBe("application/json");
+  });
+});


### PR DESCRIPTION
## Summary
- fix passkey registration on the deployed web app when `/api` proxy requests omit the `Origin` header
- derive the WebAuthn request origin from forwarded public headers (and referer fallback) on the API side
- forward public host/proto headers from the web proxy and cover the regression with API + web tests

## Test Plan
- `npm run validate`
- reproduced the bug on `https://app.theagentforum.com/auth?registration=3652e88932f4` before the fix
- verified the root cause was `rp.id: "api"` when same-origin `GET /api/auth/.../passkey/options` omitted `Origin`
