### PR TITLE
feat(auth): add web sessions and protect writes

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -29,24 +29,22 @@ interface CreateAppOptions {
   corsAllowOrigin?: string;
 }
 
+const SESSION_COOKIE_NAME = "taf_session";
+
 export function createApp(
   questionStore: QuestionStore,
   authStore: AuthStore,
   options: CreateAppOptions = {},
 ) {
   const corsAllowOrigin = options.corsAllowOrigin ?? "*";
-  const corsHeaders = {
-    "access-control-allow-origin": corsAllowOrigin,
-    "access-control-allow-methods": "GET,POST,OPTIONS",
-    "access-control-allow-headers": "content-type",
-  };
-
   const forumStore: ForumStore = createForumAdapter(questionStore);
 
   return async function app(
     req: IncomingMessage,
     res: ServerResponse,
   ): Promise<void> {
+    const corsHeaders = buildCorsHeaders(corsAllowOrigin, req.headers.origin);
+
     try {
       await routeRequest(questionStore, authStore, forumStore, req, res, corsHeaders);
     } catch (error) {
@@ -83,6 +81,8 @@ async function routeRequest(
   const method = req.method ?? "GET";
   const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
   const path = url.pathname;
+  const sessionToken = readCookie(req.headers.cookie, SESSION_COOKIE_NAME);
+  const webSession = sessionToken ? await authStore.getWebSession(sessionToken) : null;
 
   if (method === "OPTIONS") {
     sendNoContent(res, corsHeaders);
@@ -101,6 +101,46 @@ async function routeRequest(
   }
 
   if (path === "/health") {
+    sendError(res, corsHeaders, 405, "method_not_allowed", "Method not allowed.");
+    return;
+  }
+
+  if (method === "GET" && path === "/auth/session") {
+    sendJson(res, corsHeaders, 200, {
+      ok: true,
+      data: webSession,
+    });
+    return;
+  }
+
+  if (path === "/auth/session") {
+    sendError(res, corsHeaders, 405, "method_not_allowed", "Method not allowed.");
+    return;
+  }
+
+  if (method === "POST" && path === "/auth/signout") {
+    if (sessionToken) {
+      await authStore.revokeWebSession(sessionToken);
+    }
+
+    sendJson(
+      res,
+      {
+        ...corsHeaders,
+        "set-cookie": serializeClearedSessionCookie(isSecureRequest(req, url)),
+      },
+      200,
+      {
+        ok: true,
+        data: {
+          signedOut: true,
+        },
+      },
+    );
+    return;
+  }
+
+  if (path === "/auth/signout") {
     sendError(res, corsHeaders, 405, "method_not_allowed", "Method not allowed.");
     return;
   }
@@ -304,7 +344,11 @@ async function routeRequest(
   if (method === "POST" && path === "/v2/contents") {
     const payload = await readJsonBody(req);
     const input = parseCreateContentInput(payload);
-    const content = await forumStore.createContent(input);
+    const actor = requireAuthenticatedActor(webSession);
+    const content = await forumStore.createContent({
+      ...input,
+      author: actor,
+    });
     sendJson(res, corsHeaders, 201, { ok: true, data: content });
     return;
   }
@@ -344,7 +388,11 @@ async function routeRequest(
   if (method === "POST" && commentsMatch) {
     const payload = await readJsonBody(req);
     const input = parseCreateCommentInput(payload);
-    const thread = await forumStore.createComment(commentsMatch[1], input);
+    const actor = requireAuthenticatedActor(webSession);
+    const thread = await forumStore.createComment(commentsMatch[1], {
+      ...input,
+      author: actor,
+    });
 
     if (!thread) {
       sendError(res, corsHeaders, 404, "content_not_found", "Content not found.");
@@ -361,6 +409,7 @@ async function routeRequest(
   );
 
   if (method === "POST" && acceptCommentMatch) {
+    requireAuthenticatedActor(webSession);
     const contentId = acceptCommentMatch[1];
     const commentId = acceptCommentMatch[2];
     const thread = await forumStore.acceptComment(contentId, commentId);
@@ -751,10 +800,35 @@ async function routeRequest(
       return;
     }
 
-    sendJson(res, corsHeaders, 200, {
-      ok: true,
-      data: session,
-    });
+    const issuedWebSession = await authStore.createWebSession(session.id);
+
+    if (!issuedWebSession) {
+      sendError(
+        res,
+        corsHeaders,
+        500,
+        "web_session_issue_failed",
+        "Web session could not be created after successful authentication.",
+      );
+      return;
+    }
+
+    sendJson(
+      res,
+      {
+        ...corsHeaders,
+        "set-cookie": serializeSessionCookie(
+          issuedWebSession.token,
+          issuedWebSession.expiresAt,
+          isSecureRequest(req, url),
+        ),
+      },
+      200,
+      {
+        ok: true,
+        data: session,
+      },
+    );
     return;
   }
 
@@ -803,6 +877,115 @@ function sendError(
       details,
     },
   });
+}
+
+function buildCorsHeaders(
+  configuredAllowOrigin: string,
+  requestOrigin: string | string[] | undefined,
+): Record<string, string> {
+  const origin = readFirstHeaderValue(requestOrigin);
+  const allowOrigin = configuredAllowOrigin === "*" && origin ? origin : configuredAllowOrigin;
+  const headers: Record<string, string> = {
+    "access-control-allow-origin": allowOrigin,
+    "access-control-allow-methods": "GET,POST,OPTIONS",
+    "access-control-allow-headers": "content-type,authorization",
+  };
+
+  if (origin) {
+    headers.vary = "Origin";
+  }
+
+  if (allowOrigin !== "*") {
+    headers["access-control-allow-credentials"] = "true";
+  }
+
+  return headers;
+}
+
+function requireAuthenticatedActor(webSession: { actor: Actor } | null): Actor {
+  if (!webSession) {
+    throw createHttpError(401, "authentication_required", "Authentication is required.");
+  }
+
+  return webSession.actor;
+}
+
+function readCookie(cookieHeader: string | string[] | undefined, name: string): string | undefined {
+  const rawCookieHeader = readFirstHeaderValue(cookieHeader);
+  if (!rawCookieHeader) {
+    return undefined;
+  }
+
+  for (const segment of rawCookieHeader.split(";")) {
+    const [cookieName, ...rest] = segment.trim().split("=");
+    if (cookieName === name) {
+      return rest.join("=");
+    }
+  }
+
+  return undefined;
+}
+
+function serializeSessionCookie(token: string, expiresAt: string, secure: boolean): string {
+  const maxAge = Math.max(0, Math.floor((Date.parse(expiresAt) - Date.now()) / 1000));
+  return [
+    `${SESSION_COOKIE_NAME}=${token}`,
+    "Path=/",
+    "HttpOnly",
+    "SameSite=Lax",
+    `Max-Age=${maxAge}`,
+    ...(secure ? ["Secure"] : []),
+  ].join("; ");
+}
+
+function serializeClearedSessionCookie(secure: boolean): string {
+  return [
+    `${SESSION_COOKIE_NAME}=`,
+    "Path=/",
+    "HttpOnly",
+    "SameSite=Lax",
+    "Max-Age=0",
+    ...(secure ? ["Secure"] : []),
+  ].join("; ");
+}
+
+function isSecureRequest(req: IncomingMessage, url: URL): boolean {
+  const forwardedProto = readFirstHeaderValue(req.headers["x-forwarded-proto"]);
+  if (forwardedProto) {
+    return forwardedProto === "https";
+  }
+
+  const requestOrigin = readFirstHeaderValue(req.headers.origin);
+  if (requestOrigin) {
+    return requestOrigin.startsWith("https://");
+  }
+
+  const referer = readFirstHeaderValue(req.headers.referer);
+  if (referer) {
+    return referer.startsWith("https://");
+  }
+
+  return url.protocol === "https:";
+}
+
+function readFirstHeaderValue(value: string | string[] | undefined): string | undefined {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const normalized = readFirstHeaderValue(item);
+      if (normalized) {
+        return normalized;
+      }
+    }
+    return undefined;
+  }
+
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const [first] = value.split(",", 1);
+  const normalized = first?.trim();
+  return normalized ? normalized : undefined;
 }
 
 async function readJsonBody(req: IncomingMessage): Promise<unknown> {
@@ -1030,15 +1213,7 @@ function parseRedeemPairingInput(payload: unknown): RedeemPairingInput {
 
 function parseActor(value: unknown): Actor {
   const actor = asRecord(value, "author must be an object.");
-  const displayName = actor.displayName;
-
-  if (displayName !== undefined && typeof displayName !== "string") {
-    throw createHttpError(
-      400,
-      "validation_error",
-      "author.displayName must be a string.",
-    );
-  }
+  const displayName = readOptionalString(actor.displayName, "author.displayName");
 
   const kind = readRequiredString(actor.kind, "author.kind");
 

--- a/apps/api/src/auth-store.ts
+++ b/apps/api/src/auth-store.ts
@@ -7,6 +7,7 @@ import type {
   RegistrationSession,
   StartAuthenticationInput,
   StartRegistrationInput,
+  WebSession,
 } from "@theagentforum/core";
 
 export interface StoredPasskeyCredential {
@@ -35,6 +36,10 @@ export interface VerifiedPasskeyAuthentication {
   passkeyLabel?: string;
 }
 
+export interface IssuedWebSession extends WebSession {
+  token: string;
+}
+
 export interface AuthStore {
   startRegistration(input: StartRegistrationInput): Promise<RegistrationSession>;
   getRegistrationSession(registrationSessionId: string): Promise<RegistrationSession | null>;
@@ -59,4 +64,7 @@ export interface AuthStore {
   finishPasskeyAuthentication(
     input: VerifiedPasskeyAuthentication,
   ): Promise<AuthenticationSession | null>;
+  createWebSession(authenticationSessionId: string): Promise<IssuedWebSession | null>;
+  getWebSession(token: string): Promise<WebSession | null>;
+  revokeWebSession(token: string): Promise<void>;
 }

--- a/apps/api/src/http.v2.test.ts
+++ b/apps/api/src/http.v2.test.ts
@@ -2,38 +2,58 @@ import assert from "node:assert/strict";
 import { Readable } from "node:stream";
 import { describe, it } from "node:test";
 import { createApp } from "./app";
+import type { AuthStore } from "./auth-store";
 import { createInMemoryAuthStore } from "./memory-auth-store";
 import { createInMemoryQuestionStore } from "./memory-question-store";
 
-const human = { id: "u-1", kind: "human" as const, handle: "felix" };
-const agent = { id: "a-1", kind: "agent" as const, handle: "pixel" };
+const spoofedHuman = { id: "u-1", kind: "human" as const, handle: "spoofed-human" };
+const spoofedAgent = { id: "a-1", kind: "agent" as const, handle: "spoofed-agent" };
 
 describe("HTTP API v2 forum", () => {
   it("serves content create->comment->accept flow for questions", async () => {
-    const app = createApp(createInMemoryQuestionStore(), createInMemoryAuthStore());
+    const authStore = createInMemoryAuthStore();
+    const app = createApp(createInMemoryQuestionStore(), authStore);
+    const cookieHeader = await createAuthenticatedCookie(authStore, {
+      handle: "felix",
+      displayName: "Felix",
+    });
 
     const created = await requestJson(app, "/v2/contents", {
       method: "POST",
-      body: { type: "question", title: "Title", body: "Body", author: human },
+      headers: {
+        cookie: cookieHeader,
+      },
+      body: { type: "question", title: "Title", body: "Body", author: spoofedHuman },
     });
 
     assert.equal(created.status, 201);
     assert.equal(created.body.data.type, "question");
+    assert.equal(created.body.data.author.handle, "felix");
+    assert.equal(created.body.data.author.kind, "human");
 
     const contentId = created.body.data.id;
 
     const commented = await requestJson(app, `/v2/contents/${contentId}/comments`, {
       method: "POST",
-      body: { body: "First comment", author: agent },
+      headers: {
+        cookie: cookieHeader,
+      },
+      body: { body: "First comment", author: spoofedAgent },
     });
     assert.equal(commented.status, 201);
     assert.equal(commented.body.data.content.id, contentId);
     assert.equal(commented.body.data.comments.length, 1);
+    assert.equal(commented.body.data.comments[0].author.handle, "felix");
 
     const accepted = await requestJson(
       app,
       `/v2/contents/${contentId}/accept/${commented.body.data.comments[0].id}`,
-      { method: "POST" },
+      {
+        method: "POST",
+        headers: {
+          cookie: cookieHeader,
+        },
+      },
     );
 
     assert.equal(accepted.status, 200);
@@ -47,15 +67,51 @@ describe("HTTP API v2 forum", () => {
   });
 });
 
+async function createAuthenticatedCookie(
+  authStore: AuthStore,
+  input: { handle: string; displayName: string },
+): Promise<string> {
+  const registration = await authStore.startRegistration(input);
+  const credentialId = `cred-${input.handle}`;
+
+  await authStore.finishPasskeyRegistration({
+    registrationSessionId: registration.id,
+    credentialId,
+    publicKey: "public-key",
+    verificationMethod: "webauthn",
+    passkeyLabel: `${input.displayName} Passkey`,
+    transports: ["internal"],
+  });
+
+  const authenticationSession = await authStore.startAuthentication({ handle: input.handle });
+  assert.ok(authenticationSession);
+
+  await authStore.finishPasskeyAuthentication({
+    authenticationSessionId: authenticationSession.id,
+    credentialId,
+    verificationMethod: "webauthn",
+    signCount: 1,
+    passkeyLabel: `${input.displayName} Passkey`,
+  });
+
+  const webSession = await authStore.createWebSession(authenticationSession.id);
+  assert.ok(webSession);
+  return `taf_session=${webSession.token}`;
+}
+
 async function requestJson(
   app: ReturnType<typeof createApp>,
   path: string,
-  init?: { method?: string; body?: unknown },
+  init?: { method?: string; body?: unknown; headers?: Record<string, string> },
 ): Promise<{ status: number; body: any }> {
   const request = Readable.from(init?.body ? [JSON.stringify(init.body)] : []) as any;
   request.method = init?.method ?? "GET";
   request.url = path;
-  request.headers = { host: "localhost", ...(init?.body ? { "content-type": "application/json" } : {}) };
+  request.headers = {
+    host: "localhost",
+    ...(init?.body ? { "content-type": "application/json" } : {}),
+    ...(init?.headers ?? {}),
+  };
 
   const response = createMockResponse();
   await app(request, response);
@@ -79,4 +135,3 @@ function createMockResponse() {
     },
   };
 }
-

--- a/apps/api/src/http.webauthn.test.ts
+++ b/apps/api/src/http.webauthn.test.ts
@@ -518,7 +518,255 @@ describe("HTTP API - WebAuthn registration", () => {
     assert.equal(reused.body.ok, false);
     assert.equal(reused.body.error.code, "authentication_session_not_pending");
   });
+
+  it("issues a web session cookie after successful passkey authentication and resolves the current session", async () => {
+    const app = createTestApp();
+
+    const signedIn = await signInWithPasskey(app, {
+      handle: "session-felix",
+      displayName: "Session Felix",
+    });
+
+    assert.equal(signedIn.authenticated.status, 200);
+    assert.ok(signedIn.setCookie);
+    assert.match(signedIn.setCookie, /taf_session=/);
+    assert.match(signedIn.setCookie, /HttpOnly/i);
+    assert.match(signedIn.setCookie, /Path=\//i);
+    assert.match(signedIn.setCookie, /SameSite=Lax/i);
+
+    const currentSession = await requestJson(app, "/auth/session", {
+      headers: {
+        cookie: signedIn.cookieHeader,
+      },
+    });
+
+    assert.equal(currentSession.status, 200);
+    assert.equal(currentSession.body.ok, true);
+    assert.equal(currentSession.body.data.actor.kind, "human");
+    assert.equal(currentSession.body.data.actor.handle, "session-felix");
+    assert.equal(currentSession.body.data.actor.displayName, "Session Felix");
+  });
+
+  it("requires a web session for protected v2 writes and attributes writes to the signed-in actor", async () => {
+    const app = createTestApp();
+
+    const anonymousCreate = await requestJson(app, "/v2/contents", {
+      method: "POST",
+      body: {
+        type: "question",
+        title: "Anonymous title",
+        body: "Anonymous body",
+        author: {
+          id: "spoofed-user",
+          kind: "agent",
+          handle: "spoofed",
+        },
+      },
+    });
+
+    assert.equal(anonymousCreate.status, 401);
+    assert.equal(anonymousCreate.body.ok, false);
+    assert.equal(anonymousCreate.body.error.code, "authentication_required");
+
+    const signedIn = await signInWithPasskey(app, {
+      handle: "writer-felix",
+      displayName: "Writer Felix",
+    });
+
+    const created = await requestJson(app, "/v2/contents", {
+      method: "POST",
+      headers: {
+        cookie: signedIn.cookieHeader,
+      },
+      body: {
+        type: "question",
+        title: "Signed in title",
+        body: "Signed in body",
+        author: {
+          id: "spoofed-user",
+          kind: "agent",
+          handle: "spoofed",
+        },
+      },
+    });
+
+    assert.equal(created.status, 201);
+    assert.equal(created.body.data.author.kind, "human");
+    assert.equal(created.body.data.author.handle, "writer-felix");
+    assert.equal(created.body.data.author.displayName, "Writer Felix");
+
+    const contentId = created.body.data.id as string;
+
+    const anonymousComment = await requestJson(app, `/v2/contents/${contentId}/comments`, {
+      method: "POST",
+      body: {
+        body: "Anonymous comment",
+        author: {
+          id: "spoofed-commenter",
+          kind: "agent",
+          handle: "spoofed-commenter",
+        },
+      },
+    });
+
+    assert.equal(anonymousComment.status, 401);
+    assert.equal(anonymousComment.body.error.code, "authentication_required");
+
+    const commented = await requestJson(app, `/v2/contents/${contentId}/comments`, {
+      method: "POST",
+      headers: {
+        cookie: signedIn.cookieHeader,
+      },
+      body: {
+        body: "Authenticated comment",
+        author: {
+          id: "spoofed-commenter",
+          kind: "agent",
+          handle: "spoofed-commenter",
+        },
+      },
+    });
+
+    assert.equal(commented.status, 201);
+    assert.equal(commented.body.data.comments[0].author.kind, "human");
+    assert.equal(commented.body.data.comments[0].author.handle, "writer-felix");
+
+    const commentId = commented.body.data.comments[0].id as string;
+
+    const anonymousAccept = await requestJson(app, `/v2/contents/${contentId}/accept/${commentId}`, {
+      method: "POST",
+    });
+
+    assert.equal(anonymousAccept.status, 401);
+    assert.equal(anonymousAccept.body.error.code, "authentication_required");
+
+    const accepted = await requestJson(app, `/v2/contents/${contentId}/accept/${commentId}`, {
+      method: "POST",
+      headers: {
+        cookie: signedIn.cookieHeader,
+      },
+    });
+
+    assert.equal(accepted.status, 200);
+    assert.equal(accepted.body.data.content.acceptedCommentId, commentId);
+  });
+
+  it("clears the active web session on sign-out", async () => {
+    const app = createTestApp();
+
+    const signedIn = await signInWithPasskey(app, {
+      handle: "signout-felix",
+      displayName: "Signout Felix",
+    });
+
+    const signedOut = await requestJson(app, "/auth/signout", {
+      method: "POST",
+      headers: {
+        cookie: signedIn.cookieHeader,
+      },
+    });
+
+    assert.equal(signedOut.status, 200);
+    assert.equal(signedOut.body.ok, true);
+    assert.ok(signedOut.headers["set-cookie"]);
+    assert.match(signedOut.headers["set-cookie"], /taf_session=/);
+    assert.match(signedOut.headers["set-cookie"], /Max-Age=0/i);
+
+    const currentSession = await requestJson(app, "/auth/session", {
+      headers: {
+        cookie: signedIn.cookieHeader,
+      },
+    });
+
+    assert.equal(currentSession.status, 200);
+    assert.equal(currentSession.body.ok, true);
+    assert.equal(currentSession.body.data, null);
+  });
 });
+
+async function signInWithPasskey(
+  app: ReturnType<typeof createTestApp>,
+  input: { handle: string; displayName: string },
+): Promise<{
+  authenticated: { status: number; body: any; headers: Record<string, string> };
+  setCookie: string;
+  cookieHeader: string;
+}> {
+  const fixture = createPasskeyFixture();
+
+  const started = await requestJson(app, "/auth/registrations/start", {
+    method: "POST",
+    body: input,
+  });
+
+  const registrationId = started.body.data.id as string;
+  const registrationOptions = await requestJson(app, `/auth/registrations/${registrationId}/passkey/options`, {
+    headers: {
+      origin: "http://localhost:5173",
+    },
+  });
+
+  await requestJson(app, "/auth/passkeys/register", {
+    method: "POST",
+    headers: {
+      origin: "http://localhost:5173",
+    },
+    body: {
+      registrationSessionId: registrationId,
+      credential: fixture.createRegistrationCredential({
+        challenge: registrationOptions.body.data.challenge,
+        origin: "http://localhost:5173",
+        rpId: "localhost",
+      }),
+      passkeyLabel: `${input.displayName} Passkey`,
+    },
+  });
+
+  const startedAuthentication = await requestJson(app, "/auth/authentications/start", {
+    method: "POST",
+    body: {
+      handle: input.handle,
+    },
+  });
+
+  const authenticationSessionId = startedAuthentication.body.data.id as string;
+  const authenticationOptions = await requestJson(
+    app,
+    `/auth/authentications/${authenticationSessionId}/passkey/options`,
+    {
+      headers: {
+        origin: "http://localhost:5173",
+      },
+    },
+  );
+
+  const authenticated = await requestJson(app, "/auth/passkeys/authenticate", {
+    method: "POST",
+    headers: {
+      origin: "http://localhost:5173",
+    },
+    body: {
+      authenticationSessionId,
+      credential: fixture.createAuthenticationCredential({
+        challenge: authenticationOptions.body.data.challenge,
+        origin: "http://localhost:5173",
+        rpId: "localhost",
+        signCount: 1,
+      }),
+    },
+  });
+
+  const setCookie = authenticated.headers["set-cookie"];
+  if (!setCookie) {
+    throw new Error("Expected a Set-Cookie header after successful authentication.");
+  }
+
+  return {
+    authenticated,
+    setCookie,
+    cookieHeader: setCookie.split(";", 1)[0],
+  };
+}
 
 function createPasskeyFixture() {
   const credentialId = Buffer.from("cred-felix-1", "utf8");
@@ -784,7 +1032,7 @@ async function requestJson(
     body?: unknown;
     headers?: Record<string, string>;
   },
-): Promise<{ status: number; body: any }> {
+): Promise<{ status: number; body: any; headers: Record<string, string> }> {
   const request = Readable.from(init?.body ? [JSON.stringify(init.body)] : []) as IncomingRequestLike;
   request.method = init?.method ?? "GET";
   request.url = path;
@@ -800,6 +1048,7 @@ async function requestJson(
   return {
     status: response.statusCode,
     body: JSON.parse(response.body),
+    headers: response.headers,
   };
 }
 

--- a/apps/api/src/memory-auth-store.ts
+++ b/apps/api/src/memory-auth-store.ts
@@ -1,5 +1,6 @@
 import { randomBytes } from "node:crypto";
 import type {
+  Actor,
   AuthenticationSession,
   CompleteRegistrationVerificationInput,
   PairingSession,
@@ -9,9 +10,11 @@ import type {
   RegistrationSession,
   StartAuthenticationInput,
   StartRegistrationInput,
+  WebSession,
 } from "@theagentforum/core";
 import type {
   AuthStore,
+  IssuedWebSession,
   StoredPasskeyCredential,
   VerifiedPasskeyAuthentication,
   VerifiedPasskeyRegistration,
@@ -54,15 +57,33 @@ interface StoredAuthenticationSession {
   verifiedAt?: string;
 }
 
+interface StoredAccount {
+  id: string;
+  handle: string;
+  displayName?: string;
+}
+
+interface StoredWebSession {
+  token: string;
+  actor: Actor;
+  createdAt: string;
+  expiresAt: string;
+  revokedAt?: string;
+}
+
 export function createInMemoryAuthStore(): AuthStore {
   const registrationSessions = new Map<string, StoredRegistrationSession>();
   const authenticationSessions = new Map<string, StoredAuthenticationSession>();
   const credentialsByHandle = new Map<string, StoredCredential[]>();
+  const accountsByHandle = new Map<string, StoredAccount>();
+  const webSessionsByToken = new Map<string, StoredWebSession>();
+  let accountSequence = 1;
   let registrationSequence = 1;
   let pairingSequence = 1;
   let authenticationSequence = 1;
 
   async function startRegistration(input: StartRegistrationInput): Promise<RegistrationSession> {
+    ensureAccount(input.handle, input.displayName);
     const createdAt = new Date().toISOString();
     const expiresAt = new Date(Date.now() + 15 * 60 * 1000).toISOString();
     const pairingExpiresAt = new Date(Date.now() + 30 * 60 * 1000).toISOString();
@@ -268,11 +289,12 @@ export function createInMemoryAuthStore(): AuthStore {
     const latestRegistration = Array.from(registrationSessions.values())
       .filter((candidate) => candidate.handle === input.handle)
       .sort((left, right) => right.createdAt.localeCompare(left.createdAt))[0];
+    const account = accountsByHandle.get(input.handle);
 
     const session: StoredAuthenticationSession = {
       id: `aas-${authenticationSequence++}`,
       handle: input.handle,
-      displayName: latestRegistration?.displayName,
+      displayName: latestRegistration?.displayName ?? account?.displayName,
       status: "awaiting_authentication",
       challenge: createChallenge(),
       createdAt,
@@ -387,6 +409,93 @@ export function createInMemoryAuthStore(): AuthStore {
     return cloneAuthenticationSession(session);
   }
 
+  async function createWebSession(authenticationSessionId: string): Promise<IssuedWebSession | null> {
+    const authenticationSession = authenticationSessions.get(authenticationSessionId);
+
+    if (!authenticationSession) {
+      return null;
+    }
+
+    expireAuthenticationSessionIfNeeded(authenticationSession);
+
+    if (authenticationSession.status !== "verified") {
+      return null;
+    }
+
+    const account = ensureAccount(authenticationSession.handle, authenticationSession.displayName);
+    const createdAt = new Date().toISOString();
+    const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+    const token = createWebSessionToken();
+    const session: StoredWebSession = {
+      token,
+      actor: {
+        id: account.id,
+        kind: "human",
+        handle: account.handle,
+        displayName: account.displayName,
+      },
+      createdAt,
+      expiresAt,
+    };
+
+    webSessionsByToken.set(token, session);
+    return {
+      token,
+      actor: { ...session.actor },
+      createdAt,
+      expiresAt,
+    };
+  }
+
+  async function getWebSession(token: string): Promise<WebSession | null> {
+    const session = webSessionsByToken.get(token);
+
+    if (!session) {
+      return null;
+    }
+
+    if (session.revokedAt || Date.parse(session.expiresAt) <= Date.now()) {
+      webSessionsByToken.delete(token);
+      return null;
+    }
+
+    return {
+      actor: { ...session.actor },
+      createdAt: session.createdAt,
+      expiresAt: session.expiresAt,
+    };
+  }
+
+  async function revokeWebSession(token: string): Promise<void> {
+    const session = webSessionsByToken.get(token);
+
+    if (!session) {
+      return;
+    }
+
+    session.revokedAt = new Date().toISOString();
+  }
+
+  function ensureAccount(handle: string, displayName?: string): StoredAccount {
+    const existing = accountsByHandle.get(handle);
+
+    if (existing) {
+      if (displayName && !existing.displayName) {
+        existing.displayName = displayName;
+      }
+
+      return existing;
+    }
+
+    const account: StoredAccount = {
+      id: `acct-${accountSequence++}`,
+      handle,
+      displayName,
+    };
+    accountsByHandle.set(handle, account);
+    return account;
+  }
+
   return {
     startRegistration,
     getRegistrationSession,
@@ -400,6 +509,9 @@ export function createInMemoryAuthStore(): AuthStore {
     getPasskeyAuthenticationOptions,
     getPasskeyCredential,
     finishPasskeyAuthentication,
+    createWebSession,
+    getWebSession,
+    revokeWebSession,
   };
 }
 
@@ -413,6 +525,10 @@ function createPairingCode(): string {
 
 function createToken(): string {
   return `taf_${randomBytes(18).toString("base64url")}`;
+}
+
+function createWebSessionToken(): string {
+  return `taf_ws_${randomBytes(24).toString("base64url")}`;
 }
 
 function expireRegistrationSessionIfNeeded(session: StoredRegistrationSession): void {

--- a/apps/api/src/postgres-auth-store.ts
+++ b/apps/api/src/postgres-auth-store.ts
@@ -8,10 +8,12 @@ import type {
   RegistrationSession,
   StartAuthenticationInput,
   StartRegistrationInput,
+  WebSession,
 } from "@theagentforum/core";
 import { runSql } from "./postgres";
 import type {
   AuthStore,
+  IssuedWebSession,
   StoredPasskeyCredential,
   VerifiedPasskeyAuthentication,
   VerifiedPasskeyRegistration,
@@ -31,6 +33,9 @@ export function createPostgresAuthStore(): AuthStore {
     getPasskeyAuthenticationOptions,
     getPasskeyCredential,
     finishPasskeyAuthentication,
+    createWebSession,
+    getWebSession,
+    revokeWebSession,
   };
 }
 
@@ -537,6 +542,60 @@ async function finishPasskeyAuthentication(
   return output ? (JSON.parse(output) as AuthenticationSession) : null;
 }
 
+async function createWebSession(authenticationSessionId: string): Promise<IssuedWebSession | null> {
+  await expireAuthenticationSession(authenticationSessionId);
+
+  const output = await runSql(
+    `
+      with created_web_session as (
+        insert into auth_web_sessions (account_id, authentication_session_id, token)
+        select a.account_id, a.id, :'token'
+        from auth_authentication_sessions a
+        where a.id = :'authentication_session_id'
+          and a.status = 'verified'
+          and a.expires_at > now()
+        returning *
+      )
+      select ${issuedWebSessionSelect("created_web_session", "acct")} :: text
+      from created_web_session
+      join auth_accounts acct on acct.id = created_web_session.account_id;
+    `,
+    {
+      authentication_session_id: authenticationSessionId,
+      token: createWebSessionToken(),
+    },
+  );
+
+  return output ? (JSON.parse(output) as IssuedWebSession) : null;
+}
+
+async function getWebSession(token: string): Promise<WebSession | null> {
+  const output = await runSql(
+    `
+      select ${webSessionSelect("ws", "acct")} :: text
+      from auth_web_sessions ws
+      join auth_accounts acct on acct.id = ws.account_id
+      where ws.token = :'token'
+        and ws.revoked_at is null
+        and ws.expires_at > now();
+    `,
+    { token },
+  );
+
+  return output ? (JSON.parse(output) as WebSession) : null;
+}
+
+async function revokeWebSession(token: string): Promise<void> {
+  await runSql(
+    `
+      update auth_web_sessions
+      set revoked_at = coalesce(revoked_at, now())
+      where token = :'token';
+    `,
+    { token },
+  );
+}
+
 async function expireRegistrationSession(registrationSessionId: string): Promise<void> {
   await runSql(
     `
@@ -686,6 +745,33 @@ function authenticationSessionSelect(authenticationAlias: string): string {
   )`;
 }
 
+function webSessionSelect(webSessionAlias: string, accountAlias: string): string {
+  return `json_build_object(
+    'actor', json_strip_nulls(json_build_object(
+      'id', ${accountAlias}.id,
+      'kind', 'human',
+      'handle', ${accountAlias}.handle,
+      'displayName', ${accountAlias}.display_name
+    )),
+    'createdAt', to_char(${webSessionAlias}.created_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+    'expiresAt', to_char(${webSessionAlias}.expires_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+  )`;
+}
+
+function issuedWebSessionSelect(webSessionAlias: string, accountAlias: string): string {
+  return `json_build_object(
+    'token', ${webSessionAlias}.token,
+    'actor', json_strip_nulls(json_build_object(
+      'id', ${accountAlias}.id,
+      'kind', 'human',
+      'handle', ${accountAlias}.handle,
+      'displayName', ${accountAlias}.display_name
+    )),
+    'createdAt', to_char(${webSessionAlias}.created_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+    'expiresAt', to_char(${webSessionAlias}.expires_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+  )`;
+}
+
 async function queryJson<T>(sql: string, variables?: Record<string, string>): Promise<T> {
   const output = await runSql(sql, variables);
   return JSON.parse(output) as T;
@@ -701,4 +787,8 @@ function createPairingCode(): string {
 
 function createToken(): string {
   return `taf_${randomBytes(18).toString("base64url")}`;
+}
+
+function createWebSessionToken(): string {
+  return `taf_ws_${randomBytes(24).toString("base64url")}`;
 }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,18 +1,23 @@
 import type {
   Answer,
   AnswerSkill,
+  AuthenticationSession,
   CompleteRegistrationVerificationInput,
   CreateAnswerInput,
   CreateQuestionInput,
+  FinishAuthenticationInput,
   FinishRegistrationInput,
+  PasskeyAuthenticationOptions,
   PasskeyRegistrationOptions,
   Question,
   SearchMatchSource,
   QuestionThread,
   RedeemPairingInput,
   RegistrationSession,
+  StartAuthenticationInput,
   StartRegistrationInput,
   ThreadSearchResult,
+  WebSession,
 } from "../types";
 
 interface ApiSuccess<T> {
@@ -235,6 +240,35 @@ export function createApiClient(baseUrl = defaultBaseUrl) {
     return request<RegistrationSession>("POST", "/auth/pairings/redeem", input);
   }
 
+  async function startAuthentication(
+    input: StartAuthenticationInput,
+  ): Promise<AuthenticationSession> {
+    return request<AuthenticationSession>("POST", "/auth/authentications/start", input);
+  }
+
+  async function getPasskeyAuthenticationOptions(
+    authenticationSessionId: string,
+  ): Promise<PasskeyAuthenticationOptions> {
+    return request<PasskeyAuthenticationOptions>(
+      "GET",
+      `/auth/authentications/${encodeURIComponent(authenticationSessionId)}/passkey/options`,
+    );
+  }
+
+  async function authenticatePasskey(
+    input: FinishAuthenticationInput,
+  ): Promise<AuthenticationSession> {
+    return request<AuthenticationSession>("POST", "/auth/passkeys/authenticate", input);
+  }
+
+  async function getAuthSession(): Promise<WebSession | null> {
+    return request<WebSession | null>("GET", "/auth/session");
+  }
+
+  async function signOut(): Promise<{ signedOut: boolean }> {
+    return request<{ signedOut: boolean }>("POST", "/auth/signout");
+  }
+
   async function request<T>(
     method: "GET" | "POST",
     path: string,
@@ -250,6 +284,7 @@ export function createApiClient(baseUrl = defaultBaseUrl) {
       method,
       headers: Object.keys(headers).length > 0 ? headers : undefined,
       body: body !== undefined ? JSON.stringify(body) : undefined,
+      credentials: "include",
     });
 
     const payload = (await response.json()) as ApiResponse<T>;
@@ -281,6 +316,11 @@ export function createApiClient(baseUrl = defaultBaseUrl) {
     registerPasskey,
     completeRegistrationVerification,
     redeemPairing,
+    startAuthentication,
+    getPasskeyAuthenticationOptions,
+    authenticatePasskey,
+    getAuthSession,
+    signOut,
   };
 }
 

--- a/apps/web/src/pages/AuthPage.test.tsx
+++ b/apps/web/src/pages/AuthPage.test.tsx
@@ -156,6 +156,117 @@ describe("AuthPage", () => {
       passkeyLabel: "Felix MacBook Passkey",
     });
   });
+
+  it("starts passkey sign-in and refreshes auth state after authentication succeeds", async () => {
+    const user = userEvent.setup();
+    const getCredential = vi.fn().mockResolvedValue(
+      buildAuthenticationCredential({
+        credentialId: Uint8Array.from([1, 2, 3, 4]),
+        clientDataJson: new TextEncoder().encode(
+          JSON.stringify({
+            type: "webauthn.get",
+            challenge: "AQIDBA",
+            origin: window.location.origin,
+          }),
+        ),
+        authenticatorData: Uint8Array.from([9, 8, 7, 6]),
+        signature: Uint8Array.from([4, 3, 2, 1]),
+      }),
+    );
+
+    Object.defineProperty(navigator, "credentials", {
+      configurable: true,
+      value: {
+        get: getCredential,
+      },
+    });
+
+    const onAuthStateChange = vi.fn().mockResolvedValue(undefined);
+    const api = {
+      listQuestions: vi.fn(),
+      searchThreads: vi.fn(),
+      createQuestion: vi.fn(),
+      getQuestionThread: vi.fn(),
+      createAnswer: vi.fn(),
+      acceptAnswer: vi.fn(),
+      listAnswerSkills: vi.fn(),
+      startRegistration: vi.fn(),
+      getRegistrationSession: vi.fn(),
+      resolveRegistrationSession: vi.fn(),
+      getPasskeyRegistrationOptions: vi.fn(),
+      registerPasskey: vi.fn(),
+      completeRegistrationVerification: vi.fn(),
+      redeemPairing: vi.fn(),
+      startAuthentication: vi.fn().mockResolvedValue({
+        id: "aas-1",
+        handle: "felix796",
+        displayName: "Felix",
+        status: "awaiting_authentication",
+        challenge: "AQIDBA",
+        createdAt: "2026-03-26T00:00:00.000Z",
+        expiresAt: "2026-03-26T00:15:00.000Z",
+      }),
+      getPasskeyAuthenticationOptions: vi.fn().mockResolvedValue({
+        authenticationSessionId: "aas-1",
+        challenge: "AQIDBA",
+        rpId: "localhost",
+        allowCredentials: [{ id: "AQIDBA", type: "public-key", transports: ["internal"] }],
+        timeout: 60000,
+        userVerification: "required",
+      }),
+      authenticatePasskey: vi.fn().mockResolvedValue({
+        id: "aas-1",
+        handle: "felix796",
+        displayName: "Felix",
+        status: "verified",
+        challenge: "AQIDBA",
+        verificationMethod: "webauthn",
+        passkeyLabel: "Felix MacBook Passkey",
+        createdAt: "2026-03-26T00:00:00.000Z",
+        expiresAt: "2026-03-26T00:15:00.000Z",
+        verifiedAt: "2026-03-26T00:01:00.000Z",
+      }),
+    } as unknown as ApiClient;
+
+    render(
+      <MemoryRouter initialEntries={["/auth"]}>
+        <AuthPage api={api} onAuthStateChange={onAuthStateChange} />
+      </MemoryRouter>,
+    );
+
+    await user.type(screen.getByLabelText("Handle for sign-in"), "felix796");
+    await user.click(screen.getByRole("button", { name: "Sign in with passkey" }));
+
+    await waitFor(() => {
+      expect(getCredential).toHaveBeenCalledTimes(1);
+      expect(onAuthStateChange).toHaveBeenCalledTimes(1);
+    });
+
+    expect(api.startAuthentication).toHaveBeenCalledWith({ handle: "felix796" });
+    expect(api.authenticatePasskey).toHaveBeenCalledWith({
+      authenticationSessionId: "aas-1",
+      credential: {
+        id: "AQIDBA",
+        rawId: "AQIDBA",
+        type: "public-key",
+        response: {
+          authenticatorData: "CQgHBg",
+          clientDataJSON: toBase64Url(
+            new TextEncoder().encode(
+              JSON.stringify({
+                type: "webauthn.get",
+                challenge: "AQIDBA",
+                origin: window.location.origin,
+              }),
+            ),
+          ),
+          signature: "BAMCAQ",
+        },
+        authenticatorAttachment: "platform",
+        clientExtensionResults: { credProps: { rk: true } },
+      },
+    });
+  });
 });
 
 function buildRegistrationSession() {
@@ -193,6 +304,28 @@ function buildCredential(input: {
     getPublicKey: () => input.publicKey.buffer.slice(0),
     getPublicKeyAlgorithm: () => input.publicKeyAlgorithm,
     getTransports: () => input.transports,
+  };
+
+  return {
+    id: toBase64Url(input.credentialId),
+    rawId: input.credentialId.buffer.slice(0),
+    type: "public-key",
+    response,
+    authenticatorAttachment: "platform",
+    getClientExtensionResults: () => ({ credProps: { rk: true } }),
+  } as unknown as PublicKeyCredential;
+}
+
+function buildAuthenticationCredential(input: {
+  credentialId: Uint8Array;
+  clientDataJson: Uint8Array;
+  authenticatorData: Uint8Array;
+  signature: Uint8Array;
+}) {
+  const response = {
+    clientDataJSON: input.clientDataJson.buffer.slice(0),
+    authenticatorData: input.authenticatorData.buffer.slice(0),
+    signature: input.signature.buffer.slice(0),
   };
 
   return {

--- a/apps/web/src/pages/AuthPage.tsx
+++ b/apps/web/src/pages/AuthPage.tsx
@@ -1,17 +1,21 @@
 import { useEffect, useMemo, useState } from "react";
-import { Link, useSearchParams } from "react-router-dom";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import { ApiClientError, type ApiClient } from "../lib/api";
 import type {
+  FinishAuthenticationInput,
   FinishRegistrationInput,
+  PasskeyAuthenticationOptions,
   PasskeyRegistrationOptions,
   RegistrationSession,
 } from "../types";
 
 interface AuthPageProps {
   api: ApiClient;
+  onAuthStateChange?: () => Promise<void> | void;
 }
 
-export function AuthPage({ api }: AuthPageProps) {
+export function AuthPage({ api, onAuthStateChange }: AuthPageProps) {
+  const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const registrationParam = searchParams.get("registration") ?? "";
   const [registrationSession, setRegistrationSession] = useState<RegistrationSession | null>(null);
@@ -20,6 +24,8 @@ export function AuthPage({ api }: AuthPageProps) {
   const [loadingSession, setLoadingSession] = useState(false);
   const [creatingPasskey, setCreatingPasskey] = useState(false);
   const [redeeming, setRedeeming] = useState(false);
+  const [signingIn, setSigningIn] = useState(false);
+  const [signInHandle, setSignInHandle] = useState("");
   const [passkeyLabel, setPasskeyLabel] = useState("This device passkey");
   const [copiedField, setCopiedField] = useState<string | null>(null);
 
@@ -137,6 +143,36 @@ export function AuthPage({ api }: AuthPageProps) {
     }
   }
 
+  async function handleSignIn(): Promise<void> {
+    const trimmedHandle = signInHandle.trim();
+    if (!trimmedHandle) {
+      setError("Handle is required for sign-in.");
+      return;
+    }
+
+    setSigningIn(true);
+    setError(null);
+
+    try {
+      const authenticationSession = await api.startAuthentication({
+        handle: trimmedHandle,
+      });
+      const options = await api.getPasskeyAuthenticationOptions(authenticationSession.id);
+      const credential = await createBrowserAuthenticationCredential(options);
+
+      await api.authenticatePasskey({
+        authenticationSessionId: authenticationSession.id,
+        credential,
+      });
+      await onAuthStateChange?.();
+      navigate("/");
+    } catch (cause) {
+      setError(readErrorMessage(cause));
+    } finally {
+      setSigningIn(false);
+    }
+  }
+
   async function handleRedeem(formData: FormData): Promise<void> {
     if (!registrationSession) {
       return;
@@ -190,6 +226,37 @@ export function AuthPage({ api }: AuthPageProps) {
 
       {error ? <p className="error">{error}</p> : null}
       {loadingSession ? <p className="muted">Loading registration session...</p> : null}
+
+      <section className="card stack">
+        <div>
+          <p className="eyebrow">Returning user</p>
+          <h2>Sign in with your passkey</h2>
+          <p className="muted">
+            Already registered a passkey? Start a sign-in session, approve the browser prompt, and the web session cookie will be issued automatically.
+          </p>
+        </div>
+
+        <form
+          className="stack"
+          onSubmit={(event) => {
+            event.preventDefault();
+            void handleSignIn();
+          }}
+        >
+          <label className="stack">
+            <span>Handle for sign-in</span>
+            <input
+              value={signInHandle}
+              onChange={(event) => setSignInHandle(event.target.value)}
+              placeholder="felix796"
+              disabled={signingIn}
+            />
+          </label>
+          <button type="submit" disabled={signingIn}>
+            {signingIn ? "Signing in..." : "Sign in with passkey"}
+          </button>
+        </form>
+      </section>
 
       <section className="card stack auth-guide-card">
         <div>
@@ -427,6 +494,19 @@ type BrowserCredentialWithAttestation = {
   getClientExtensionResults?: () => AuthenticationExtensionsClientOutputs;
 };
 
+type BrowserCredentialWithAssertion = {
+  id: string;
+  rawId: ArrayBuffer;
+  response: {
+    authenticatorData: ArrayBuffer;
+    clientDataJSON: ArrayBuffer;
+    signature: ArrayBuffer;
+    userHandle?: ArrayBuffer | null;
+  };
+  authenticatorAttachment?: string | null;
+  getClientExtensionResults?: () => AuthenticationExtensionsClientOutputs;
+};
+
 async function createBrowserCredential(
   options: PasskeyRegistrationOptions,
 ): Promise<FinishRegistrationInput["credential"]> {
@@ -477,6 +557,57 @@ async function createBrowserCredential(
       ...(publicKey ? { publicKey: toBase64Url(new Uint8Array(publicKey)) } : {}),
       ...(typeof publicKeyAlgorithm === "number" ? { publicKeyAlgorithm } : {}),
       ...(transports && transports.length > 0 ? { transports } : {}),
+    },
+    authenticatorAttachment: credential.authenticatorAttachment ?? undefined,
+    clientExtensionResults: credential.getClientExtensionResults?.() as Record<string, unknown> | undefined,
+  };
+}
+
+async function createBrowserAuthenticationCredential(
+  options: PasskeyAuthenticationOptions,
+): Promise<FinishAuthenticationInput["credential"]> {
+  const credentials = navigator.credentials;
+
+  if (!credentials?.get || typeof window.PublicKeyCredential === "undefined") {
+    throw new Error("This browser does not support WebAuthn passkey sign-in.");
+  }
+
+  const fetched = await credentials.get({
+    publicKey: {
+      challenge: toArrayBuffer(decodeMaybeBase64Url(options.challenge)),
+      rpId: options.rpId,
+      allowCredentials: options.allowCredentials.map((credential) => ({
+        id: toArrayBuffer(decodeMaybeBase64Url(credential.id)),
+        type: credential.type,
+        ...(credential.transports
+          ? { transports: credential.transports as AuthenticatorTransport[] }
+          : {}),
+      })),
+      timeout: options.timeout,
+      userVerification: options.userVerification,
+    },
+  });
+
+  if (!fetched || typeof fetched !== "object" || !("rawId" in fetched) || !("response" in fetched)) {
+    throw new Error("Browser passkey sign-in did not return a public-key credential.");
+  }
+
+  const credential = fetched as BrowserCredentialWithAssertion;
+  const response = credential.response;
+
+  if (!response || typeof response !== "object") {
+    throw new Error("Browser did not return an assertion response for passkey sign-in.");
+  }
+
+  return {
+    id: credential.id,
+    rawId: toBase64Url(new Uint8Array(credential.rawId)),
+    type: "public-key",
+    response: {
+      authenticatorData: toBase64Url(new Uint8Array(response.authenticatorData)),
+      clientDataJSON: toBase64Url(new Uint8Array(response.clientDataJSON)),
+      signature: toBase64Url(new Uint8Array(response.signature)),
+      ...(response.userHandle ? { userHandle: toBase64Url(new Uint8Array(response.userHandle)) } : {}),
     },
     authenticatorAttachment: credential.authenticatorAttachment ?? undefined,
     clientExtensionResults: credential.getClientExtensionResults?.() as Record<string, unknown> | undefined,

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -168,3 +168,64 @@ export interface RegistrationSession {
   verifiedAt?: string;
   pairing: PairingSession;
 }
+
+export type AuthenticationStatus =
+  | "awaiting_authentication"
+  | "pending_webauthn_authentication"
+  | "verified"
+  | "expired";
+
+export interface WebAuthnAuthenticationCredentialPayload {
+  id: string;
+  rawId: string;
+  type: "public-key";
+  response: {
+    authenticatorData: string;
+    clientDataJSON: string;
+    signature: string;
+    userHandle?: string;
+  };
+  authenticatorAttachment?: string;
+  clientExtensionResults?: Record<string, unknown>;
+}
+
+export interface FinishAuthenticationInput {
+  authenticationSessionId: string;
+  credential: WebAuthnAuthenticationCredentialPayload;
+}
+
+export interface StartAuthenticationInput {
+  handle: string;
+}
+
+export interface AuthenticationSession {
+  id: string;
+  handle: string;
+  displayName?: string;
+  status: AuthenticationStatus;
+  challenge: string;
+  verificationMethod?: string;
+  passkeyLabel?: string;
+  createdAt: string;
+  expiresAt: string;
+  verifiedAt?: string;
+}
+
+export interface PasskeyAuthenticationOptions {
+  authenticationSessionId: string;
+  challenge: string;
+  rpId: string;
+  allowCredentials: Array<{
+    id: string;
+    type: "public-key";
+    transports?: string[];
+  }>;
+  timeout: number;
+  userVerification: "required";
+}
+
+export interface WebSession {
+  actor: Actor;
+  createdAt: string;
+  expiresAt: string;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -227,6 +227,12 @@ export interface PasskeyAuthenticationOptions {
   userVerification: "required";
 }
 
+export interface WebSession {
+  actor: Actor;
+  createdAt: string;
+  expiresAt: string;
+}
+
 // Forum v2 model — additive to preserve v1 compatibility
 export type ContentType = "question" | "article";
 

--- a/packages/db/sql/001-init.sql
+++ b/packages/db/sql/001-init.sql
@@ -5,6 +5,7 @@ create sequence if not exists auth_pairing_session_id_seq;
 create sequence if not exists auth_account_id_seq;
 create sequence if not exists auth_passkey_credential_id_seq;
 create sequence if not exists auth_authentication_session_id_seq;
+create sequence if not exists auth_web_session_id_seq;
 
 create table if not exists questions (
   id text primary key default ('q-' || nextval('question_id_seq')),
@@ -124,6 +125,22 @@ create index if not exists auth_authentication_sessions_account_id_idx
 
 create index if not exists auth_authentication_sessions_handle_idx
   on auth_authentication_sessions (handle, created_at);
+
+create table if not exists auth_web_sessions (
+  id text primary key default ('aws-' || nextval('auth_web_session_id_seq')),
+  account_id text not null references auth_accounts(id) on delete cascade,
+  authentication_session_id text references auth_authentication_sessions(id) on delete set null,
+  token text not null unique,
+  created_at timestamptz not null default now(),
+  expires_at timestamptz not null default (now() + interval '7 days'),
+  revoked_at timestamptz
+);
+
+create index if not exists auth_web_sessions_account_id_idx
+  on auth_web_sessions (account_id, created_at);
+
+create index if not exists auth_web_sessions_token_idx
+  on auth_web_sessions (token);
 
 do $$
 begin

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -42,6 +42,10 @@ export const plannedTables: TableNote[] = [
     name: "auth_accounts",
     purpose: "Stores human account identity created through passkey verification.",
   },
+  {
+    name: "auth_web_sessions",
+    purpose: "Stores issued browser session cookies for authenticated web usage.",
+  },
 ];
 
 export function readDatabaseConfig(env: NodeJS.ProcessEnv = process.env): DatabaseConfig {


### PR DESCRIPTION
## Summary
- issue httpOnly web session cookies after successful passkey authentication
- add `/auth/session` and `/auth/signout`
- require a signed-in web session for v2 write routes and attribute writes to the authenticated actor
- persist web sessions in both memory and Postgres auth stores
- add a basic returning-user passkey sign-in flow on `/auth`

## Test Plan
- [x] `npm run validate`

Closes #50
