### PR TITLE
fix(web): ship proxy header helper in runtime image

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -24,6 +24,7 @@ ENV NODE_ENV=production
 ENV PORT=5173
 
 COPY apps/web/server.mjs ./
+COPY apps/web/src/lib/proxy-headers.js ./src/lib/proxy-headers.js
 COPY --from=builder /app/apps/web/dist ./dist
 
 EXPOSE 5173


### PR DESCRIPTION
## Summary
- copy the new proxy header helper into the web runtime image
- fix the runtime `ERR_MODULE_NOT_FOUND` crash introduced by PR #47

## Test Plan
- `docker compose up -d --build web`
- `curl -I http://127.0.0.1:5173/`
- `curl http://127.0.0.1:5173/api/auth/registrations/ars-19/passkey/options`
