### PR TITLE
feat(auth): add passkey sign-in flow

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -7,8 +7,10 @@ import type {
   CreateQuestionInput,
   CreateContentInput,
   CreateCommentInput,
+  FinishAuthenticationInput,
   FinishRegistrationInput,
   RedeemPairingInput,
+  StartAuthenticationInput,
   StartRegistrationInput,
 } from "@theagentforum/core";
 import type { AuthStore } from "./auth-store";
@@ -18,6 +20,7 @@ import { createForumAdapter } from "./forum-adapter";
 import {
   deriveRequestOrigin,
   deriveRpId,
+  verifyPasskeyAuthentication,
   verifyPasskeyRegistration,
   WebAuthnVerificationError,
 } from "./webauthn";
@@ -585,6 +588,176 @@ async function routeRequest(
     return;
   }
 
+  if (method === "POST" && path === "/auth/authentications/start") {
+    const payload = await readJsonBody(req);
+    const input = parseStartAuthenticationInput(payload);
+    const session = await authStore.startAuthentication(input);
+
+    if (!session) {
+      sendError(
+        res,
+        corsHeaders,
+        404,
+        "passkey_authentication_not_available",
+        "No registered passkey was found for that handle.",
+      );
+      return;
+    }
+
+    sendJson(res, corsHeaders, 201, {
+      ok: true,
+      data: session,
+    });
+    return;
+  }
+
+  const passkeyAuthenticationOptionsMatch = matchPath(
+    path,
+    /^\/auth\/authentications\/([^/]+)\/passkey\/options$/,
+  );
+
+  if (method === "GET" && passkeyAuthenticationOptionsMatch) {
+    const authenticationSession = await authStore.getAuthenticationSession(passkeyAuthenticationOptionsMatch[1]);
+
+    if (!authenticationSession) {
+      sendError(
+        res,
+        corsHeaders,
+        404,
+        "authentication_session_not_found",
+        "Authentication session not found.",
+      );
+      return;
+    }
+
+    if (authenticationSession.status === "verified") {
+      sendError(
+        res,
+        corsHeaders,
+        409,
+        "authentication_session_not_pending",
+        "Authentication session has already been verified.",
+      );
+      return;
+    }
+
+    if (authenticationSession.status === "expired") {
+      sendError(
+        res,
+        corsHeaders,
+        409,
+        "authentication_session_expired",
+        "Authentication session has expired.",
+      );
+      return;
+    }
+
+    const options = await authStore.getPasskeyAuthenticationOptions(passkeyAuthenticationOptionsMatch[1]);
+
+    if (!options) {
+      sendError(
+        res,
+        corsHeaders,
+        404,
+        "authentication_session_not_found",
+        "Authentication session not found.",
+      );
+      return;
+    }
+
+    const requestOrigin = deriveRequestOrigin(req.headers.origin, url, {
+      forwardedHost: req.headers["x-forwarded-host"],
+      forwardedProto: req.headers["x-forwarded-proto"],
+      referer: req.headers.referer,
+    });
+
+    sendJson(res, corsHeaders, 200, {
+      ok: true,
+      data: {
+        ...options,
+        rpId: deriveRpId(requestOrigin),
+      },
+    });
+    return;
+  }
+
+  if (method === "POST" && path === "/auth/passkeys/authenticate") {
+    const payload = await readJsonBody(req);
+    const input = parseFinishAuthenticationInput(payload);
+    const authenticationSession = await authStore.getAuthenticationSession(input.authenticationSessionId);
+
+    if (!authenticationSession) {
+      sendError(
+        res,
+        corsHeaders,
+        404,
+        "authentication_session_not_found",
+        "Authentication session not found.",
+      );
+      return;
+    }
+
+    if (
+      authenticationSession.status !== "awaiting_authentication"
+      && authenticationSession.status !== "pending_webauthn_authentication"
+    ) {
+      sendError(
+        res,
+        corsHeaders,
+        409,
+        "authentication_session_not_pending",
+        authenticationSession.status === "expired"
+          ? "Authentication session has expired."
+          : "Authentication session has already been verified.",
+      );
+      return;
+    }
+
+    const passkeyCredential = await authStore.getPasskeyCredential(input.credential.id);
+
+    if (!passkeyCredential || passkeyCredential.handle !== authenticationSession.handle) {
+      sendError(
+        res,
+        corsHeaders,
+        404,
+        "passkey_credential_not_found",
+        "Passkey credential not found for this authentication request.",
+      );
+      return;
+    }
+
+    const requestOrigin = deriveRequestOrigin(req.headers.origin, url, {
+      forwardedHost: req.headers["x-forwarded-host"],
+      forwardedProto: req.headers["x-forwarded-proto"],
+      referer: req.headers.referer,
+    });
+    const session = await authStore.finishPasskeyAuthentication(
+      verifyPasskeyAuthentication(input, {
+        authenticationSession,
+        passkeyCredential,
+        expectedOrigin: requestOrigin,
+        expectedRpId: deriveRpId(requestOrigin),
+      }),
+    );
+
+    if (!session) {
+      sendError(
+        res,
+        corsHeaders,
+        404,
+        "authentication_session_not_found",
+        "Authentication session not found.",
+      );
+      return;
+    }
+
+    sendJson(res, corsHeaders, 200, {
+      ok: true,
+      data: session,
+    });
+    return;
+  }
+
   if (path.startsWith("/auth/")) {
     sendError(res, corsHeaders, 405, "method_not_allowed", "Method not allowed.");
     return;
@@ -730,6 +903,14 @@ function parseStartRegistrationInput(payload: unknown): StartRegistrationInput {
   };
 }
 
+function parseStartAuthenticationInput(payload: unknown): StartAuthenticationInput {
+  const input = asRecord(payload, "Request body must be an object.");
+
+  return {
+    handle: readRequiredString(input.handle, "handle"),
+  };
+}
+
 function parseFinishRegistrationInput(payload: unknown): FinishRegistrationInput {
   const input = asRecord(payload, "Request body must be an object.");
   const credential = asRecord(input.credential, "credential must be an object.");
@@ -782,6 +963,51 @@ function parseFinishRegistrationInput(payload: unknown): FinishRegistrationInput
   };
 }
 
+
+function parseFinishAuthenticationInput(payload: unknown): FinishAuthenticationInput {
+  const input = asRecord(payload, "Request body must be an object.");
+  const credential = asRecord(input.credential, "credential must be an object.");
+  const response = asRecord(credential.response, "credential.response must be an object.");
+  const credentialType = readRequiredString(credential.type, "credential.type");
+
+  if (credentialType !== "public-key") {
+    throw createHttpError(400, "validation_error", "credential.type must be public-key.");
+  }
+
+  const clientExtensionResults = readOptionalRecord(
+    credential.clientExtensionResults,
+    "credential.clientExtensionResults",
+  );
+
+  return {
+    authenticationSessionId: readRequiredString(
+      input.authenticationSessionId,
+      "authenticationSessionId",
+    ),
+    credential: {
+      id: readRequiredString(credential.id, "credential.id"),
+      rawId: readRequiredString(credential.rawId, "credential.rawId"),
+      type: "public-key",
+      response: {
+        authenticatorData: readRequiredString(
+          response.authenticatorData,
+          "credential.response.authenticatorData",
+        ),
+        clientDataJSON: readRequiredString(
+          response.clientDataJSON,
+          "credential.response.clientDataJSON",
+        ),
+        signature: readRequiredString(response.signature, "credential.response.signature"),
+        userHandle: readOptionalString(response.userHandle, "credential.response.userHandle"),
+      },
+      authenticatorAttachment: readOptionalString(
+        credential.authenticatorAttachment,
+        "credential.authenticatorAttachment",
+      ),
+      clientExtensionResults,
+    },
+  };
+}
 
 function parseCompleteRegistrationVerificationInput(
   payload: unknown,

--- a/apps/api/src/auth-store.ts
+++ b/apps/api/src/auth-store.ts
@@ -1,10 +1,22 @@
 import type {
+  AuthenticationSession,
   CompleteRegistrationVerificationInput,
+  PasskeyAuthenticationOptions,
   PasskeyRegistrationOptions,
   RedeemPairingInput,
   RegistrationSession,
+  StartAuthenticationInput,
   StartRegistrationInput,
 } from "@theagentforum/core";
+
+export interface StoredPasskeyCredential {
+  handle: string;
+  credentialId: string;
+  publicKey: string;
+  signCount: number;
+  label?: string;
+  transports?: string[];
+}
 
 export interface VerifiedPasskeyRegistration {
   registrationSessionId: string;
@@ -13,6 +25,14 @@ export interface VerifiedPasskeyRegistration {
   verificationMethod: string;
   passkeyLabel?: string;
   transports?: string[];
+}
+
+export interface VerifiedPasskeyAuthentication {
+  authenticationSessionId: string;
+  credentialId: string;
+  verificationMethod: string;
+  signCount: number;
+  passkeyLabel?: string;
 }
 
 export interface AuthStore {
@@ -30,4 +50,13 @@ export interface AuthStore {
     input: CompleteRegistrationVerificationInput,
   ): Promise<RegistrationSession | null>;
   redeemPairing(input: RedeemPairingInput): Promise<RegistrationSession | null>;
+  startAuthentication(input: StartAuthenticationInput): Promise<AuthenticationSession | null>;
+  getAuthenticationSession(authenticationSessionId: string): Promise<AuthenticationSession | null>;
+  getPasskeyAuthenticationOptions(
+    authenticationSessionId: string,
+  ): Promise<PasskeyAuthenticationOptions | null>;
+  getPasskeyCredential(credentialId: string): Promise<StoredPasskeyCredential | null>;
+  finishPasskeyAuthentication(
+    input: VerifiedPasskeyAuthentication,
+  ): Promise<AuthenticationSession | null>;
 }

--- a/apps/api/src/http.webauthn.test.ts
+++ b/apps/api/src/http.webauthn.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { createHash } from "node:crypto";
+import { createHash, generateKeyPairSync, sign as signWithKey } from "node:crypto";
 import { Readable } from "node:stream";
 import { describe, it } from "node:test";
 import { createApp } from "./app";
@@ -156,7 +156,468 @@ describe("HTTP API - WebAuthn registration", () => {
     assert.equal(rejected.body.error.code, "webauthn_verification_failed");
     assert.match(rejected.body.error.message, /challenge/i);
   });
+
+  it("authenticates a returning user with a registered passkey", async () => {
+    const app = createTestApp();
+    const fixture = createPasskeyFixture();
+
+    const started = await requestJson(app, "/auth/registrations/start", {
+      method: "POST",
+      body: {
+        handle: "felix796",
+        displayName: "Felix",
+      },
+    });
+
+    const registrationId = started.body.data.id as string;
+    const registrationOptions = await requestJson(app, `/auth/registrations/${registrationId}/passkey/options`, {
+      headers: {
+        origin: "http://localhost:5173",
+      },
+    });
+
+    const registered = await requestJson(app, "/auth/passkeys/register", {
+      method: "POST",
+      headers: {
+        origin: "http://localhost:5173",
+      },
+      body: {
+        registrationSessionId: registrationId,
+        credential: fixture.createRegistrationCredential({
+          challenge: registrationOptions.body.data.challenge,
+          origin: "http://localhost:5173",
+          rpId: "localhost",
+        }),
+        passkeyLabel: "Felix MacBook Passkey",
+      },
+    });
+
+    assert.equal(registered.status, 200);
+
+    const startedAuthentication = await requestJson(app, "/auth/authentications/start", {
+      method: "POST",
+      body: {
+        handle: "felix796",
+      },
+    });
+
+    assert.equal(startedAuthentication.status, 201);
+    const authenticationSessionId = startedAuthentication.body.data.id as string;
+
+    const authenticationOptions = await requestJson(
+      app,
+      `/auth/authentications/${authenticationSessionId}/passkey/options`,
+      {
+        headers: {
+          origin: "http://localhost:5173",
+        },
+      },
+    );
+
+    assert.equal(authenticationOptions.status, 200);
+    assert.equal(authenticationOptions.body.data.rpId, "localhost");
+    assert.equal(authenticationOptions.body.data.userVerification, "required");
+    assert.deepEqual(authenticationOptions.body.data.allowCredentials, [
+      {
+        id: fixture.credentialId,
+        type: "public-key",
+        transports: ["internal"],
+      },
+    ]);
+
+    const authenticated = await requestJson(app, "/auth/passkeys/authenticate", {
+      method: "POST",
+      headers: {
+        origin: "http://localhost:5173",
+      },
+      body: {
+        authenticationSessionId,
+        credential: fixture.createAuthenticationCredential({
+          challenge: authenticationOptions.body.data.challenge,
+          origin: "http://localhost:5173",
+          rpId: "localhost",
+          signCount: 1,
+        }),
+      },
+    });
+
+    assert.equal(authenticated.status, 200);
+    assert.equal(authenticated.body.data.status, "verified");
+    assert.equal(authenticated.body.data.handle, "felix796");
+    assert.equal(authenticated.body.data.displayName, "Felix");
+    assert.equal(authenticated.body.data.verificationMethod, "webauthn");
+    assert.equal(authenticated.body.data.passkeyLabel, "Felix MacBook Passkey");
+    assert.ok(authenticated.body.data.verifiedAt);
+  });
+
+  it("rejects a passkey authentication assertion whose challenge does not match", async () => {
+    const app = createTestApp();
+    const fixture = createPasskeyFixture();
+
+    const started = await requestJson(app, "/auth/registrations/start", {
+      method: "POST",
+      body: {
+        handle: "felix-auth-mismatch",
+      },
+    });
+
+    const registrationId = started.body.data.id as string;
+    const registrationOptions = await requestJson(app, `/auth/registrations/${registrationId}/passkey/options`, {
+      headers: {
+        origin: "http://localhost:5173",
+      },
+    });
+
+    await requestJson(app, "/auth/passkeys/register", {
+      method: "POST",
+      headers: {
+        origin: "http://localhost:5173",
+      },
+      body: {
+        registrationSessionId: registrationId,
+        credential: fixture.createRegistrationCredential({
+          challenge: registrationOptions.body.data.challenge,
+          origin: "http://localhost:5173",
+          rpId: "localhost",
+        }),
+      },
+    });
+
+    const startedAuthentication = await requestJson(app, "/auth/authentications/start", {
+      method: "POST",
+      body: {
+        handle: "felix-auth-mismatch",
+      },
+    });
+
+    const authenticationSessionId = startedAuthentication.body.data.id as string;
+    const authenticationOptions = await requestJson(
+      app,
+      `/auth/authentications/${authenticationSessionId}/passkey/options`,
+      {
+        headers: {
+          origin: "http://localhost:5173",
+        },
+      },
+    );
+
+    const rejected = await requestJson(app, "/auth/passkeys/authenticate", {
+      method: "POST",
+      headers: {
+        origin: "http://localhost:5173",
+      },
+      body: {
+        authenticationSessionId,
+        credential: fixture.createAuthenticationCredential({
+          challenge: `${authenticationOptions.body.data.challenge}-wrong`,
+          origin: "http://localhost:5173",
+          rpId: "localhost",
+          signCount: 1,
+        }),
+      },
+    });
+
+    assert.equal(rejected.status, 400);
+    assert.equal(rejected.body.ok, false);
+    assert.equal(rejected.body.error.code, "webauthn_verification_failed");
+    assert.match(rejected.body.error.message, /challenge/i);
+  });
+
+  it("does not offer passkey sign-in for manual internal verification scaffolds", async () => {
+    const app = createTestApp();
+
+    const started = await requestJson(app, "/auth/registrations/start", {
+      method: "POST",
+      body: {
+        handle: "manual-only",
+      },
+    });
+
+    const registrationId = started.body.data.id as string;
+    const verified = await requestJson(app, `/auth/registrations/${registrationId}/verify`, {
+      method: "POST",
+      body: {
+        passkeyLabel: "Internal fallback only",
+      },
+    });
+
+    assert.equal(verified.status, 200);
+    assert.equal(verified.body.data.verificationMethod, "manual_internal");
+
+    const startedAuthentication = await requestJson(app, "/auth/authentications/start", {
+      method: "POST",
+      body: {
+        handle: "manual-only",
+      },
+    });
+
+    assert.equal(startedAuthentication.status, 404);
+    assert.equal(startedAuthentication.body.ok, false);
+    assert.equal(startedAuthentication.body.error.code, "passkey_authentication_not_available");
+  });
+
+  it("rejects a passkey authentication assertion without user verification", async () => {
+    const app = createTestApp();
+    const fixture = createPasskeyFixture();
+
+    const started = await requestJson(app, "/auth/registrations/start", {
+      method: "POST",
+      body: {
+        handle: "felix-no-uv",
+      },
+    });
+
+    const registrationId = started.body.data.id as string;
+    const registrationOptions = await requestJson(app, `/auth/registrations/${registrationId}/passkey/options`, {
+      headers: {
+        origin: "http://localhost:5173",
+      },
+    });
+
+    await requestJson(app, "/auth/passkeys/register", {
+      method: "POST",
+      headers: {
+        origin: "http://localhost:5173",
+      },
+      body: {
+        registrationSessionId: registrationId,
+        credential: fixture.createRegistrationCredential({
+          challenge: registrationOptions.body.data.challenge,
+          origin: "http://localhost:5173",
+          rpId: "localhost",
+        }),
+      },
+    });
+
+    const startedAuthentication = await requestJson(app, "/auth/authentications/start", {
+      method: "POST",
+      body: {
+        handle: "felix-no-uv",
+      },
+    });
+
+    const authenticationSessionId = startedAuthentication.body.data.id as string;
+    const authenticationOptions = await requestJson(
+      app,
+      `/auth/authentications/${authenticationSessionId}/passkey/options`,
+      {
+        headers: {
+          origin: "http://localhost:5173",
+        },
+      },
+    );
+
+    assert.equal(authenticationOptions.body.data.userVerification, "required");
+
+    const rejected = await requestJson(app, "/auth/passkeys/authenticate", {
+      method: "POST",
+      headers: {
+        origin: "http://localhost:5173",
+      },
+      body: {
+        authenticationSessionId,
+        credential: fixture.createAuthenticationCredential({
+          challenge: authenticationOptions.body.data.challenge,
+          origin: "http://localhost:5173",
+          rpId: "localhost",
+          signCount: 1,
+          userVerified: false,
+        }),
+      },
+    });
+
+    assert.equal(rejected.status, 400);
+    assert.equal(rejected.body.ok, false);
+    assert.equal(rejected.body.error.code, "webauthn_verification_failed");
+    assert.match(rejected.body.error.message, /user verification/i);
+  });
+
+  it("rejects reusing an authentication session after it has been verified", async () => {
+    const app = createTestApp();
+    const fixture = createPasskeyFixture();
+
+    const started = await requestJson(app, "/auth/registrations/start", {
+      method: "POST",
+      body: {
+        handle: "felix-reuse",
+      },
+    });
+
+    const registrationId = started.body.data.id as string;
+    const registrationOptions = await requestJson(app, `/auth/registrations/${registrationId}/passkey/options`, {
+      headers: {
+        origin: "http://localhost:5173",
+      },
+    });
+
+    await requestJson(app, "/auth/passkeys/register", {
+      method: "POST",
+      headers: {
+        origin: "http://localhost:5173",
+      },
+      body: {
+        registrationSessionId: registrationId,
+        credential: fixture.createRegistrationCredential({
+          challenge: registrationOptions.body.data.challenge,
+          origin: "http://localhost:5173",
+          rpId: "localhost",
+        }),
+      },
+    });
+
+    const startedAuthentication = await requestJson(app, "/auth/authentications/start", {
+      method: "POST",
+      body: {
+        handle: "felix-reuse",
+      },
+    });
+
+    const authenticationSessionId = startedAuthentication.body.data.id as string;
+    const authenticationOptions = await requestJson(
+      app,
+      `/auth/authentications/${authenticationSessionId}/passkey/options`,
+      {
+        headers: {
+          origin: "http://localhost:5173",
+        },
+      },
+    );
+
+    const credential = fixture.createAuthenticationCredential({
+      challenge: authenticationOptions.body.data.challenge,
+      origin: "http://localhost:5173",
+      rpId: "localhost",
+      signCount: 1,
+    });
+
+    const authenticated = await requestJson(app, "/auth/passkeys/authenticate", {
+      method: "POST",
+      headers: {
+        origin: "http://localhost:5173",
+      },
+      body: {
+        authenticationSessionId,
+        credential,
+      },
+    });
+
+    assert.equal(authenticated.status, 200);
+
+    const reused = await requestJson(app, "/auth/passkeys/authenticate", {
+      method: "POST",
+      headers: {
+        origin: "http://localhost:5173",
+      },
+      body: {
+        authenticationSessionId,
+        credential,
+      },
+    });
+
+    assert.equal(reused.status, 409);
+    assert.equal(reused.body.ok, false);
+    assert.equal(reused.body.error.code, "authentication_session_not_pending");
+  });
 });
+
+function createPasskeyFixture() {
+  const credentialId = Buffer.from("cred-felix-1", "utf8");
+  const { privateKey, publicKey } = generateKeyPairSync("ec", { namedCurve: "prime256v1" });
+  const publicJwk = publicKey.export({ format: "jwk" }) as JsonWebKey;
+  const x = decodeBase64UrlSegment(publicJwk.x);
+  const y = decodeBase64UrlSegment(publicJwk.y);
+  const spki = publicKey.export({ format: "der", type: "spki" });
+  const credentialPublicKey = encodeCbor(
+    new Map<unknown, unknown>([
+      [1, 2],
+      [3, -7],
+      [-1, 1],
+      [-2, x],
+      [-3, y],
+    ]),
+  );
+
+  return {
+    credentialId: toBase64Url(credentialId),
+    createRegistrationCredential(input: { challenge: string; origin: string; rpId: string }) {
+      const authData = Buffer.concat([
+        sha256(input.rpId),
+        Buffer.from([0x41]),
+        Buffer.alloc(4),
+        Buffer.alloc(16),
+        Buffer.from([0x00, credentialId.length]),
+        credentialId,
+        credentialPublicKey,
+      ]);
+      const clientDataJSON = Buffer.from(
+        JSON.stringify({
+          type: "webauthn.create",
+          challenge: input.challenge,
+          origin: input.origin,
+        }),
+        "utf8",
+      );
+      const attestationObject = encodeCbor(
+        new Map<unknown, unknown>([
+          ["fmt", "none"],
+          ["attStmt", new Map()],
+          ["authData", authData],
+        ]),
+      );
+
+      return {
+        id: toBase64Url(credentialId),
+        rawId: toBase64Url(credentialId),
+        type: "public-key",
+        response: {
+          clientDataJSON: toBase64Url(clientDataJSON),
+          attestationObject: toBase64Url(attestationObject),
+          publicKey: toBase64Url(spki),
+          publicKeyAlgorithm: -7,
+          transports: ["internal"],
+        },
+      };
+    },
+    createAuthenticationCredential(input: {
+      challenge: string;
+      origin: string;
+      rpId: string;
+      signCount: number;
+      userVerified?: boolean;
+    }) {
+      const authenticatorData = Buffer.concat([
+        sha256(input.rpId),
+        Buffer.from([input.userVerified === false ? 0x01 : 0x05]),
+        encodeUint32(input.signCount),
+      ]);
+      const clientDataJSON = Buffer.from(
+        JSON.stringify({
+          type: "webauthn.get",
+          challenge: input.challenge,
+          origin: input.origin,
+        }),
+        "utf8",
+      );
+      const clientDataHash = createHash("sha256").update(clientDataJSON).digest();
+      const signature = signWithKey(
+        "sha256",
+        Buffer.concat([authenticatorData, clientDataHash]),
+        privateKey,
+      );
+
+      return {
+        id: toBase64Url(credentialId),
+        rawId: toBase64Url(credentialId),
+        type: "public-key",
+        response: {
+          authenticatorData: toBase64Url(authenticatorData),
+          clientDataJSON: toBase64Url(clientDataJSON),
+          signature: toBase64Url(signature),
+        },
+      };
+    },
+  };
+}
 
 function createRegistrationCredential(input: {
   challenge: string;
@@ -285,6 +746,22 @@ function encodeCborHeader(majorType: number, value: number): Buffer {
 
 function sha256(value: string): Buffer {
   return createHash("sha256").update(value, "utf8").digest();
+}
+
+function encodeUint32(value: number): Buffer {
+  const buffer = Buffer.alloc(4);
+  buffer.writeUInt32BE(value);
+  return buffer;
+}
+
+function decodeBase64UrlSegment(value: string | undefined): Buffer {
+  if (!value) {
+    throw new Error("Expected a base64url-encoded JWK coordinate.");
+  }
+
+  const normalized = value.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, "=");
+  return Buffer.from(padded, "base64");
 }
 
 function toBase64Url(value: Uint8Array): string {

--- a/apps/api/src/memory-auth-store.ts
+++ b/apps/api/src/memory-auth-store.ts
@@ -1,17 +1,26 @@
 import { randomBytes } from "node:crypto";
 import type {
+  AuthenticationSession,
   CompleteRegistrationVerificationInput,
   PairingSession,
+  PasskeyAuthenticationOptions,
   PasskeyRegistrationOptions,
   RedeemPairingInput,
   RegistrationSession,
+  StartAuthenticationInput,
   StartRegistrationInput,
 } from "@theagentforum/core";
-import type { AuthStore, VerifiedPasskeyRegistration } from "./auth-store";
+import type {
+  AuthStore,
+  StoredPasskeyCredential,
+  VerifiedPasskeyAuthentication,
+  VerifiedPasskeyRegistration,
+} from "./auth-store";
 
 interface StoredCredential {
   credentialId: string;
   publicKey: string;
+  signCount: number;
   label?: string;
   transports?: string[];
 }
@@ -32,11 +41,26 @@ interface StoredRegistrationSession {
   pairing: PairingSession;
 }
 
+interface StoredAuthenticationSession {
+  id: string;
+  handle: string;
+  displayName?: string;
+  status: AuthenticationSession["status"];
+  challenge: string;
+  verificationMethod?: string;
+  passkeyLabel?: string;
+  createdAt: string;
+  expiresAt: string;
+  verifiedAt?: string;
+}
+
 export function createInMemoryAuthStore(): AuthStore {
   const registrationSessions = new Map<string, StoredRegistrationSession>();
+  const authenticationSessions = new Map<string, StoredAuthenticationSession>();
   const credentialsByHandle = new Map<string, StoredCredential[]>();
   let registrationSequence = 1;
   let pairingSequence = 1;
+  let authenticationSequence = 1;
 
   async function startRegistration(input: StartRegistrationInput): Promise<RegistrationSession> {
     const createdAt = new Date().toISOString();
@@ -77,7 +101,7 @@ export function createInMemoryAuthStore(): AuthStore {
       return null;
     }
 
-    expireSessionIfNeeded(session);
+    expireRegistrationSessionIfNeeded(session);
     return cloneRegistrationSession(session);
   }
 
@@ -92,7 +116,7 @@ export function createInMemoryAuthStore(): AuthStore {
       return null;
     }
 
-    expireSessionIfNeeded(session);
+    expireRegistrationSessionIfNeeded(session);
     return cloneRegistrationSession(session);
   }
 
@@ -105,7 +129,7 @@ export function createInMemoryAuthStore(): AuthStore {
       return null;
     }
 
-    expireSessionIfNeeded(session);
+    expireRegistrationSessionIfNeeded(session);
 
     if (session.status === "expired") {
       return null;
@@ -147,7 +171,7 @@ export function createInMemoryAuthStore(): AuthStore {
       return null;
     }
 
-    expireSessionIfNeeded(session);
+    expireRegistrationSessionIfNeeded(session);
 
     if (session.status === "expired") {
       return cloneRegistrationSession(session);
@@ -156,13 +180,21 @@ export function createInMemoryAuthStore(): AuthStore {
     const verifiedAt = new Date().toISOString();
     const label = input.passkeyLabel?.trim() || `${session.handle} passkey`;
     const credentials = credentialsByHandle.get(session.handle) ?? [];
+    const existingCredential = credentials.find((credential) => credential.credentialId === input.credentialId);
 
-    credentials.push({
-      credentialId: input.credentialId,
-      publicKey: input.publicKey,
-      label,
-      transports: input.transports,
-    });
+    if (existingCredential) {
+      existingCredential.publicKey = input.publicKey;
+      existingCredential.label = label;
+      existingCredential.transports = input.transports;
+    } else {
+      credentials.push({
+        credentialId: input.credentialId,
+        publicKey: input.publicKey,
+        signCount: 0,
+        label,
+        transports: input.transports,
+      });
+    }
     credentialsByHandle.set(session.handle, credentials);
 
     session.status = "verified";
@@ -178,13 +210,25 @@ export function createInMemoryAuthStore(): AuthStore {
     registrationSessionId: string,
     input: CompleteRegistrationVerificationInput,
   ): Promise<RegistrationSession | null> {
-    return finishPasskeyRegistration({
-      registrationSessionId,
-      credentialId: `manual-${registrationSessionId}`,
-      publicKey: JSON.stringify({ source: "manual_internal" }),
-      verificationMethod: "manual_internal",
-      passkeyLabel: input.passkeyLabel,
-    });
+    const session = registrationSessions.get(registrationSessionId);
+
+    if (!session) {
+      return null;
+    }
+
+    expireRegistrationSessionIfNeeded(session);
+
+    if (session.status === "expired") {
+      return cloneRegistrationSession(session);
+    }
+
+    session.status = "verified";
+    session.verificationMethod = "manual_internal";
+    session.passkeyLabel = input.passkeyLabel.trim();
+    session.verifiedAt = new Date().toISOString();
+    session.pairing.status = "ready_to_pair";
+
+    return cloneRegistrationSession(session);
   }
 
   async function redeemPairing(input: RedeemPairingInput): Promise<RegistrationSession | null> {
@@ -196,7 +240,7 @@ export function createInMemoryAuthStore(): AuthStore {
       return null;
     }
 
-    expireSessionIfNeeded(session);
+    expireRegistrationSessionIfNeeded(session);
 
     if (session.pairing.status !== "ready_to_pair") {
       return cloneRegistrationSession(session);
@@ -210,6 +254,139 @@ export function createInMemoryAuthStore(): AuthStore {
     return cloneRegistrationSession(session);
   }
 
+  async function startAuthentication(
+    input: StartAuthenticationInput,
+  ): Promise<AuthenticationSession | null> {
+    const credentials = (credentialsByHandle.get(input.handle) ?? []).filter(isAuthenticatablePasskey);
+
+    if (credentials.length === 0) {
+      return null;
+    }
+
+    const createdAt = new Date().toISOString();
+    const expiresAt = new Date(Date.now() + 15 * 60 * 1000).toISOString();
+    const latestRegistration = Array.from(registrationSessions.values())
+      .filter((candidate) => candidate.handle === input.handle)
+      .sort((left, right) => right.createdAt.localeCompare(left.createdAt))[0];
+
+    const session: StoredAuthenticationSession = {
+      id: `aas-${authenticationSequence++}`,
+      handle: input.handle,
+      displayName: latestRegistration?.displayName,
+      status: "awaiting_authentication",
+      challenge: createChallenge(),
+      createdAt,
+      expiresAt,
+    };
+
+    authenticationSessions.set(session.id, session);
+    return cloneAuthenticationSession(session);
+  }
+
+  async function getAuthenticationSession(
+    authenticationSessionId: string,
+  ): Promise<AuthenticationSession | null> {
+    const session = authenticationSessions.get(authenticationSessionId);
+
+    if (!session) {
+      return null;
+    }
+
+    expireAuthenticationSessionIfNeeded(session);
+    return cloneAuthenticationSession(session);
+  }
+
+  async function getPasskeyAuthenticationOptions(
+    authenticationSessionId: string,
+  ): Promise<PasskeyAuthenticationOptions | null> {
+    const session = authenticationSessions.get(authenticationSessionId);
+
+    if (!session) {
+      return null;
+    }
+
+    expireAuthenticationSessionIfNeeded(session);
+
+    if (session.status === "expired") {
+      return null;
+    }
+
+    const credentials = (credentialsByHandle.get(session.handle) ?? []).filter(isAuthenticatablePasskey);
+    if (credentials.length === 0) {
+      return null;
+    }
+
+    session.status = session.status === "verified" ? session.status : "pending_webauthn_authentication";
+
+    return {
+      authenticationSessionId: session.id,
+      challenge: session.challenge,
+      rpId: "theagentforum.local",
+      allowCredentials: credentials.map((credential) => ({
+        id: credential.credentialId,
+        type: "public-key" as const,
+        ...(credential.transports && credential.transports.length > 0
+          ? { transports: credential.transports }
+          : {}),
+      })),
+      timeout: 60000,
+      userVerification: "required",
+    };
+  }
+
+  async function getPasskeyCredential(
+    credentialId: string,
+  ): Promise<StoredPasskeyCredential | null> {
+    for (const [handle, credentials] of credentialsByHandle.entries()) {
+      const credential = credentials.find((candidate) => candidate.credentialId === credentialId);
+      if (credential) {
+        return {
+          handle,
+          credentialId: credential.credentialId,
+          publicKey: credential.publicKey,
+          signCount: credential.signCount,
+          label: credential.label,
+          transports: credential.transports,
+        };
+      }
+    }
+
+    return null;
+  }
+
+  async function finishPasskeyAuthentication(
+    input: VerifiedPasskeyAuthentication,
+  ): Promise<AuthenticationSession | null> {
+    const session = authenticationSessions.get(input.authenticationSessionId);
+
+    if (!session) {
+      return null;
+    }
+
+    expireAuthenticationSessionIfNeeded(session);
+
+    if (session.status === "expired") {
+      return cloneAuthenticationSession(session);
+    }
+
+    const credentials = credentialsByHandle.get(session.handle) ?? [];
+    const credential = credentials.find((candidate) => candidate.credentialId === input.credentialId);
+
+    if (!credential) {
+      return null;
+    }
+
+    credential.signCount = input.signCount;
+    const verifiedAt = new Date().toISOString();
+
+    session.status = "verified";
+    session.verificationMethod = input.verificationMethod;
+    session.passkeyLabel = input.passkeyLabel ?? credential.label;
+    session.verifiedAt = verifiedAt;
+
+    return cloneAuthenticationSession(session);
+  }
+
   return {
     startRegistration,
     getRegistrationSession,
@@ -218,6 +395,11 @@ export function createInMemoryAuthStore(): AuthStore {
     finishPasskeyRegistration,
     completeRegistrationVerification,
     redeemPairing,
+    startAuthentication,
+    getAuthenticationSession,
+    getPasskeyAuthenticationOptions,
+    getPasskeyCredential,
+    finishPasskeyAuthentication,
   };
 }
 
@@ -233,7 +415,7 @@ function createToken(): string {
   return `taf_${randomBytes(18).toString("base64url")}`;
 }
 
-function expireSessionIfNeeded(session: StoredRegistrationSession): void {
+function expireRegistrationSessionIfNeeded(session: StoredRegistrationSession): void {
   const now = Date.now();
 
   if (session.status !== "expired" && Date.parse(session.expiresAt) <= now) {
@@ -245,9 +427,31 @@ function expireSessionIfNeeded(session: StoredRegistrationSession): void {
   }
 }
 
+function expireAuthenticationSessionIfNeeded(session: StoredAuthenticationSession): void {
+  if (
+    session.status !== "expired"
+    && session.status !== "verified"
+    && Date.parse(session.expiresAt) <= Date.now()
+  ) {
+    session.status = "expired";
+  }
+}
+
+function isAuthenticatablePasskey(credential: StoredCredential): boolean {
+  return !credential.credentialId.startsWith("manual-");
+}
+
 function cloneRegistrationSession(session: StoredRegistrationSession): RegistrationSession {
   return {
     ...session,
     pairing: { ...session.pairing },
+  };
+}
+
+function cloneAuthenticationSession(
+  session: StoredAuthenticationSession,
+): AuthenticationSession {
+  return {
+    ...session,
   };
 }

--- a/apps/api/src/postgres-auth-store.ts
+++ b/apps/api/src/postgres-auth-store.ts
@@ -1,13 +1,21 @@
 import { randomBytes } from "node:crypto";
 import type {
+  AuthenticationSession,
   CompleteRegistrationVerificationInput,
+  PasskeyAuthenticationOptions,
   PasskeyRegistrationOptions,
   RedeemPairingInput,
   RegistrationSession,
+  StartAuthenticationInput,
   StartRegistrationInput,
 } from "@theagentforum/core";
 import { runSql } from "./postgres";
-import type { AuthStore, VerifiedPasskeyRegistration } from "./auth-store";
+import type {
+  AuthStore,
+  StoredPasskeyCredential,
+  VerifiedPasskeyAuthentication,
+  VerifiedPasskeyRegistration,
+} from "./auth-store";
 
 export function createPostgresAuthStore(): AuthStore {
   return {
@@ -18,6 +26,11 @@ export function createPostgresAuthStore(): AuthStore {
     finishPasskeyRegistration,
     completeRegistrationVerification,
     redeemPairing,
+    startAuthentication,
+    getAuthenticationSession,
+    getPasskeyAuthenticationOptions,
+    getPasskeyCredential,
+    finishPasskeyAuthentication,
   };
 }
 
@@ -240,13 +253,57 @@ async function completeRegistrationVerification(
   registrationSessionId: string,
   input: CompleteRegistrationVerificationInput,
 ): Promise<RegistrationSession | null> {
-  return finishPasskeyRegistration({
-    registrationSessionId,
-    credentialId: `manual-${registrationSessionId}`,
-    publicKey: JSON.stringify({ source: "manual_internal" }),
-    verificationMethod: "manual_internal",
-    passkeyLabel: input.passkeyLabel,
-  });
+  await expireRegistrationSession(registrationSessionId);
+
+  const output = await runSql(
+    `
+      with updated_registration as (
+        update auth_registration_sessions
+        set
+          status = case
+            when expires_at <= now() then 'expired'
+            else 'verified'
+          end,
+          verification_method = case
+            when expires_at <= now() then verification_method
+            else 'manual_internal'
+          end,
+          passkey_label = case
+            when expires_at <= now() then passkey_label
+            else :'passkey_label'
+          end,
+          verified_at = case
+            when expires_at <= now() then verified_at
+            else now()
+          end,
+          updated_at = now()
+        where id = :'registration_session_id'
+        returning *
+      ),
+      updated_pairing as (
+        update auth_pairing_sessions
+        set
+          status = case
+            when status = 'paired' then status
+            when expires_at <= now() then 'expired'
+            when exists (select 1 from updated_registration where status = 'verified') then 'ready_to_pair'
+            else status
+          end,
+          updated_at = now()
+        where registration_session_id = :'registration_session_id'
+        returning *
+      )
+      select ${registrationSessionSelect("updated_registration", "updated_pairing")} :: text
+      from updated_registration
+      join updated_pairing on updated_pairing.registration_session_id = updated_registration.id;
+    `,
+    {
+      registration_session_id: registrationSessionId,
+      passkey_label: input.passkeyLabel,
+    },
+  );
+
+  return output ? (JSON.parse(output) as RegistrationSession) : null;
 }
 
 async function redeemPairing(input: RedeemPairingInput): Promise<RegistrationSession | null> {
@@ -296,6 +353,188 @@ async function redeemPairing(input: RedeemPairingInput): Promise<RegistrationSes
   );
 
   return output ? (JSON.parse(output) as RegistrationSession) : null;
+}
+
+async function startAuthentication(
+  input: StartAuthenticationInput,
+): Promise<AuthenticationSession | null> {
+  const output = await runSql(
+    `
+      with matched_account as (
+        select a.id, a.handle, a.display_name
+        from auth_accounts a
+        where a.handle = :'handle'
+          and exists (
+            select 1
+            from auth_passkey_credentials c
+            where c.account_id = a.id
+              and c.credential_id not like 'manual-%'
+          )
+      ),
+      created_authentication as (
+        insert into auth_authentication_sessions (
+          account_id,
+          handle,
+          display_name,
+          challenge
+        )
+        select
+          matched_account.id,
+          matched_account.handle,
+          matched_account.display_name,
+          :'challenge'
+        from matched_account
+        returning *
+      )
+      select ${authenticationSessionSelect("created_authentication")} :: text
+      from created_authentication;
+    `,
+    {
+      handle: input.handle,
+      challenge: createChallenge(),
+    },
+  );
+
+  return output ? (JSON.parse(output) as AuthenticationSession) : null;
+}
+
+async function getAuthenticationSession(
+  authenticationSessionId: string,
+): Promise<AuthenticationSession | null> {
+  await expireAuthenticationSession(authenticationSessionId);
+  const output = await selectAuthenticationSession(authenticationSessionId);
+  return output ? (JSON.parse(output) as AuthenticationSession) : null;
+}
+
+async function getPasskeyAuthenticationOptions(
+  authenticationSessionId: string,
+): Promise<PasskeyAuthenticationOptions | null> {
+  await expireAuthenticationSession(authenticationSessionId);
+
+  const output = await runSql(
+    `
+      with updated_authentication as (
+        update auth_authentication_sessions
+        set
+          status = case
+            when status = 'verified' then status
+            when expires_at <= now() then 'expired'
+            else 'pending_webauthn_authentication'
+          end,
+          updated_at = now()
+        where id = :'authentication_session_id'
+        returning *
+      )
+      select json_build_object(
+        'authenticationSessionId', updated_authentication.id,
+        'challenge', updated_authentication.challenge,
+        'rpId', 'theagentforum.local',
+        'allowCredentials', coalesce(
+          json_agg(
+            json_strip_nulls(json_build_object(
+              'id', c.credential_id,
+              'type', 'public-key',
+              'transports', c.transports
+            ))
+          ) filter (where c.id is not null),
+          '[]'::json
+        ),
+        'timeout', 60000,
+        'userVerification', 'required'
+      ) :: text
+      from updated_authentication
+      left join auth_passkey_credentials c
+        on c.account_id = updated_authentication.account_id
+       and c.credential_id not like 'manual-%'
+      where updated_authentication.status <> 'expired'
+      group by updated_authentication.id, updated_authentication.challenge;
+    `,
+    {
+      authentication_session_id: authenticationSessionId,
+    },
+  );
+
+  return output ? (JSON.parse(output) as PasskeyAuthenticationOptions) : null;
+}
+
+async function getPasskeyCredential(
+  credentialId: string,
+): Promise<StoredPasskeyCredential | null> {
+  const output = await runSql(
+    `
+      select json_build_object(
+        'handle', a.handle,
+        'credentialId', c.credential_id,
+        'publicKey', c.public_key,
+        'signCount', c.sign_count,
+        'label', c.label,
+        'transports', c.transports
+      ) :: text
+      from auth_passkey_credentials c
+      join auth_accounts a on a.id = c.account_id
+      where c.credential_id = :'credential_id'
+        and c.credential_id not like 'manual-%';
+    `,
+    {
+      credential_id: credentialId,
+    },
+  );
+
+  return output ? (JSON.parse(output) as StoredPasskeyCredential) : null;
+}
+
+async function finishPasskeyAuthentication(
+  input: VerifiedPasskeyAuthentication,
+): Promise<AuthenticationSession | null> {
+  await expireAuthenticationSession(input.authenticationSessionId);
+
+  const output = await runSql(
+    `
+      with updated_credential as (
+        update auth_passkey_credentials
+        set
+          sign_count = greatest(sign_count, :'sign_count'::bigint),
+          last_used_at = now()
+        where credential_id = :'credential_id'
+        returning id
+      ),
+      updated_authentication as (
+        update auth_authentication_sessions
+        set
+          status = case
+            when expires_at <= now() then 'expired'
+            else 'verified'
+          end,
+          verification_method = case
+            when expires_at <= now() then verification_method
+            else :'verification_method'
+          end,
+          passkey_label = case
+            when expires_at <= now() then passkey_label
+            else nullif(:'passkey_label', '')
+          end,
+          verified_at = case
+            when expires_at <= now() then verified_at
+            else now()
+          end,
+          updated_at = now()
+        where id = :'authentication_session_id'
+        returning *
+      )
+      select ${authenticationSessionSelect("updated_authentication")} :: text
+      from updated_authentication
+      where exists (select 1 from updated_credential);
+    `,
+    {
+      authentication_session_id: input.authenticationSessionId,
+      credential_id: input.credentialId,
+      sign_count: String(input.signCount),
+      verification_method: input.verificationMethod,
+      passkey_label: input.passkeyLabel ?? "",
+    },
+  );
+
+  return output ? (JSON.parse(output) as AuthenticationSession) : null;
 }
 
 async function expireRegistrationSession(registrationSessionId: string): Promise<void> {
@@ -353,6 +592,21 @@ async function expireRegistrationSessionByVerificationToken(
   );
 }
 
+async function expireAuthenticationSession(authenticationSessionId: string): Promise<void> {
+  await runSql(
+    `
+      update auth_authentication_sessions
+      set
+        status = 'expired',
+        updated_at = now()
+      where id = :'authentication_session_id'
+        and status <> 'verified'
+        and expires_at <= now();
+    `,
+    { authentication_session_id: authenticationSessionId },
+  );
+}
+
 async function selectRegistrationSession(registrationSessionId: string): Promise<string> {
   return runSql(
     `
@@ -363,6 +617,17 @@ async function selectRegistrationSession(registrationSessionId: string): Promise
       where r.id = :'registration_session_id';
     `,
     { registration_session_id: registrationSessionId },
+  );
+}
+
+async function selectAuthenticationSession(authenticationSessionId: string): Promise<string> {
+  return runSql(
+    `
+      select ${authenticationSessionSelect("a")} :: text
+      from auth_authentication_sessions a
+      where a.id = :'authentication_session_id';
+    `,
+    { authentication_session_id: authenticationSessionId },
   );
 }
 
@@ -403,6 +668,24 @@ function registrationSessionSelect(
   )`;
 }
 
+function authenticationSessionSelect(authenticationAlias: string): string {
+  return `json_build_object(
+    'id', ${authenticationAlias}.id,
+    'handle', ${authenticationAlias}.handle,
+    'displayName', ${authenticationAlias}.display_name,
+    'status', ${authenticationAlias}.status,
+    'challenge', ${authenticationAlias}.challenge,
+    'verificationMethod', ${authenticationAlias}.verification_method,
+    'passkeyLabel', ${authenticationAlias}.passkey_label,
+    'createdAt', to_char(${authenticationAlias}.created_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+    'expiresAt', to_char(${authenticationAlias}.expires_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+    'verifiedAt', case
+      when ${authenticationAlias}.verified_at is null then null
+      else to_char(${authenticationAlias}.verified_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+    end
+  )`;
+}
+
 async function queryJson<T>(sql: string, variables?: Record<string, string>): Promise<T> {
   const output = await runSql(sql, variables);
   return JSON.parse(output) as T;
@@ -419,4 +702,3 @@ function createPairingCode(): string {
 function createToken(): string {
   return `taf_${randomBytes(18).toString("base64url")}`;
 }
-

--- a/apps/api/src/webauthn.ts
+++ b/apps/api/src/webauthn.ts
@@ -1,13 +1,30 @@
-import { createHash, timingSafeEqual } from "node:crypto";
+import {
+  createHash,
+  createPublicKey,
+  timingSafeEqual,
+  verify as verifySignature,
+} from "node:crypto";
 import type {
+  AuthenticationSession,
+  FinishAuthenticationInput,
   FinishRegistrationInput,
   RegistrationSession,
-  WebAuthnCredentialPayload,
 } from "@theagentforum/core";
-import type { VerifiedPasskeyRegistration } from "./auth-store";
+import type {
+  StoredPasskeyCredential,
+  VerifiedPasskeyAuthentication,
+  VerifiedPasskeyRegistration,
+} from "./auth-store";
 
 interface WebAuthnVerificationContext {
   registrationSession: RegistrationSession;
+  expectedOrigin: string;
+  expectedRpId: string;
+}
+
+interface WebAuthnAuthenticationVerificationContext {
+  authenticationSession: AuthenticationSession;
+  passkeyCredential: StoredPasskeyCredential;
   expectedOrigin: string;
   expectedRpId: string;
 }
@@ -18,6 +35,12 @@ interface AuthenticatorData {
   signCount: number;
   credentialId: Buffer;
   credentialPublicKey: Buffer;
+}
+
+interface AssertionAuthenticatorData {
+  rpIdHash: Buffer;
+  flags: number;
+  signCount: number;
 }
 
 export class WebAuthnVerificationError extends Error {
@@ -95,10 +118,98 @@ export function verifyPasskeyRegistration(
   };
 }
 
+export function verifyPasskeyAuthentication(
+  input: FinishAuthenticationInput,
+  context: WebAuthnAuthenticationVerificationContext,
+): VerifiedPasskeyAuthentication {
+  const credential = input.credential;
+
+  if (credential.type !== "public-key") {
+    throw new WebAuthnVerificationError("credential.type must be public-key.");
+  }
+
+  const rawIdBytes = decodeBase64Url(credential.rawId, "credential.rawId");
+  const credentialIdBytes = decodeBase64Url(credential.id, "credential.id");
+  const storedCredentialIdBytes = decodeBase64Url(
+    context.passkeyCredential.credentialId,
+    "stored credential ID",
+  );
+  assertBuffersEqual(rawIdBytes, credentialIdBytes, "credential.id must match credential.rawId.");
+  assertBuffersEqual(
+    storedCredentialIdBytes,
+    rawIdBytes,
+    "credential.rawId does not match the stored passkey credential.",
+  );
+
+  const clientData = parseClientData(credential.response.clientDataJSON);
+
+  if (clientData.type !== "webauthn.get") {
+    throw new WebAuthnVerificationError("clientDataJSON.type must be webauthn.get.");
+  }
+
+  if (clientData.challenge !== context.authenticationSession.challenge) {
+    throw new WebAuthnVerificationError("clientDataJSON.challenge does not match the pending authentication challenge.");
+  }
+
+  const expectedOrigin = normalizeOrigin(context.expectedOrigin);
+  const observedOrigin = normalizeOrigin(clientData.origin);
+
+  if (observedOrigin !== expectedOrigin) {
+    throw new WebAuthnVerificationError("clientDataJSON.origin does not match the browser origin that submitted this request.");
+  }
+
+  const authenticatorDataBytes = decodeBase64Url(
+    credential.response.authenticatorData,
+    "credential.response.authenticatorData",
+  );
+  const authenticatorData = parseAssertionAuthenticatorData(authenticatorDataBytes);
+
+  assertBuffersEqual(
+    authenticatorData.rpIdHash,
+    sha256(context.expectedRpId),
+    "authenticatorData.rpIdHash does not match the expected RP ID.",
+  );
+
+  if ((authenticatorData.flags & 0x01) === 0) {
+    throw new WebAuthnVerificationError("authenticatorData must indicate user presence.");
+  }
+
+  if ((authenticatorData.flags & 0x04) === 0) {
+    throw new WebAuthnVerificationError("authenticatorData must indicate user verification.");
+  }
+
+  if (
+    context.passkeyCredential.signCount > 0 &&
+    authenticatorData.signCount <= context.passkeyCredential.signCount
+  ) {
+    throw new WebAuthnVerificationError("authenticatorData.signCount did not increase from the stored passkey credential.");
+  }
+
+  const signature = decodeBase64Url(credential.response.signature, "credential.response.signature");
+  const signedPayload = Buffer.concat([
+    authenticatorDataBytes,
+    createHash("sha256").update(clientData.rawBytes).digest(),
+  ]);
+  const publicKey = parseStoredPublicKey(context.passkeyCredential.publicKey);
+
+  if (!verifySignature("sha256", signedPayload, publicKey, signature)) {
+    throw new WebAuthnVerificationError("credential.response.signature could not be verified with the stored passkey credential.");
+  }
+
+  return {
+    authenticationSessionId: input.authenticationSessionId,
+    credentialId: context.passkeyCredential.credentialId,
+    verificationMethod: "webauthn",
+    signCount: authenticatorData.signCount,
+    passkeyLabel: context.passkeyCredential.label,
+  };
+}
+
 function parseClientData(clientDataJsonBase64Url: string): {
   type: string;
   challenge: string;
   origin: string;
+  rawBytes: Buffer;
 } {
   const clientDataJsonBytes = decodeBase64Url(
     clientDataJsonBase64Url,
@@ -121,7 +232,7 @@ function parseClientData(clientDataJsonBase64Url: string): {
   const challenge = readRequiredString(clientData.challenge, "clientDataJSON.challenge");
   const origin = readRequiredString(clientData.origin, "clientDataJSON.origin");
 
-  return { type, challenge, origin };
+  return { type, challenge, origin, rawBytes: clientDataJsonBytes };
 }
 
 function parseAttestationObject(attestationObjectBase64Url: string): { authData: Buffer } {
@@ -182,6 +293,76 @@ function parseAuthenticatorData(authData: Buffer): AuthenticatorData {
     credentialId,
     credentialPublicKey,
   };
+}
+
+function parseAssertionAuthenticatorData(authData: Buffer): AssertionAuthenticatorData {
+  if (authData.length < 37) {
+    throw new WebAuthnVerificationError("authenticatorData is too short.");
+  }
+
+  return {
+    rpIdHash: authData.subarray(0, 32),
+    flags: authData[32] ?? 0,
+    signCount: authData.readUInt32BE(33),
+  };
+}
+
+function parseStoredPublicKey(publicKeyBase64Url: string) {
+  const publicKeyBytes = decodeBase64Url(publicKeyBase64Url, "stored passkey public key");
+
+  try {
+    return createPublicKey({
+      key: publicKeyBytes,
+      format: "der",
+      type: "spki",
+    });
+  } catch {
+    return createPublicKey({
+      key: parseCosePublicKeyToJwk(publicKeyBytes) as any,
+      format: "jwk",
+    });
+  }
+}
+
+function parseCosePublicKeyToJwk(publicKeyBytes: Buffer): JsonWebKey {
+  const decoded = decodeCbor(publicKeyBytes);
+
+  if (decoded.bytesRead !== publicKeyBytes.length) {
+    throw new WebAuthnVerificationError("Stored passkey public key contains trailing CBOR data.");
+  }
+
+  if (!decoded.value || typeof decoded.value !== "object" || Array.isArray(decoded.value)) {
+    throw new WebAuthnVerificationError("Stored passkey public key must decode to a CBOR map.");
+  }
+
+  const cose = decoded.value as Record<string, unknown>;
+  const keyType = readRequiredInteger(cose["1"], "stored passkey public key[1]");
+
+  if (keyType === 2) {
+    const curve = readRequiredInteger(cose["-1"], "stored passkey public key[-1]");
+    if (curve !== 1) {
+      throw new WebAuthnVerificationError("Only P-256 EC passkey public keys are supported.");
+    }
+
+    return {
+      kty: "EC",
+      crv: "P-256",
+      x: toBase64Url(readRequiredBuffer(cose["-2"], "stored passkey public key[-2]")),
+      y: toBase64Url(readRequiredBuffer(cose["-3"], "stored passkey public key[-3]")),
+      ext: true,
+    };
+  }
+
+  if (keyType === 3) {
+    return {
+      kty: "RSA",
+      n: toBase64Url(readRequiredBuffer(cose["-1"], "stored passkey public key[-1]")),
+      e: toBase64Url(readRequiredBuffer(cose["-2"], "stored passkey public key[-2]")),
+      ext: true,
+    };
+  }
+
+  throw new WebAuthnVerificationError("Unsupported stored passkey public key type.");
 }
 
 function decodeCbor(data: Buffer, offset = 0): { value: unknown; bytesRead: number } {
@@ -317,6 +498,22 @@ function readCborLength(
 function readRequiredString(value: unknown, fieldName: string): string {
   if (typeof value !== "string" || value.trim() === "") {
     throw new WebAuthnVerificationError(`${fieldName} must be a non-empty string.`);
+  }
+
+  return value;
+}
+
+function readRequiredInteger(value: unknown, fieldName: string): number {
+  if (typeof value !== "number" || !Number.isInteger(value)) {
+    throw new WebAuthnVerificationError(`${fieldName} must be an integer.`);
+  }
+
+  return value;
+}
+
+function readRequiredBuffer(value: unknown, fieldName: string): Buffer {
+  if (!Buffer.isBuffer(value)) {
+    throw new WebAuthnVerificationError(`${fieldName} must be a binary buffer.`);
   }
 
   return value;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -86,6 +86,12 @@ export type PairingStatus =
   | "paired"
   | "expired";
 
+export type AuthenticationStatus =
+  | "awaiting_authentication"
+  | "pending_webauthn_authentication"
+  | "verified"
+  | "expired";
+
 export interface PairingSession {
   id: string;
   code: string;
@@ -170,6 +176,55 @@ export interface PasskeyRegistrationOptions {
     residentKey: "preferred";
     userVerification: "preferred";
   };
+}
+
+export interface StartAuthenticationInput {
+  handle: string;
+}
+
+export interface WebAuthnAuthenticationCredentialPayload {
+  id: string;
+  rawId: string; // base64url
+  type: "public-key";
+  response: {
+    authenticatorData: string; // base64url
+    clientDataJSON: string; // base64url
+    signature: string; // base64url
+    userHandle?: string; // base64url
+  };
+  authenticatorAttachment?: string;
+  clientExtensionResults?: Record<string, unknown>;
+}
+
+export interface FinishAuthenticationInput {
+  authenticationSessionId: string;
+  credential: WebAuthnAuthenticationCredentialPayload;
+}
+
+export interface AuthenticationSession {
+  id: string;
+  handle: string;
+  displayName?: string;
+  status: AuthenticationStatus;
+  challenge: string;
+  verificationMethod?: string;
+  passkeyLabel?: string;
+  createdAt: string;
+  expiresAt: string;
+  verifiedAt?: string;
+}
+
+export interface PasskeyAuthenticationOptions {
+  authenticationSessionId: string;
+  challenge: string;
+  rpId: string;
+  allowCredentials: Array<{
+    id: string;
+    type: "public-key";
+    transports?: string[];
+  }>;
+  timeout: number;
+  userVerification: "required";
 }
 
 // Forum v2 model — additive to preserve v1 compatibility

--- a/packages/db/sql/001-init.sql
+++ b/packages/db/sql/001-init.sql
@@ -4,6 +4,7 @@ create sequence if not exists auth_registration_session_id_seq;
 create sequence if not exists auth_pairing_session_id_seq;
 create sequence if not exists auth_account_id_seq;
 create sequence if not exists auth_passkey_credential_id_seq;
+create sequence if not exists auth_authentication_session_id_seq;
 
 create table if not exists questions (
   id text primary key default ('q-' || nextval('question_id_seq')),
@@ -100,6 +101,29 @@ create table if not exists auth_passkey_credentials (
 
 create index if not exists auth_passkey_credentials_account_id_idx
   on auth_passkey_credentials (account_id, created_at);
+
+create table if not exists auth_authentication_sessions (
+  id text primary key default ('aas-' || nextval('auth_authentication_session_id_seq')),
+  account_id text not null references auth_accounts(id) on delete cascade,
+  handle text not null,
+  display_name text,
+  status text not null default 'awaiting_authentication',
+  challenge text not null,
+  verification_method text,
+  passkey_label text,
+  created_at timestamptz not null default now(),
+  expires_at timestamptz not null default (now() + interval '15 minutes'),
+  verified_at timestamptz,
+  updated_at timestamptz not null default now(),
+  constraint auth_authentication_sessions_status_check
+    check (status in ('awaiting_authentication', 'pending_webauthn_authentication', 'verified', 'expired'))
+);
+
+create index if not exists auth_authentication_sessions_account_id_idx
+  on auth_authentication_sessions (account_id, created_at);
+
+create index if not exists auth_authentication_sessions_handle_idx
+  on auth_authentication_sessions (handle, created_at);
 
 do $$
 begin


### PR DESCRIPTION
## Summary
- add a real returning-user passkey sign-in/assertion flow for TAF accounts
- verify WebAuthn assertions server-side and require user verification for login
- add authentication session models/routes/store support across memory and Postgres paths
- reject manual/internal fallback scaffolds from passkey sign-in eligibility and block auth-session reuse

## Test Plan
- npm run validate

## Links
- Closes #49
- Part of #40
- Informed by #41
