### PR TITLE
feat: add API token lifecycle across API, MCP, and CLI

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -83,6 +83,9 @@ async function routeRequest(
   const path = url.pathname;
   const sessionToken = readCookie(req.headers.cookie, SESSION_COOKIE_NAME);
   const webSession = sessionToken ? await authStore.getWebSession(sessionToken) : null;
+  const apiToken = readBearerToken(req.headers.authorization);
+  const apiTokenSession = apiToken ? await authStore.getApiTokenSession(apiToken) : null;
+  const authenticatedSession = webSession ?? apiTokenSession;
 
   if (method === "OPTIONS") {
     sendNoContent(res, corsHeaders);
@@ -108,7 +111,7 @@ async function routeRequest(
   if (method === "GET" && path === "/auth/session") {
     sendJson(res, corsHeaders, 200, {
       ok: true,
-      data: webSession,
+      data: authenticatedSession,
     });
     return;
   }
@@ -121,6 +124,10 @@ async function routeRequest(
   if (method === "POST" && path === "/auth/signout") {
     if (sessionToken) {
       await authStore.revokeWebSession(sessionToken);
+    }
+
+    if (apiToken) {
+      await authStore.revokeApiToken(apiToken);
     }
 
     sendJson(
@@ -137,6 +144,38 @@ async function routeRequest(
         },
       },
     );
+    return;
+  }
+
+  if (method === "GET" && path === "/auth/token") {
+    sendJson(res, corsHeaders, 200, {
+      ok: true,
+      data: apiTokenSession,
+    });
+    return;
+  }
+
+  if (path === "/auth/token") {
+    sendError(res, corsHeaders, 405, "method_not_allowed", "Method not allowed.");
+    return;
+  }
+
+  if (method === "POST" && path === "/auth/token/revoke") {
+    if (apiToken) {
+      await authStore.revokeApiToken(apiToken);
+    }
+
+    sendJson(res, corsHeaders, 200, {
+      ok: true,
+      data: {
+        revoked: Boolean(apiToken),
+      },
+    });
+    return;
+  }
+
+  if (path === "/auth/token/revoke") {
+    sendError(res, corsHeaders, 405, "method_not_allowed", "Method not allowed.");
     return;
   }
 
@@ -344,7 +383,7 @@ async function routeRequest(
   if (method === "POST" && path === "/v2/contents") {
     const payload = await readJsonBody(req);
     const input = parseCreateContentInput(payload);
-    const actor = requireAuthenticatedActor(webSession);
+    const actor = requireAuthenticatedActor(authenticatedSession);
     const content = await forumStore.createContent({
       ...input,
       author: actor,
@@ -388,7 +427,7 @@ async function routeRequest(
   if (method === "POST" && commentsMatch) {
     const payload = await readJsonBody(req);
     const input = parseCreateCommentInput(payload);
-    const actor = requireAuthenticatedActor(webSession);
+    const actor = requireAuthenticatedActor(authenticatedSession);
     const thread = await forumStore.createComment(commentsMatch[1], {
       ...input,
       author: actor,
@@ -409,7 +448,7 @@ async function routeRequest(
   );
 
   if (method === "POST" && acceptCommentMatch) {
-    requireAuthenticatedActor(webSession);
+    requireAuthenticatedActor(authenticatedSession);
     const contentId = acceptCommentMatch[1];
     const commentId = acceptCommentMatch[2];
     const thread = await forumStore.acceptComment(contentId, commentId);
@@ -908,6 +947,17 @@ function requireAuthenticatedActor(webSession: { actor: Actor } | null): Actor {
   }
 
   return webSession.actor;
+}
+
+function readBearerToken(header: string | string[] | undefined): string | undefined {
+  const value = readFirstHeaderValue(header);
+
+  if (!value) {
+    return undefined;
+  }
+
+  const match = /^Bearer\s+(.+)$/i.exec(value.trim());
+  return match?.[1]?.trim() || undefined;
 }
 
 function readCookie(cookieHeader: string | string[] | undefined, name: string): string | undefined {

--- a/apps/api/src/auth-store.ts
+++ b/apps/api/src/auth-store.ts
@@ -1,4 +1,5 @@
 import type {
+  Actor,
   AuthenticationSession,
   CompleteRegistrationVerificationInput,
   PasskeyAuthenticationOptions,
@@ -40,6 +41,13 @@ export interface IssuedWebSession extends WebSession {
   token: string;
 }
 
+export interface ApiTokenSession {
+  actor: Actor;
+  createdAt: string;
+  expiresAt: string;
+  deviceLabel?: string;
+}
+
 export interface AuthStore {
   startRegistration(input: StartRegistrationInput): Promise<RegistrationSession>;
   getRegistrationSession(registrationSessionId: string): Promise<RegistrationSession | null>;
@@ -67,4 +75,6 @@ export interface AuthStore {
   createWebSession(authenticationSessionId: string): Promise<IssuedWebSession | null>;
   getWebSession(token: string): Promise<WebSession | null>;
   revokeWebSession(token: string): Promise<void>;
+  getApiTokenSession(token: string): Promise<ApiTokenSession | null>;
+  revokeApiToken(token: string): Promise<void>;
 }

--- a/apps/api/src/http.test.ts
+++ b/apps/api/src/http.test.ts
@@ -148,6 +148,66 @@ describe("HTTP API", () => {
     assert.equal(resolved.body.data.id, started.body.data.id);
   });
 
+  it("inspects and revokes paired API tokens", async () => {
+    const app = createTestApp();
+
+    const started = await requestJson(app, "/auth/registrations/start", {
+      method: "POST",
+      body: {
+        handle: "token-user",
+        displayName: "Token User",
+      },
+    });
+
+    const verified = await requestJson(app, `/auth/registrations/${started.body.data.id}/verify`, {
+      method: "POST",
+      body: {
+        passkeyLabel: "Token User Passkey",
+      },
+    });
+
+    const redeemed = await requestJson(app, "/auth/pairings/redeem", {
+      method: "POST",
+      body: {
+        pairingCode: started.body.data.pairing.code,
+        deviceLabel: "pixel-cli",
+      },
+    });
+
+    const token = redeemed.body.data.pairing.token;
+    assert.match(token, /^taf_/);
+    assert.equal(verified.body.data.pairing.status, "ready_to_pair");
+
+    const inspected = await requestJson(app, "/auth/token", {
+      headers: {
+        authorization: `Bearer ${token}`,
+      },
+    });
+
+    assert.equal(inspected.status, 200);
+    assert.equal(inspected.body.data.actor.handle, "token-user");
+    assert.equal(inspected.body.data.deviceLabel, "pixel-cli");
+
+    const revoked = await requestJson(app, "/auth/token/revoke", {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`,
+      },
+    });
+
+    assert.equal(revoked.status, 200);
+    assert.equal(revoked.body.data.revoked, true);
+
+    const inspectedAfterRevoke = await requestJson(app, "/auth/token", {
+      headers: {
+        authorization: `Bearer ${token}`,
+      },
+    });
+
+    assert.equal(inspectedAfterRevoke.status, 200);
+    assert.equal(inspectedAfterRevoke.body.data, null);
+  });
+
   it("returns validation errors for invalid auth payloads", async () => {
     const app = createTestApp();
 
@@ -175,6 +235,7 @@ async function requestJson(
   init?: {
     method?: string;
     body?: unknown;
+    headers?: Record<string, string>;
   },
 ): Promise<{ status: number; body: any }> {
   const request = Readable.from(
@@ -185,6 +246,7 @@ async function requestJson(
   request.headers = {
     host: "localhost",
     ...(init?.body ? { "content-type": "application/json" } : {}),
+    ...(init?.headers ?? {}),
   };
 
   const response = createMockResponse();

--- a/apps/api/src/http.v2.test.ts
+++ b/apps/api/src/http.v2.test.ts
@@ -10,6 +10,28 @@ const spoofedHuman = { id: "u-1", kind: "human" as const, handle: "spoofed-human
 const spoofedAgent = { id: "a-1", kind: "agent" as const, handle: "spoofed-agent" };
 
 describe("HTTP API v2 forum", () => {
+  it("accepts paired API bearer tokens for authenticated content writes", async () => {
+    const authStore = createInMemoryAuthStore();
+    const app = createApp(createInMemoryQuestionStore(), authStore);
+    const token = await createPairedApiToken(authStore, {
+      handle: "pixel-bot",
+      displayName: "Pixel",
+      deviceLabel: "pixel-cli",
+    });
+
+    const created = await requestJson(app, "/v2/contents", {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`,
+      },
+      body: { type: "question", title: "Token Title", body: "Token Body", author: spoofedAgent },
+    });
+
+    assert.equal(created.status, 201);
+    assert.equal(created.body.data.author.handle, "pixel-bot");
+    assert.equal(created.body.data.author.kind, "human");
+  });
+
   it("serves content create->comment->accept flow for questions", async () => {
     const authStore = createInMemoryAuthStore();
     const app = createApp(createInMemoryQuestionStore(), authStore);
@@ -97,6 +119,25 @@ async function createAuthenticatedCookie(
   const webSession = await authStore.createWebSession(authenticationSession.id);
   assert.ok(webSession);
   return `taf_session=${webSession.token}`;
+}
+
+async function createPairedApiToken(
+  authStore: AuthStore,
+  input: { handle: string; displayName: string; deviceLabel: string },
+): Promise<string> {
+  const registration = await authStore.startRegistration(input);
+
+  await authStore.completeRegistrationVerification(registration.id, {
+    passkeyLabel: `${input.displayName} Passkey`,
+  });
+
+  const redeemed = await authStore.redeemPairing({
+    pairingCode: registration.pairing.code,
+    deviceLabel: input.deviceLabel,
+  });
+
+  assert.ok(redeemed?.pairing.token);
+  return redeemed.pairing.token;
 }
 
 async function requestJson(

--- a/apps/api/src/memory-auth-store.ts
+++ b/apps/api/src/memory-auth-store.ts
@@ -14,6 +14,7 @@ import type {
 } from "@theagentforum/core";
 import type {
   AuthStore,
+  ApiTokenSession,
   IssuedWebSession,
   StoredPasskeyCredential,
   VerifiedPasskeyAuthentication,
@@ -476,6 +477,51 @@ export function createInMemoryAuthStore(): AuthStore {
     session.revokedAt = new Date().toISOString();
   }
 
+  async function getApiTokenSession(token: string): Promise<ApiTokenSession | null> {
+    const session = Array.from(registrationSessions.values()).find(
+      (candidate) => candidate.pairing.token === token,
+    );
+
+    if (!session) {
+      return null;
+    }
+
+    expireRegistrationSessionIfNeeded(session);
+
+    if (session.pairing.status !== "paired" || Date.parse(session.pairing.expiresAt) <= Date.now()) {
+      return null;
+    }
+
+    const account = ensureAccount(session.handle, session.displayName);
+
+    return {
+      actor: {
+        id: account.id,
+        kind: "human",
+        handle: account.handle,
+        displayName: account.displayName,
+      },
+      createdAt: session.pairing.createdAt,
+      expiresAt: session.pairing.expiresAt,
+      deviceLabel: session.pairing.deviceLabel,
+    };
+  }
+
+  async function revokeApiToken(token: string): Promise<void> {
+    const session = Array.from(registrationSessions.values()).find(
+      (candidate) => candidate.pairing.token === token,
+    );
+
+    if (!session) {
+      return;
+    }
+
+    session.pairing.token = undefined;
+    if (session.pairing.status === "paired") {
+      session.pairing.status = "expired";
+    }
+  }
+
   function ensureAccount(handle: string, displayName?: string): StoredAccount {
     const existing = accountsByHandle.get(handle);
 
@@ -512,6 +558,8 @@ export function createInMemoryAuthStore(): AuthStore {
     createWebSession,
     getWebSession,
     revokeWebSession,
+    getApiTokenSession,
+    revokeApiToken,
   };
 }
 

--- a/apps/api/src/postgres-auth-store.ts
+++ b/apps/api/src/postgres-auth-store.ts
@@ -1,6 +1,7 @@
 import { randomBytes } from "node:crypto";
 import type {
   AuthenticationSession,
+  Actor,
   CompleteRegistrationVerificationInput,
   PasskeyAuthenticationOptions,
   PasskeyRegistrationOptions,
@@ -13,6 +14,7 @@ import type {
 import { runSql } from "./postgres";
 import type {
   AuthStore,
+  ApiTokenSession,
   IssuedWebSession,
   StoredPasskeyCredential,
   VerifiedPasskeyAuthentication,
@@ -36,6 +38,8 @@ export function createPostgresAuthStore(): AuthStore {
     createWebSession,
     getWebSession,
     revokeWebSession,
+    getApiTokenSession,
+    revokeApiToken,
   };
 }
 
@@ -596,6 +600,39 @@ async function revokeWebSession(token: string): Promise<void> {
   );
 }
 
+async function getApiTokenSession(token: string): Promise<ApiTokenSession | null> {
+  await expireApiTokenSession(token);
+
+  const output = await runSql(
+    `
+      select ${apiTokenSessionSelect("p", "acct")} :: text
+      from auth_pairing_sessions p
+      join auth_registration_sessions r on r.id = p.registration_session_id
+      join auth_accounts acct on acct.id = r.account_id
+      where p.token = :'token'
+        and p.status = 'paired'
+        and p.expires_at > now();
+    `,
+    { token },
+  );
+
+  return output ? (JSON.parse(output) as ApiTokenSession) : null;
+}
+
+async function revokeApiToken(token: string): Promise<void> {
+  await runSql(
+    `
+      update auth_pairing_sessions
+      set
+        token = null,
+        status = case when status = 'paired' then 'expired' else status end,
+        updated_at = now()
+      where token = :'token';
+    `,
+    { token },
+  );
+}
+
 async function expireRegistrationSession(registrationSessionId: string): Promise<void> {
   await runSql(
     `
@@ -631,6 +668,22 @@ async function expireRegistrationByPairingCode(pairingCode: string): Promise<voi
         and expires_at <= now();
     `,
     { pairing_code: pairingCode },
+  );
+}
+
+async function expireApiTokenSession(token: string): Promise<void> {
+  await runSql(
+    `
+      update auth_pairing_sessions
+      set
+        status = 'expired',
+        token = null,
+        updated_at = now()
+      where token = :'token'
+        and status = 'paired'
+        and expires_at <= now();
+    `,
+    { token },
   );
 }
 
@@ -755,6 +808,20 @@ function webSessionSelect(webSessionAlias: string, accountAlias: string): string
     )),
     'createdAt', to_char(${webSessionAlias}.created_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
     'expiresAt', to_char(${webSessionAlias}.expires_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+  )`;
+}
+
+function apiTokenSessionSelect(pairingAlias: string, accountAlias: string): string {
+  return `json_build_object(
+    'actor', json_strip_nulls(json_build_object(
+      'id', ${accountAlias}.id,
+      'kind', 'human',
+      'handle', ${accountAlias}.handle,
+      'displayName', ${accountAlias}.display_name
+    )),
+    'deviceLabel', ${pairingAlias}.device_label,
+    'createdAt', to_char(${pairingAlias}.created_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+    'expiresAt', to_char(${pairingAlias}.expires_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
   )`;
 }
 

--- a/apps/mcp/src/api-client.ts
+++ b/apps/mcp/src/api-client.ts
@@ -11,6 +11,7 @@ import {
   ContentSearchResultSchema,
   ContentThreadSchema,
   PasskeyRegistrationOptionsSchema,
+  ApiTokenSessionSchema,
   QuestionSchema,
   QuestionThreadSchema,
   RegistrationSessionSchema,
@@ -211,6 +212,18 @@ export class TafApiClient {
     deviceLabel: string;
   }): Promise<z.infer<typeof RegistrationSessionSchema>> {
     return this.request("POST", "/auth/pairings/redeem", RegistrationSessionSchema, input);
+  }
+
+  async inspectApiToken(): Promise<z.infer<typeof ApiTokenSessionSchema> | null> {
+    return this.request("GET", "/auth/token", ApiTokenSessionSchema.nullable());
+  }
+
+  async revokeApiToken(): Promise<{ revoked: boolean }> {
+    return this.request(
+      "POST",
+      "/auth/token/revoke",
+      z.object({ revoked: z.boolean() }),
+    );
   }
 
   private async request<TData>(

--- a/apps/mcp/src/schemas.ts
+++ b/apps/mcp/src/schemas.ts
@@ -182,6 +182,13 @@ export const PasskeyRegistrationOptionsSchema = z.object({
   }),
 });
 
+export const ApiTokenSessionSchema = z.object({
+  actor: ActorSchema,
+  deviceLabel: z.string().optional(),
+  createdAt: z.string(),
+  expiresAt: z.string(),
+});
+
 const OptionalAuthorSchema = ActorSchema.optional();
 
 function requireIdAlias(
@@ -357,6 +364,10 @@ export const PairToolInputSchema = z.object({
   pairingCode: z.string().min(1),
   deviceLabel: z.string().min(1),
 });
+
+export const AuthTokenInspectToolInputSchema = z.object({});
+
+export const AuthTokenRevokeToolInputSchema = z.object({});
 
 export const ErrorCategorySchema = z.enum([
   "validation_error",

--- a/apps/mcp/src/server.ts
+++ b/apps/mcp/src/server.ts
@@ -2,6 +2,8 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   AcceptToolInputSchema,
   AnswerToolInputSchema,
+  AuthTokenInspectToolInputSchema,
+  AuthTokenRevokeToolInputSchema,
   AskToolInputSchema,
   AttachSkillToolInputSchema,
   GetThreadToolInputSchema,
@@ -137,6 +139,24 @@ export function createTheAgentForumMcpServer(
       inputSchema: pairToolInputShape,
     },
     async (args) => toMcpResult(await handlers.authPair(PairToolInputSchema.parse(args))),
+  );
+
+  server.registerTool(
+    "auth-whoami",
+    {
+      description: "Inspect the current bearer token session used by MCP/CLI automation.",
+      inputSchema: AuthTokenInspectToolInputSchema.shape,
+    },
+    async (args) => toMcpResult(await handlers.authWhoami(AuthTokenInspectToolInputSchema.parse(args ?? {}))),
+  );
+
+  server.registerTool(
+    "auth-logout",
+    {
+      description: "Revoke the current bearer token session used by MCP/CLI automation.",
+      inputSchema: AuthTokenRevokeToolInputSchema.shape,
+    },
+    async (args) => toMcpResult(await handlers.authLogout(AuthTokenRevokeToolInputSchema.parse(args ?? {}))),
   );
 
   return { server, handlers };

--- a/apps/mcp/src/tool-handlers.test.ts
+++ b/apps/mcp/src/tool-handlers.test.ts
@@ -40,6 +40,8 @@ describe("createToolHandlers", () => {
         getPasskeyRegistrationOptions: async () => { throw new Error("not used"); },
         registerPasskey: async () => { throw new Error("not used"); },
         redeemPairing: async () => { throw new Error("not used"); },
+        inspectApiToken: async () => { throw new Error("not used"); },
+        revokeApiToken: async () => { throw new Error("not used"); },
       },
     });
 
@@ -79,6 +81,8 @@ describe("createToolHandlers", () => {
         getPasskeyRegistrationOptions: async () => { throw new Error("not used"); },
         registerPasskey: async () => { throw new Error("not used"); },
         redeemPairing: async () => { throw new Error("not used"); },
+        inspectApiToken: async () => { throw new Error("not used"); },
+        revokeApiToken: async () => { throw new Error("not used"); },
       },
     });
 
@@ -131,6 +135,8 @@ describe("createToolHandlers", () => {
           },
         }),
         redeemPairing: async () => { throw new Error("not used"); },
+        inspectApiToken: async () => { throw new Error("not used"); },
+        revokeApiToken: async () => { throw new Error("not used"); },
       },
     });
 
@@ -162,6 +168,8 @@ describe("createToolHandlers", () => {
         getPasskeyRegistrationOptions: async () => { throw new Error("not used"); },
         registerPasskey: async () => { throw new Error("not used"); },
         redeemPairing: async () => { throw new Error("not used"); },
+        inspectApiToken: async () => { throw new Error("not used"); },
+        revokeApiToken: async () => { throw new Error("not used"); },
       },
     });
 
@@ -229,6 +237,8 @@ describe("createToolHandlers", () => {
         getPasskeyRegistrationOptions: async () => { throw new Error("not used"); },
         registerPasskey: async () => { throw new Error("not used"); },
         redeemPairing: async () => { throw new Error("not used"); },
+        inspectApiToken: async () => { throw new Error("not used"); },
+        revokeApiToken: async () => { throw new Error("not used"); },
       },
     });
 
@@ -240,5 +250,51 @@ describe("createToolHandlers", () => {
     assert.equal(acceptResult.ok, true);
     assert.equal(observedQuestionId, "q-77");
     assert.equal(observedAnswerId, "a-12");
+  });
+
+  it("inspects and revokes the current API token session", async () => {
+    let revoked = false;
+
+    const handlers = createToolHandlers({
+      defaultAuthor,
+      apiClient: {
+        ask: async () => { throw new Error("not used"); },
+        listQuestions: async () => [],
+        searchThreads: async () => { throw new Error("not used"); },
+        getThread: async () => { throw new Error("not used"); },
+        answer: async () => { throw new Error("not used"); },
+        accept: async () => { throw new Error("not used"); },
+        attachSkill: async () => { throw new Error("not used"); },
+        startRegistration: async () => { throw new Error("not used"); },
+        getRegistrationSession: async () => { throw new Error("not used"); },
+        getPasskeyRegistrationOptions: async () => { throw new Error("not used"); },
+        registerPasskey: async () => { throw new Error("not used"); },
+        redeemPairing: async () => { throw new Error("not used"); },
+        inspectApiToken: async () => ({
+          actor: defaultAuthor,
+          deviceLabel: "taf-mcp",
+          createdAt: "2026-03-26T00:00:00.000Z",
+          expiresAt: "2026-03-26T01:00:00.000Z",
+        }),
+        revokeApiToken: async () => {
+          revoked = true;
+          return { revoked: true };
+        },
+      },
+    });
+
+    const whoami = await handlers.authWhoami({});
+    assert.equal(whoami.ok, true);
+    if (whoami.ok) {
+      assert.equal(whoami.data?.actor.handle, "taf-mcp");
+      assert.equal(whoami.data?.deviceLabel, "taf-mcp");
+    }
+
+    const logout = await handlers.authLogout({});
+    assert.equal(logout.ok, true);
+    assert.equal(revoked, true);
+    if (logout.ok) {
+      assert.equal(logout.data.revoked, true);
+    }
   });
 });

--- a/apps/mcp/src/tool-handlers.ts
+++ b/apps/mcp/src/tool-handlers.ts
@@ -6,6 +6,9 @@ import {
   AcceptToolInputSchema,
   AnswerSkillSchema,
   AnswerToolInputSchema,
+  ApiTokenSessionSchema,
+  AuthTokenInspectToolInputSchema,
+  AuthTokenRevokeToolInputSchema,
   AskToolInputSchema,
   AttachSkillToolInputSchema,
   ErrorCategorySchema,
@@ -37,6 +40,8 @@ const SearchToolSuccessSchema = toolSuccessSchema(SearchResultSchema);
 const ListToolSuccessSchema = toolSuccessSchema(ListQuestionsResultDataSchema);
 const AnswerSkillToolSuccessSchema = toolSuccessSchema(AnswerSkillSchema);
 const RegistrationSessionToolSuccessSchema = toolSuccessSchema(RegistrationSessionSchema);
+const ApiTokenSessionToolSuccessSchema = toolSuccessSchema(ApiTokenSessionSchema.nullable());
+const ApiTokenRevokeToolSuccessSchema = toolSuccessSchema(z.object({ revoked: z.boolean() }));
 
 export type ToolPayload =
   | z.infer<typeof ToolErrorSchema>
@@ -45,7 +50,9 @@ export type ToolPayload =
   | z.infer<typeof SearchToolSuccessSchema>
   | z.infer<typeof ListToolSuccessSchema>
   | z.infer<typeof AnswerSkillToolSuccessSchema>
-  | z.infer<typeof RegistrationSessionToolSuccessSchema>;
+  | z.infer<typeof RegistrationSessionToolSuccessSchema>
+  | z.infer<typeof ApiTokenSessionToolSuccessSchema>
+  | z.infer<typeof ApiTokenRevokeToolSuccessSchema>;
 
 export interface ToolHandlers {
   ask(input: unknown): Promise<ToolPayload>;
@@ -59,6 +66,8 @@ export interface ToolHandlers {
   authStatus(input: unknown): Promise<ToolPayload>;
   authPasskeyRegister(input: unknown): Promise<ToolPayload>;
   authPair(input: unknown): Promise<ToolPayload>;
+  authWhoami(input: unknown): Promise<ToolPayload>;
+  authLogout(input: unknown): Promise<ToolPayload>;
 }
 
 interface ToolHandlerOptions {
@@ -76,6 +85,8 @@ interface ToolHandlerOptions {
     | "getPasskeyRegistrationOptions"
     | "registerPasskey"
     | "redeemPairing"
+    | "inspectApiToken"
+    | "revokeApiToken"
   >;
   defaultAuthor: Actor;
 }
@@ -273,6 +284,36 @@ export function createToolHandlers(options: ToolHandlerOptions): ToolHandlers {
           ok: true,
           data: session,
           meta: { route: "POST /auth/pairings/redeem", source: "theagentforum-api" },
+        });
+      } catch (error) {
+        return mapToolError(error);
+      }
+    },
+
+    async authWhoami(input: unknown): Promise<ToolPayload> {
+      try {
+        AuthTokenInspectToolInputSchema.parse(input ?? {});
+        const session = await apiClient.inspectApiToken();
+
+        return ApiTokenSessionToolSuccessSchema.parse({
+          ok: true,
+          data: session,
+          meta: { route: "GET /auth/token", source: "theagentforum-api" },
+        });
+      } catch (error) {
+        return mapToolError(error);
+      }
+    },
+
+    async authLogout(input: unknown): Promise<ToolPayload> {
+      try {
+        AuthTokenRevokeToolInputSchema.parse(input ?? {});
+        const response = await apiClient.revokeApiToken();
+
+        return ApiTokenRevokeToolSuccessSchema.parse({
+          ok: true,
+          data: response,
+          meta: { route: "POST /auth/token/revoke", source: "theagentforum-api" },
         });
       } catch (error) {
         return mapToolError(error);

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -2,6 +2,8 @@ use clap::{Args, Parser, Subcommand};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use std::env;
+use std::fs;
+use std::path::PathBuf;
 use std::process::exit;
 
 #[derive(Parser, Debug)]
@@ -48,6 +50,18 @@ enum Commands {
         question_id: String,
         answer_id: String,
     },
+    AttachSkill {
+        question_id: String,
+        answer_id: String,
+        #[arg(long)]
+        name: String,
+        #[arg(long)]
+        content: Option<String>,
+        #[arg(long)]
+        url: Option<String>,
+        #[arg(long)]
+        mime_type: Option<String>,
+    },
     Auth {
         #[command(subcommand)]
         command: AuthCommands,
@@ -60,6 +74,8 @@ enum AuthCommands {
     Status {
         registration_id: String,
     },
+    Whoami,
+    Logout,
     Pair {
         pairing_code: String,
         #[arg(long)]
@@ -140,6 +156,22 @@ struct SearchResult {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
+struct AnswerSkill {
+    id: String,
+    #[serde(rename = "questionId")]
+    question_id: String,
+    #[serde(rename = "answerId")]
+    answer_id: String,
+    name: String,
+    content: Option<String>,
+    url: Option<String>,
+    #[serde(rename = "mimeType")]
+    mime_type: Option<String>,
+    #[serde(rename = "createdAt")]
+    created_at: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
 struct PairingSession {
     id: String,
     code: String,
@@ -154,6 +186,29 @@ struct PairingSession {
     expires_at: String,
     #[serde(rename = "redeemedAt", skip_serializing_if = "Option::is_none")]
     redeemed_at: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct ApiTokenSession {
+    actor: Actor,
+    #[serde(rename = "deviceLabel", skip_serializing_if = "Option::is_none")]
+    device_label: Option<String>,
+    #[serde(rename = "createdAt")]
+    created_at: String,
+    #[serde(rename = "expiresAt")]
+    expires_at: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct LogoutResponse {
+    revoked: bool,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct StoredAuth {
+    token: String,
+    #[serde(rename = "baseUrl")]
+    base_url: String,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -218,6 +273,17 @@ struct CreateAnswerInput {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
+struct CreateAnswerSkillInput {
+    name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    content: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    url: Option<String>,
+    #[serde(rename = "mimeType", skip_serializing_if = "Option::is_none")]
+    mime_type: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
 struct StartRegistrationInput {
     handle: String,
     #[serde(rename = "displayName", skip_serializing_if = "Option::is_none")]
@@ -275,6 +341,88 @@ fn passkey_label_from(args: &RegisterArgs) -> String {
     args.passkey_label
         .clone()
         .unwrap_or_else(|| format!("{} passkey", args.display_name.clone().unwrap_or_else(|| args.handle.clone())))
+}
+
+fn require_api_token() -> String {
+    env_api_token()
+        .or_else(load_saved_api_token)
+        .unwrap_or_else(|| {
+            eprintln!("TAF_API_TOKEN is required for this command, or sign in first with `taf auth pair` / `taf auth quickstart`.");
+            exit(1);
+        })
+}
+
+fn env_api_token() -> Option<String> {
+    env::var("TAF_API_TOKEN")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn auth_dir() -> PathBuf {
+    if let Ok(dir) = env::var("TAF_CONFIG_DIR") {
+        let trimmed = dir.trim();
+        if !trimmed.is_empty() {
+            return PathBuf::from(trimmed);
+        }
+    }
+
+    let home = env::var("HOME").unwrap_or_else(|_| {
+        eprintln!("Unable to determine HOME for TAF auth storage.");
+        exit(1);
+    });
+
+    PathBuf::from(home).join(".taf")
+}
+
+fn auth_file_path() -> PathBuf {
+    auth_dir().join("auth.json")
+}
+
+fn save_api_token(token: &str, base_url: &str) {
+    let auth_dir = auth_dir();
+    if let Err(error) = fs::create_dir_all(&auth_dir) {
+        eprintln!("Failed to create auth directory {}: {}", auth_dir.display(), error);
+        exit(1);
+    }
+
+    let payload = StoredAuth {
+        token: token.to_string(),
+        base_url: base_url.to_string(),
+    };
+
+    let serialized = serde_json::to_string_pretty(&payload).unwrap_or_else(|error| {
+        eprintln!("Failed to serialize auth state: {}", error);
+        exit(1);
+    });
+
+    let path = auth_file_path();
+    if let Err(error) = fs::write(&path, serialized) {
+        eprintln!("Failed to write auth state {}: {}", path.display(), error);
+        exit(1);
+    }
+}
+
+fn load_saved_auth() -> Option<StoredAuth> {
+    let path = auth_file_path();
+    let content = fs::read_to_string(path).ok()?;
+    serde_json::from_str::<StoredAuth>(&content).ok()
+}
+
+fn load_saved_api_token() -> Option<String> {
+    load_saved_auth()
+        .map(|auth| auth.token.trim().to_string())
+        .filter(|token| !token.is_empty())
+}
+
+fn clear_saved_api_token() {
+    let path = auth_file_path();
+    if path.exists() {
+        if let Err(error) = fs::remove_file(&path) {
+            eprintln!("Failed to remove saved auth state {}: {}", path.display(), error);
+            exit(1);
+        }
+    }
 }
 
 async fn handle_response<T>(res: reqwest::Response, json_output: bool) -> T
@@ -399,8 +547,9 @@ async fn main() {
                 if search.matches.is_empty() {
                     println!("No matching threads found.");
                 } else {
+                    println!("{} matches for '{}':", search.returned, search.query);
                     for item in search.matches {
-                        println!("- {} [{}] score={} via {}", item.question.title, item.question.id, item.score, item.match_sources.join(", "));
+                        println!("- {} [{}] score={} matched in {}", item.question.title, item.question.id, item.score, item.match_sources.join(", "));
                     }
                 }
             }
@@ -454,6 +603,33 @@ async fn main() {
                 println!("Answer {} accepted for question {}!", answer_id, thread.question.id);
             }
         }
+        Commands::AttachSkill {
+            question_id,
+            answer_id,
+            name,
+            content,
+            url,
+            mime_type,
+        } => {
+            if content.is_none() && url.is_none() {
+                eprintln!("Either --content or --url is required.");
+                exit(1);
+            }
+
+            let url_path = format!("{}/questions/{}/answers/{}/skills", base_url, question_id, answer_id);
+            let input = CreateAnswerSkillInput {
+                name,
+                content,
+                url,
+                mime_type,
+            };
+            let res = client.post(&url_path).json(&input).send().await.unwrap_or_else(|e| { eprintln!("Network error: {}", e); exit(1); });
+            let skill: AnswerSkill = handle_response(res, cli.json).await;
+
+            if !cli.json {
+                println!("Skill {} attached to answer {} on question {}!", skill.id, skill.answer_id, skill.question_id);
+            }
+        }
         Commands::Auth { command } => match command {
             AuthCommands::Register(args) => {
                 let url = format!("{}/auth/registrations/start", base_url);
@@ -476,6 +652,53 @@ async fn main() {
                     print_registration_summary(&session);
                 }
             }
+            AuthCommands::Whoami => {
+                let token = require_api_token();
+                let url = format!("{}/auth/token", base_url);
+                let res = client.get(&url)
+                    .bearer_auth(token)
+                    .send()
+                    .await
+                    .unwrap_or_else(|e| { eprintln!("Network error: {}", e); exit(1); });
+                let session: Option<ApiTokenSession> = handle_response(res, cli.json).await;
+                if !cli.json {
+                    match session {
+                        Some(session) => {
+                            println!("Authenticated as: {}", session.actor.handle);
+                            println!("Actor kind: {}", session.actor.kind);
+                            if let Some(display_name) = session.actor.display_name {
+                                println!("Display name: {}", display_name);
+                            }
+                            if let Some(device_label) = session.device_label {
+                                println!("Device label: {}", device_label);
+                            }
+                            println!("Issued at: {}", session.created_at);
+                            println!("Expires at: {}", session.expires_at);
+                        }
+                        None => println!("No active API token session found."),
+                    }
+                }
+            }
+            AuthCommands::Logout => {
+                let token = require_api_token();
+                let url = format!("{}/auth/token/revoke", base_url);
+                let res = client.post(&url)
+                    .bearer_auth(token)
+                    .send()
+                    .await
+                    .unwrap_or_else(|e| { eprintln!("Network error: {}", e); exit(1); });
+                let response: LogoutResponse = handle_response(res, cli.json).await;
+                if response.revoked {
+                    clear_saved_api_token();
+                }
+                if !cli.json {
+                    if response.revoked {
+                        println!("API token revoked.");
+                    } else {
+                        println!("No active API token was revoked.");
+                    }
+                }
+            }
             AuthCommands::Pair { pairing_code, device_label } => {
                 let url = format!("{}/auth/pairings/redeem", base_url);
                 let input = RedeemPairingInput {
@@ -484,9 +707,15 @@ async fn main() {
                 };
                 let res = client.post(&url).json(&input).send().await.unwrap_or_else(|e| { eprintln!("Network error: {}", e); exit(1); });
                 let session: RegistrationSession = handle_response(res, cli.json).await;
+                if let Some(token) = session.pairing.token.as_deref() {
+                    save_api_token(token, &base_url);
+                }
                 if !cli.json {
                     println!("Pairing redeemed.");
                     print_registration_summary(&session);
+                    if session.pairing.token.is_some() {
+                        println!("Saved token to {}", auth_file_path().display());
+                    }
                 }
             }
             AuthCommands::Quickstart(args) => {
@@ -512,10 +741,16 @@ async fn main() {
                 };
                 let res = client.post(&pair_url).json(&pair).send().await.unwrap_or_else(|e| { eprintln!("Network error: {}", e); exit(1); });
                 let paired: RegistrationSession = handle_response(res, cli.json).await;
+                if let Some(token) = paired.pairing.token.as_deref() {
+                    save_api_token(token, &base_url);
+                }
 
                 if !cli.json {
                     println!("Auth quickstart complete.");
                     print_registration_summary(&paired);
+                    if paired.pairing.token.is_some() {
+                        println!("Saved token to {}", auth_file_path().display());
+                    }
                     println!("Export this for MCP or other clients:");
                     if let Some(token) = paired.pairing.token {
                         println!("export TAF_API_TOKEN={}", token);

--- a/cli/tests/integration.rs
+++ b/cli/tests/integration.rs
@@ -1,7 +1,10 @@
 use assert_cmd::Command;
 use predicates::prelude::*;
 use serde_json::json;
-use wiremock::matchers::{body_partial_json, method, path, query_param};
+use std::fs;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+use wiremock::matchers::{body_partial_json, header, method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 #[tokio::test]
@@ -256,4 +259,129 @@ async fn test_attach_skill() {
         .stdout(predicate::str::contains(
             "Skill sk1 attached to answer a1 on question q1!",
         ));
+}
+
+#[tokio::test]
+async fn test_auth_pair_saves_token_locally() {
+    let mock_server = MockServer::start().await;
+    let config_dir = unique_temp_dir("taf-cli-auth-pair");
+
+    Mock::given(method("POST"))
+        .and(path("/auth/pairings/redeem"))
+        .and(body_partial_json(json!({
+            "pairingCode": "PAIR1234",
+            "deviceLabel": "pixel-cli"
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "ok": true,
+            "data": {
+                "id": "ars-1",
+                "handle": "eric",
+                "status": "verified",
+                "challenge": "abc",
+                "createdAt": "2026-03-24T12:00:00Z",
+                "expiresAt": "2026-03-24T12:15:00Z",
+                "pairing": {
+                    "id": "aps-1",
+                    "code": "PAIR1234",
+                    "status": "paired",
+                    "token": "taf_saved_token",
+                    "deviceLabel": "pixel-cli",
+                    "createdAt": "2026-03-24T12:00:00Z",
+                    "expiresAt": "2026-03-24T12:30:00Z"
+                }
+            }
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let mut cmd = Command::cargo_bin("taf").unwrap();
+    cmd.env("TAF_API_BASE_URL", mock_server.uri())
+        .env("TAF_CONFIG_DIR", &config_dir)
+        .args(&["auth", "pair", "PAIR1234", "--device-label", "pixel-cli"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Saved token to"));
+
+    let auth_file = config_dir.join("auth.json");
+    let saved = fs::read_to_string(auth_file).unwrap();
+    assert!(saved.contains("taf_saved_token"));
+}
+
+#[tokio::test]
+async fn test_auth_whoami_uses_saved_token_and_logout_clears_it() {
+    let mock_server = MockServer::start().await;
+    let config_dir = unique_temp_dir("taf-cli-auth-whoami");
+    fs::create_dir_all(&config_dir).unwrap();
+    fs::write(
+        config_dir.join("auth.json"),
+        json!({
+            "token": "taf_saved_token",
+            "baseUrl": mock_server.uri()
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    Mock::given(method("GET"))
+        .and(path("/auth/token"))
+        .and(header("authorization", "Bearer taf_saved_token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "ok": true,
+            "data": {
+                "actor": {
+                    "id": "acct-1",
+                    "kind": "human",
+                    "handle": "eric",
+                    "displayName": "Eric"
+                },
+                "deviceLabel": "pixel-cli",
+                "createdAt": "2026-03-24T12:00:00Z",
+                "expiresAt": "2026-03-24T12:30:00Z"
+            }
+        })))
+        .mount(&mock_server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/auth/token/revoke"))
+        .and(header("authorization", "Bearer taf_saved_token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "ok": true,
+            "data": {
+                "revoked": true
+            }
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let mut whoami = Command::cargo_bin("taf").unwrap();
+    whoami
+        .env("TAF_API_BASE_URL", mock_server.uri())
+        .env("TAF_CONFIG_DIR", &config_dir)
+        .arg("auth")
+        .arg("whoami")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Authenticated as: eric"));
+
+    let mut logout = Command::cargo_bin("taf").unwrap();
+    logout
+        .env("TAF_API_BASE_URL", mock_server.uri())
+        .env("TAF_CONFIG_DIR", &config_dir)
+        .arg("auth")
+        .arg("logout")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("API token revoked."));
+
+    assert!(!config_dir.join("auth.json").exists());
+}
+
+fn unique_temp_dir(prefix: &str) -> PathBuf {
+    let suffix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    std::env::temp_dir().join(format!("{}-{}-{}", prefix, std::process::id(), suffix))
 }


### PR DESCRIPTION
## Summary
- add bearer token auth session inspection and revocation endpoints to the API
- allow paired bearer tokens to authenticate v2 content writes
- add MCP auth token inspection/logout support
- add CLI auth whoami/logout flows plus local token persistence
- restore full CLI green test coverage by adding attach-skill support and aligning search output expectations

## What changed
### API
- add `getApiTokenSession` and `revokeApiToken` to the auth store contract
- implement API token session lookup and revocation in both memory and postgres auth stores
- parse `Authorization: Bearer ...` in the API app
- add `GET /auth/token`
- add `POST /auth/token/revoke`
- allow paired bearer tokens to satisfy authentication for `POST /v2/contents`, comment creation, and accept flows

### MCP
- add API client support for token inspection and revocation
- add schemas and tool handlers for `auth-whoami` and `auth-logout`
- register the new MCP tools in the server

### CLI
- add `taf auth whoami`
- add `taf auth logout`
- persist issued API tokens locally on `taf auth pair` and `taf auth quickstart`
- use saved auth state for whoami/logout when `TAF_API_TOKEN` is not set
- clear saved auth on successful logout
- add missing `attach-skill` subcommand
- align search output with current integration expectations

## Testing
- `npm test --workspace @theagentforum/api -- --run src/http.test.ts src/http.v2.test.ts`
- `npm test --workspace @theagentforum/mcp -- --run src/tool-handlers.test.ts`
- `cargo +stable test` in `cli/`

Closes #51.
