### PR TITLE
feat: add authenticated passkey management endpoints

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -179,6 +179,55 @@ async function routeRequest(
     return;
   }
 
+  if (method === "GET" && path === "/auth/passkeys") {
+    const actor = requireAuthenticatedActor(authenticatedSession);
+    sendJson(res, corsHeaders, 200, {
+      ok: true,
+      data: await authStore.listAccountPasskeys(actor.id),
+    });
+    return;
+  }
+
+  const passkeyManagementMatch = matchPath(
+    path,
+    /^\/auth\/passkeys\/(?!register$)(?!authenticate$)([^/]+)$/,
+  );
+
+  if (method === "DELETE" && passkeyManagementMatch) {
+    const actor = requireAuthenticatedActor(authenticatedSession);
+    const credentialId = decodeURIComponent(passkeyManagementMatch[1]);
+    const result = await authStore.removeAccountPasskey(actor.id, credentialId);
+
+    if (result === "not_found") {
+      sendError(res, corsHeaders, 404, "passkey_not_found", "Passkey not found.");
+      return;
+    }
+
+    if (result === "last_passkey") {
+      sendError(
+        res,
+        corsHeaders,
+        409,
+        "last_passkey_removal_forbidden",
+        "You cannot remove the last remaining passkey.",
+      );
+      return;
+    }
+
+    sendJson(res, corsHeaders, 200, {
+      ok: true,
+      data: {
+        removed: true,
+      },
+    });
+    return;
+  }
+
+  if (path === "/auth/passkeys" || passkeyManagementMatch) {
+    sendError(res, corsHeaders, 405, "method_not_allowed", "Method not allowed.");
+    return;
+  }
+
   if (path === "/auth/signout") {
     sendError(res, corsHeaders, 405, "method_not_allowed", "Method not allowed.");
     return;

--- a/apps/api/src/auth-store.ts
+++ b/apps/api/src/auth-store.ts
@@ -1,5 +1,6 @@
 import type {
   Actor,
+  AuthPasskey,
   AuthenticationSession,
   CompleteRegistrationVerificationInput,
   PasskeyAuthenticationOptions,
@@ -48,6 +49,8 @@ export interface ApiTokenSession {
   deviceLabel?: string;
 }
 
+export type RemovePasskeyResult = "removed" | "not_found" | "last_passkey";
+
 export interface AuthStore {
   startRegistration(input: StartRegistrationInput): Promise<RegistrationSession>;
   getRegistrationSession(registrationSessionId: string): Promise<RegistrationSession | null>;
@@ -77,4 +80,6 @@ export interface AuthStore {
   revokeWebSession(token: string): Promise<void>;
   getApiTokenSession(token: string): Promise<ApiTokenSession | null>;
   revokeApiToken(token: string): Promise<void>;
+  listAccountPasskeys(accountId: string): Promise<AuthPasskey[]>;
+  removeAccountPasskey(accountId: string, credentialId: string): Promise<RemovePasskeyResult>;
 }

--- a/apps/api/src/http.webauthn.test.ts
+++ b/apps/api/src/http.webauthn.test.ts
@@ -682,44 +682,129 @@ describe("HTTP API - WebAuthn registration", () => {
     assert.equal(currentSession.body.ok, true);
     assert.equal(currentSession.body.data, null);
   });
+
+  it("lists registered passkeys for the signed-in actor and allows removing a non-final passkey", async () => {
+    const app = createTestApp();
+
+    const primaryFixture = createPasskeyFixture();
+    const backupFixture = createPasskeyFixture("backup");
+    await registerPasskey(app, {
+      handle: "passkey-owner",
+      displayName: "Passkey Owner",
+      passkeyLabel: "Primary Passkey",
+      fixture: primaryFixture,
+    });
+    await registerPasskey(app, {
+      handle: "passkey-owner",
+      displayName: "Passkey Owner",
+      passkeyLabel: "Backup Passkey",
+      fixture: backupFixture,
+    });
+
+    const signedIn = await signInWithPasskey(app, {
+      handle: "passkey-owner",
+      displayName: "Passkey Owner",
+      passkeyLabel: "Primary Passkey",
+    });
+
+    const listed = await requestJson(app, "/auth/passkeys", {
+      headers: {
+        cookie: signedIn.cookieHeader,
+      },
+    });
+
+    assert.equal(listed.status, 200);
+    assert.equal(listed.body.data.length, 2);
+    assert.equal(listed.body.data[0].label, "Primary Passkey");
+    assert.equal(listed.body.data[1].label, "Backup Passkey");
+
+    const removed = await requestJson(
+      app,
+      `/auth/passkeys/${encodeURIComponent(backupFixture.credentialId)}`,
+      {
+        method: "DELETE",
+        headers: {
+          cookie: signedIn.cookieHeader,
+        },
+      },
+    );
+
+    assert.equal(removed.status, 200);
+    assert.equal(removed.body.data.removed, true);
+
+    const listedAfterRemoval = await requestJson(app, "/auth/passkeys", {
+      headers: {
+        cookie: signedIn.cookieHeader,
+      },
+    });
+
+    assert.equal(listedAfterRemoval.status, 200);
+    assert.equal(listedAfterRemoval.body.data.length, 1);
+    assert.equal(listedAfterRemoval.body.data[0].credentialId, primaryFixture.credentialId);
+  });
+
+  it("forbids removing the last remaining passkey", async () => {
+    const app = createTestApp();
+
+    const signedIn = await signInWithPasskey(app, {
+      handle: "single-passkey-user",
+      displayName: "Single Passkey User",
+    });
+
+    const listedBeforeRemoval = await requestJson(app, "/auth/passkeys", {
+      headers: {
+        cookie: signedIn.cookieHeader,
+      },
+    });
+
+    const onlyCredentialId = listedBeforeRemoval.body.data[0].credentialId as string;
+
+    const removed = await requestJson(
+      app,
+      `/auth/passkeys/${encodeURIComponent(onlyCredentialId)}`,
+      {
+        method: "DELETE",
+        headers: {
+          cookie: signedIn.cookieHeader,
+        },
+      },
+    );
+
+    assert.equal(removed.status, 409);
+    assert.equal(removed.body.error.code, "last_passkey_removal_forbidden");
+
+    const listed = await requestJson(app, "/auth/passkeys", {
+      headers: {
+        cookie: signedIn.cookieHeader,
+      },
+    });
+
+    assert.equal(listed.status, 200);
+    assert.equal(listed.body.data.length, 1);
+    assert.equal(listed.body.data[0].credentialId, onlyCredentialId);
+  });
 });
 
 async function signInWithPasskey(
   app: ReturnType<typeof createTestApp>,
-  input: { handle: string; displayName: string },
+  input: {
+    handle: string;
+    displayName: string;
+    fixture?: ReturnType<typeof createPasskeyFixture>;
+    passkeyLabel?: string;
+  },
 ): Promise<{
   authenticated: { status: number; body: any; headers: Record<string, string> };
   setCookie: string;
   cookieHeader: string;
 }> {
-  const fixture = createPasskeyFixture();
+  const fixture = input.fixture ?? createPasskeyFixture();
 
-  const started = await requestJson(app, "/auth/registrations/start", {
-    method: "POST",
-    body: input,
-  });
-
-  const registrationId = started.body.data.id as string;
-  const registrationOptions = await requestJson(app, `/auth/registrations/${registrationId}/passkey/options`, {
-    headers: {
-      origin: "http://localhost:5173",
-    },
-  });
-
-  await requestJson(app, "/auth/passkeys/register", {
-    method: "POST",
-    headers: {
-      origin: "http://localhost:5173",
-    },
-    body: {
-      registrationSessionId: registrationId,
-      credential: fixture.createRegistrationCredential({
-        challenge: registrationOptions.body.data.challenge,
-        origin: "http://localhost:5173",
-        rpId: "localhost",
-      }),
-      passkeyLabel: `${input.displayName} Passkey`,
-    },
+  await registerPasskey(app, {
+    handle: input.handle,
+    displayName: input.displayName,
+    passkeyLabel: input.passkeyLabel ?? `${input.displayName} Passkey`,
+    fixture,
   });
 
   const startedAuthentication = await requestJson(app, "/auth/authentications/start", {
@@ -728,6 +813,10 @@ async function signInWithPasskey(
       handle: input.handle,
     },
   });
+
+  if (!startedAuthentication.body.data) {
+    throw new Error(`Expected authentication session, got: ${JSON.stringify(startedAuthentication.body)}`);
+  }
 
   const authenticationSessionId = startedAuthentication.body.data.id as string;
   const authenticationOptions = await requestJson(
@@ -768,8 +857,55 @@ async function signInWithPasskey(
   };
 }
 
-function createPasskeyFixture() {
-  const credentialId = Buffer.from("cred-felix-1", "utf8");
+async function registerPasskey(
+  app: ReturnType<typeof createTestApp>,
+  input: {
+    handle: string;
+    displayName: string;
+    passkeyLabel: string;
+    fixture: ReturnType<typeof createPasskeyFixture>;
+  },
+): Promise<void> {
+  const fixture = input.fixture;
+
+  const started = await requestJson(app, "/auth/registrations/start", {
+    method: "POST",
+    body: {
+      handle: input.handle,
+      displayName: input.displayName,
+    },
+  });
+
+  const registrationId = started.body.data.id as string;
+  const registrationOptions = await requestJson(app, `/auth/registrations/${registrationId}/passkey/options`, {
+    headers: {
+      origin: "http://localhost:5173",
+    },
+  });
+
+  const registered = await requestJson(app, "/auth/passkeys/register", {
+    method: "POST",
+    headers: {
+      origin: "http://localhost:5173",
+    },
+    body: {
+      registrationSessionId: registrationId,
+      credential: fixture.createRegistrationCredential({
+        challenge: registrationOptions.body.data.challenge,
+        origin: "http://localhost:5173",
+        rpId: "localhost",
+      }),
+      passkeyLabel: input.passkeyLabel,
+    },
+  });
+
+  if (!registered.body.ok) {
+    throw new Error(`Expected passkey registration success, got: ${JSON.stringify(registered.body)}`);
+  }
+}
+
+function createPasskeyFixture(seed = "felix-1") {
+  const credentialId = Buffer.from(`cred-${seed}`, "utf8");
   const { privateKey, publicKey } = generateKeyPairSync("ec", { namedCurve: "prime256v1" });
   const publicJwk = publicKey.export({ format: "jwk" }) as JsonWebKey;
   const x = decodeBase64UrlSegment(publicJwk.x);

--- a/apps/api/src/memory-auth-store.ts
+++ b/apps/api/src/memory-auth-store.ts
@@ -1,6 +1,7 @@
 import { randomBytes } from "node:crypto";
 import type {
   Actor,
+  AuthPasskey,
   AuthenticationSession,
   CompleteRegistrationVerificationInput,
   PairingSession,
@@ -16,6 +17,7 @@ import type {
   AuthStore,
   ApiTokenSession,
   IssuedWebSession,
+  RemovePasskeyResult,
   StoredPasskeyCredential,
   VerifiedPasskeyAuthentication,
   VerifiedPasskeyRegistration,
@@ -25,6 +27,8 @@ interface StoredCredential {
   credentialId: string;
   publicKey: string;
   signCount: number;
+  createdAt: string;
+  lastUsedAt?: string;
   label?: string;
   transports?: string[];
 }
@@ -213,6 +217,7 @@ export function createInMemoryAuthStore(): AuthStore {
         credentialId: input.credentialId,
         publicKey: input.publicKey,
         signCount: 0,
+        createdAt: verifiedAt,
         label,
         transports: input.transports,
       });
@@ -400,6 +405,7 @@ export function createInMemoryAuthStore(): AuthStore {
     }
 
     credential.signCount = input.signCount;
+    credential.lastUsedAt = new Date().toISOString();
     const verifiedAt = new Date().toISOString();
 
     session.status = "verified";
@@ -522,6 +528,53 @@ export function createInMemoryAuthStore(): AuthStore {
     }
   }
 
+  async function listAccountPasskeys(accountId: string): Promise<AuthPasskey[]> {
+    const account = Array.from(accountsByHandle.values()).find((candidate) => candidate.id === accountId);
+
+    if (!account) {
+      return [];
+    }
+
+    return (credentialsByHandle.get(account.handle) ?? [])
+      .filter(isAuthenticatablePasskey)
+      .map((credential) => ({
+        credentialId: credential.credentialId,
+        label: credential.label,
+        createdAt: credential.createdAt,
+        lastUsedAt: credential.lastUsedAt,
+        transports: credential.transports,
+      }));
+  }
+
+  async function removeAccountPasskey(
+    accountId: string,
+    credentialId: string,
+  ): Promise<RemovePasskeyResult> {
+    const account = Array.from(accountsByHandle.values()).find((candidate) => candidate.id === accountId);
+
+    if (!account) {
+      return "not_found";
+    }
+
+    const credentials = credentialsByHandle.get(account.handle) ?? [];
+    const credentialIndex = credentials.findIndex(
+      (candidate) => candidate.credentialId === credentialId && isAuthenticatablePasskey(candidate),
+    );
+
+    if (credentialIndex < 0) {
+      return "not_found";
+    }
+
+    const authenticatableCredentials = credentials.filter(isAuthenticatablePasskey);
+    if (authenticatableCredentials.length <= 1) {
+      return "last_passkey";
+    }
+
+    credentials.splice(credentialIndex, 1);
+    credentialsByHandle.set(account.handle, credentials);
+    return "removed";
+  }
+
   function ensureAccount(handle: string, displayName?: string): StoredAccount {
     const existing = accountsByHandle.get(handle);
 
@@ -560,6 +613,8 @@ export function createInMemoryAuthStore(): AuthStore {
     revokeWebSession,
     getApiTokenSession,
     revokeApiToken,
+    listAccountPasskeys,
+    removeAccountPasskey,
   };
 }
 

--- a/apps/api/src/postgres-auth-store.ts
+++ b/apps/api/src/postgres-auth-store.ts
@@ -2,6 +2,7 @@ import { randomBytes } from "node:crypto";
 import type {
   AuthenticationSession,
   Actor,
+  AuthPasskey,
   CompleteRegistrationVerificationInput,
   PasskeyAuthenticationOptions,
   PasskeyRegistrationOptions,
@@ -16,6 +17,7 @@ import type {
   AuthStore,
   ApiTokenSession,
   IssuedWebSession,
+  RemovePasskeyResult,
   StoredPasskeyCredential,
   VerifiedPasskeyAuthentication,
   VerifiedPasskeyRegistration,
@@ -40,6 +42,8 @@ export function createPostgresAuthStore(): AuthStore {
     revokeWebSession,
     getApiTokenSession,
     revokeApiToken,
+    listAccountPasskeys,
+    removeAccountPasskey,
   };
 }
 
@@ -631,6 +635,69 @@ async function revokeApiToken(token: string): Promise<void> {
     `,
     { token },
   );
+}
+
+async function listAccountPasskeys(accountId: string): Promise<AuthPasskey[]> {
+  return queryJson<AuthPasskey[]>(
+    `
+      select coalesce(json_agg(json_strip_nulls(json_build_object(
+        'credentialId', c.credential_id,
+        'label', c.label,
+        'createdAt', to_char(c.created_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+        'lastUsedAt', case
+          when c.last_used_at is null then null
+          else to_char(c.last_used_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+        end,
+        'transports', c.transports
+      ) order by c.created_at asc), '[]'::json) :: text
+      from auth_passkey_credentials c
+      where c.account_id = :'account_id'
+        and c.credential_id not like 'manual-%';
+    `,
+    { account_id: accountId },
+  );
+}
+
+async function removeAccountPasskey(
+  accountId: string,
+  credentialId: string,
+): Promise<RemovePasskeyResult> {
+  const output = await runSql(
+    `
+      with matched_credential as (
+        select c.id
+        from auth_passkey_credentials c
+        where c.account_id = :'account_id'
+          and c.credential_id = :'credential_id'
+          and c.credential_id not like 'manual-%'
+      ),
+      credential_count as (
+        select count(*)::int as total
+        from auth_passkey_credentials c
+        where c.account_id = :'account_id'
+          and c.credential_id not like 'manual-%'
+      ),
+      deleted as (
+        delete from auth_passkey_credentials c
+        where c.account_id = :'account_id'
+          and c.credential_id = :'credential_id'
+          and c.credential_id not like 'manual-%'
+          and (select total from credential_count) > 1
+        returning c.id
+      )
+      select case
+        when exists (select 1 from deleted) then 'removed'
+        when not exists (select 1 from matched_credential) then 'not_found'
+        else 'last_passkey'
+      end :: text;
+    `,
+    {
+      account_id: accountId,
+      credential_id: credentialId,
+    },
+  );
+
+  return (output as RemovePasskeyResult | null) ?? "not_found";
 }
 
 async function expireRegistrationSession(registrationSessionId: string): Promise<void> {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -233,6 +233,14 @@ export interface WebSession {
   expiresAt: string;
 }
 
+export interface AuthPasskey {
+  credentialId: string;
+  label?: string;
+  createdAt: string;
+  lastUsedAt?: string;
+  transports?: string[];
+}
+
 // Forum v2 model — additive to preserve v1 compatibility
 export type ContentType = "question" | "article";
 


### PR DESCRIPTION
## Summary
- add authenticated passkey management endpoints for the signed-in user
- list registered passkeys and allow deleting a non-final passkey
- block removal of the last remaining passkey
- add targeted WebAuthn HTTP coverage for happy path and guardrail behavior

## Testing
- npm test --workspace @theagentforum/api -- --run src/http.test.ts src/http.v2.test.ts src/http.webauthn.test.ts

Closes #54
