### PR TITLE
feat: add auth settings hub

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -228,6 +228,41 @@ async function routeRequest(
     return;
   }
 
+  if (method === "GET" && path === "/auth/devices") {
+    const actor = requireAuthenticatedActor(authenticatedSession);
+    sendJson(res, corsHeaders, 200, {
+      ok: true,
+      data: await authStore.listAccountDevices(actor.id),
+    });
+    return;
+  }
+
+  const deviceManagementMatch = matchPath(path, /^\/auth\/devices\/([^/]+)$/);
+
+  if (method === "DELETE" && deviceManagementMatch) {
+    const actor = requireAuthenticatedActor(authenticatedSession);
+    const deviceId = decodeURIComponent(deviceManagementMatch[1]);
+    const result = await authStore.revokeAccountDevice(actor.id, deviceId);
+
+    if (result === "not_found") {
+      sendError(res, corsHeaders, 404, "device_not_found", "Device not found.");
+      return;
+    }
+
+    sendJson(res, corsHeaders, 200, {
+      ok: true,
+      data: {
+        revoked: true,
+      },
+    });
+    return;
+  }
+
+  if (path === "/auth/devices" || deviceManagementMatch) {
+    sendError(res, corsHeaders, 405, "method_not_allowed", "Method not allowed.");
+    return;
+  }
+
   if (path === "/auth/signout") {
     sendError(res, corsHeaders, 405, "method_not_allowed", "Method not allowed.");
     return;

--- a/apps/api/src/auth-store.ts
+++ b/apps/api/src/auth-store.ts
@@ -1,5 +1,6 @@
 import type {
   Actor,
+  AuthDevice,
   AuthPasskey,
   AuthenticationSession,
   CompleteRegistrationVerificationInput,
@@ -50,6 +51,7 @@ export interface ApiTokenSession {
 }
 
 export type RemovePasskeyResult = "removed" | "not_found" | "last_passkey";
+export type RevokeDeviceResult = "revoked" | "not_found";
 
 export interface AuthStore {
   startRegistration(input: StartRegistrationInput): Promise<RegistrationSession>;
@@ -82,4 +84,6 @@ export interface AuthStore {
   revokeApiToken(token: string): Promise<void>;
   listAccountPasskeys(accountId: string): Promise<AuthPasskey[]>;
   removeAccountPasskey(accountId: string, credentialId: string): Promise<RemovePasskeyResult>;
+  listAccountDevices(accountId: string): Promise<AuthDevice[]>;
+  revokeAccountDevice(accountId: string, deviceId: string): Promise<RevokeDeviceResult>;
 }

--- a/apps/api/src/http.webauthn.test.ts
+++ b/apps/api/src/http.webauthn.test.ts
@@ -783,6 +783,62 @@ describe("HTTP API - WebAuthn registration", () => {
     assert.equal(listed.body.data.length, 1);
     assert.equal(listed.body.data[0].credentialId, onlyCredentialId);
   });
+
+  it("lists paired devices for the signed-in actor and allows forgetting one", async () => {
+    const app = createTestApp();
+
+    const signedIn = await signInWithPasskey(app, {
+      handle: "device-owner",
+      displayName: "Device Owner",
+    });
+
+    const firstDevice = await pairDevice(app, {
+      handle: "device-owner",
+      displayName: "Device Owner",
+      deviceLabel: "Felix CLI",
+      fixture: createPasskeyFixture("device-a"),
+    });
+    await pairDevice(app, {
+      handle: "device-owner",
+      displayName: "Device Owner",
+      deviceLabel: "Pixel Agent",
+      fixture: createPasskeyFixture("device-b"),
+    });
+
+    const listed = await requestJson(app, "/auth/devices", {
+      headers: {
+        cookie: signedIn.cookieHeader,
+      },
+    });
+
+    assert.equal(listed.status, 200);
+    assert.equal(listed.body.data.length, 2);
+    assert.deepEqual(
+      listed.body.data.map((device: { deviceLabel: string }) => device.deviceLabel).sort(),
+      ["Felix CLI", "Pixel Agent"],
+    );
+
+    const revoked = await requestJson(app, `/auth/devices/${encodeURIComponent(firstDevice.pairing.id)}`, {
+      method: "DELETE",
+      headers: {
+        cookie: signedIn.cookieHeader,
+      },
+    });
+
+    assert.equal(revoked.status, 200);
+    assert.equal(revoked.body.data.revoked, true);
+
+    const listedAfterRevoke = await requestJson(app, "/auth/devices", {
+      headers: {
+        cookie: signedIn.cookieHeader,
+      },
+    });
+
+    assert.equal(listedAfterRevoke.status, 200);
+    assert.equal(listedAfterRevoke.body.data.length, 2);
+    const revokedDevice = listedAfterRevoke.body.data.find((device: { id: string }) => device.id === firstDevice.pairing.id);
+    assert.equal(revokedDevice?.status, "expired");
+  });
 });
 
 async function signInWithPasskey(
@@ -865,7 +921,7 @@ async function registerPasskey(
     passkeyLabel: string;
     fixture: ReturnType<typeof createPasskeyFixture>;
   },
-): Promise<void> {
+): Promise<any> {
   const fixture = input.fixture;
 
   const started = await requestJson(app, "/auth/registrations/start", {
@@ -902,6 +958,39 @@ async function registerPasskey(
   if (!registered.body.ok) {
     throw new Error(`Expected passkey registration success, got: ${JSON.stringify(registered.body)}`);
   }
+
+  return registered.body.data;
+}
+
+async function pairDevice(
+  app: ReturnType<typeof createTestApp>,
+  input: {
+    handle: string;
+    displayName: string;
+    deviceLabel: string;
+    fixture: ReturnType<typeof createPasskeyFixture>;
+  },
+): Promise<any> {
+  const registration = await registerPasskey(app, {
+    handle: input.handle,
+    displayName: input.displayName,
+    passkeyLabel: `${input.deviceLabel} passkey`,
+    fixture: input.fixture,
+  });
+
+  const redeemed = await requestJson(app, "/auth/pairings/redeem", {
+    method: "POST",
+    body: {
+      pairingCode: registration.pairing.code,
+      deviceLabel: input.deviceLabel,
+    },
+  });
+
+  if (!redeemed.body.ok) {
+    throw new Error(`Expected pairing redeem success, got: ${JSON.stringify(redeemed.body)}`);
+  }
+
+  return redeemed.body.data;
 }
 
 function createPasskeyFixture(seed = "felix-1") {

--- a/apps/api/src/memory-auth-store.ts
+++ b/apps/api/src/memory-auth-store.ts
@@ -1,6 +1,7 @@
 import { randomBytes } from "node:crypto";
 import type {
   Actor,
+  AuthDevice,
   AuthPasskey,
   AuthenticationSession,
   CompleteRegistrationVerificationInput,
@@ -18,6 +19,7 @@ import type {
   ApiTokenSession,
   IssuedWebSession,
   RemovePasskeyResult,
+  RevokeDeviceResult,
   StoredPasskeyCredential,
   VerifiedPasskeyAuthentication,
   VerifiedPasskeyRegistration,
@@ -575,6 +577,46 @@ export function createInMemoryAuthStore(): AuthStore {
     return "removed";
   }
 
+  async function listAccountDevices(accountId: string): Promise<AuthDevice[]> {
+    const account = Array.from(accountsByHandle.values()).find((candidate) => candidate.id === accountId);
+
+    if (!account) {
+      return [];
+    }
+
+    return Array.from(registrationSessions.values())
+      .filter((session) => session.handle === account.handle && Boolean(session.pairing.deviceLabel))
+      .map((session) => ({
+        id: session.pairing.id,
+        deviceLabel: session.pairing.deviceLabel ?? "Unnamed device",
+        status: session.pairing.status,
+        createdAt: session.pairing.createdAt,
+        expiresAt: session.pairing.expiresAt,
+        redeemedAt: session.pairing.redeemedAt,
+      }))
+      .sort((left, right) => right.createdAt.localeCompare(left.createdAt));
+  }
+
+  async function revokeAccountDevice(accountId: string, deviceId: string): Promise<RevokeDeviceResult> {
+    const account = Array.from(accountsByHandle.values()).find((candidate) => candidate.id === accountId);
+
+    if (!account) {
+      return "not_found";
+    }
+
+    const session = Array.from(registrationSessions.values()).find(
+      (candidate) => candidate.handle === account.handle && candidate.pairing.id === deviceId,
+    );
+
+    if (!session || !session.pairing.deviceLabel) {
+      return "not_found";
+    }
+
+    session.pairing.token = undefined;
+    session.pairing.status = "expired";
+    return "revoked";
+  }
+
   function ensureAccount(handle: string, displayName?: string): StoredAccount {
     const existing = accountsByHandle.get(handle);
 
@@ -615,6 +657,8 @@ export function createInMemoryAuthStore(): AuthStore {
     revokeApiToken,
     listAccountPasskeys,
     removeAccountPasskey,
+    listAccountDevices,
+    revokeAccountDevice,
   };
 }
 

--- a/apps/api/src/postgres-auth-store.ts
+++ b/apps/api/src/postgres-auth-store.ts
@@ -2,6 +2,7 @@ import { randomBytes } from "node:crypto";
 import type {
   AuthenticationSession,
   Actor,
+  AuthDevice,
   AuthPasskey,
   CompleteRegistrationVerificationInput,
   PasskeyAuthenticationOptions,
@@ -18,6 +19,7 @@ import type {
   ApiTokenSession,
   IssuedWebSession,
   RemovePasskeyResult,
+  RevokeDeviceResult,
   StoredPasskeyCredential,
   VerifiedPasskeyAuthentication,
   VerifiedPasskeyRegistration,
@@ -44,6 +46,8 @@ export function createPostgresAuthStore(): AuthStore {
     revokeApiToken,
     listAccountPasskeys,
     removeAccountPasskey,
+    listAccountDevices,
+    revokeAccountDevice,
   };
 }
 
@@ -698,6 +702,64 @@ async function removeAccountPasskey(
   );
 
   return (output as RemovePasskeyResult | null) ?? "not_found";
+}
+
+async function listAccountDevices(accountId: string): Promise<AuthDevice[]> {
+  return queryJson<AuthDevice[]>(
+    `
+      select coalesce(json_agg(json_strip_nulls(json_build_object(
+        'id', p.id,
+        'deviceLabel', p.device_label,
+        'status', p.status,
+        'createdAt', to_char(p.created_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+        'expiresAt', to_char(p.expires_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+        'redeemedAt', case
+          when p.redeemed_at is null then null
+          else to_char(p.redeemed_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+        end
+      ) order by p.created_at desc), '[]'::json) :: text
+      from auth_pairing_sessions p
+      join auth_registration_sessions r on r.id = p.registration_session_id
+      where r.account_id = :'account_id'
+        and p.device_label is not null;
+    `,
+    { account_id: accountId },
+  );
+}
+
+async function revokeAccountDevice(
+  accountId: string,
+  deviceId: string,
+): Promise<RevokeDeviceResult> {
+  const output = await runSql(
+    `
+      with updated_pairing as (
+        update auth_pairing_sessions p
+        set
+          token = null,
+          status = 'expired'
+        where p.id = :'device_id'
+          and exists (
+            select 1
+            from auth_registration_sessions r
+            where r.id = p.registration_session_id
+              and r.account_id = :'account_id'
+          )
+          and p.device_label is not null
+        returning p.id
+      )
+      select case
+        when exists (select 1 from updated_pairing) then 'revoked'
+        else 'not_found'
+      end :: text;
+    `,
+    {
+      account_id: accountId,
+      device_id: deviceId,
+    },
+  );
+
+  return (output as RevokeDeviceResult | null) ?? "not_found";
 }
 
 async function expireRegistrationSession(registrationSessionId: string): Promise<void> {

--- a/apps/api/src/postgres-auth-store.ts
+++ b/apps/api/src/postgres-auth-store.ts
@@ -653,7 +653,7 @@ async function listAccountPasskeys(accountId: string): Promise<AuthPasskey[]> {
           else to_char(c.last_used_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
         end,
         'transports', c.transports
-      ) order by c.created_at asc), '[]'::json) :: text
+      )) order by c.created_at asc), '[]'::json) :: text
       from auth_passkey_credentials c
       where c.account_id = :'account_id'
         and c.credential_id not like 'manual-%';
@@ -717,7 +717,7 @@ async function listAccountDevices(accountId: string): Promise<AuthDevice[]> {
           when p.redeemed_at is null then null
           else to_char(p.redeemed_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
         end
-      ) order by p.created_at desc), '[]'::json) :: text
+      )) order by p.created_at desc), '[]'::json) :: text
       from auth_pairing_sessions p
       join auth_registration_sessions r on r.id = p.registration_session_id
       where r.account_id = :'account_id'

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -3,6 +3,7 @@ import { createApiClient } from "./lib/api";
 import { AuthPage } from "./pages/AuthPage";
 import { HomePage } from "./pages/HomePage";
 import { QuestionPage } from "./pages/QuestionPage";
+import { SettingsPage } from "./pages/SettingsPage";
 
 const api = createApiClient();
 
@@ -12,6 +13,7 @@ export function App() {
       <Routes>
         <Route path="/" element={<HomePage api={api} />} />
         <Route path="/auth" element={<AuthPage api={api} />} />
+        <Route path="/settings" element={<SettingsPage api={api} />} />
         <Route path="/threads/:questionId" element={<QuestionPage api={api} />} />
         <Route path="/questions/:questionId" element={<QuestionPage api={api} />} />
         <Route path="*" element={<Navigate to="/" replace />} />

--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -28,6 +28,7 @@ export function AppShell({ children, cta }: AppShellProps) {
             <a href="/#featured-discussions">Featured</a>
             <a href="/#why-connect">Why connect</a>
             <a href="/#recent-questions">Browse</a>
+            <Link to="/settings">Settings</Link>
             <a href="/skill.md">Agent pack</a>
             {cta}
           </nav>

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,6 +1,8 @@
 import type {
   Answer,
   AnswerSkill,
+  AuthDevice,
+  AuthPasskey,
   AuthenticationSession,
   CompleteRegistrationVerificationInput,
   CreateAnswerInput,
@@ -265,12 +267,28 @@ export function createApiClient(baseUrl = defaultBaseUrl) {
     return request<WebSession | null>("GET", "/auth/session");
   }
 
+  async function listPasskeys(): Promise<AuthPasskey[]> {
+    return request<AuthPasskey[]>("GET", "/auth/passkeys");
+  }
+
+  async function removePasskey(credentialId: string): Promise<{ removed: boolean }> {
+    return request<{ removed: boolean }>("DELETE", `/auth/passkeys/${encodeURIComponent(credentialId)}`);
+  }
+
+  async function listDevices(): Promise<AuthDevice[]> {
+    return request<AuthDevice[]>("GET", "/auth/devices");
+  }
+
+  async function revokeDevice(deviceId: string): Promise<{ revoked: boolean }> {
+    return request<{ revoked: boolean }>("DELETE", `/auth/devices/${encodeURIComponent(deviceId)}`);
+  }
+
   async function signOut(): Promise<{ signedOut: boolean }> {
     return request<{ signedOut: boolean }>("POST", "/auth/signout");
   }
 
   async function request<T>(
-    method: "GET" | "POST",
+    method: "GET" | "POST" | "DELETE",
     path: string,
     body?: unknown,
   ): Promise<T> {
@@ -320,6 +338,10 @@ export function createApiClient(baseUrl = defaultBaseUrl) {
     getPasskeyAuthenticationOptions,
     authenticatePasskey,
     getAuthSession,
+    listPasskeys,
+    removePasskey,
+    listDevices,
+    revokeDevice,
     signOut,
   };
 }

--- a/apps/web/src/pages/SettingsPage.test.tsx
+++ b/apps/web/src/pages/SettingsPage.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+import type { ApiClient } from "../lib/api";
+import { SettingsPage } from "./SettingsPage";
+
+describe("SettingsPage", () => {
+  it("shows sign-in guidance when there is no authenticated session", async () => {
+    const api = {
+      getAuthSession: vi.fn().mockResolvedValue(null),
+      listPasskeys: vi.fn(),
+      listDevices: vi.fn(),
+    } as unknown as ApiClient;
+
+    render(
+      <MemoryRouter initialEntries={["/settings"]}>
+        <SettingsPage api={api} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: /sign in to view your settings/i })).toBeInTheDocument();
+    });
+
+    expect(api.listPasskeys).not.toHaveBeenCalled();
+    expect(api.listDevices).not.toHaveBeenCalled();
+  });
+
+  it("renders passkeys and devices, then removes and revokes them", async () => {
+    const user = userEvent.setup();
+    const getAuthSession = vi.fn().mockResolvedValue({
+      actor: {
+        id: "acct-1",
+        kind: "human",
+        handle: "felix796",
+        displayName: "Felix",
+      },
+      createdAt: "2026-04-24T03:00:00.000Z",
+      expiresAt: "2026-05-01T03:00:00.000Z",
+    });
+    const listPasskeys = vi
+      .fn()
+      .mockResolvedValueOnce([
+        {
+          credentialId: "cred-1",
+          label: "MacBook Passkey",
+          createdAt: "2026-04-20T03:00:00.000Z",
+        },
+      ])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+    const listDevices = vi
+      .fn()
+      .mockResolvedValueOnce([
+        {
+          id: "aps-1",
+          deviceLabel: "Pixel Agent",
+          status: "paired",
+          createdAt: "2026-04-22T03:00:00.000Z",
+          expiresAt: "2026-04-23T03:00:00.000Z",
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: "aps-1",
+          deviceLabel: "Pixel Agent",
+          status: "paired",
+          createdAt: "2026-04-22T03:00:00.000Z",
+          expiresAt: "2026-04-23T03:00:00.000Z",
+        },
+      ])
+      .mockResolvedValueOnce([]);
+
+    const api = {
+      getAuthSession,
+      listPasskeys,
+      removePasskey: vi.fn().mockResolvedValue({ removed: true }),
+      listDevices,
+      revokeDevice: vi.fn().mockResolvedValue({ revoked: true }),
+      signOut: vi.fn().mockResolvedValue({ signedOut: true }),
+    } as unknown as ApiClient;
+
+    render(
+      <MemoryRouter initialEntries={["/settings"]}>
+        <SettingsPage api={api} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: /registered passkeys/i })).toBeInTheDocument();
+      expect(screen.getByRole("heading", { name: /paired agents/i })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Remove" }));
+
+    await waitFor(() => {
+      expect(api.removePasskey).toHaveBeenCalledWith("cred-1");
+      expect(listPasskeys).toHaveBeenCalledTimes(2);
+    });
+
+    await user.click(screen.getByRole("button", { name: "Forget" }));
+
+    await waitFor(() => {
+      expect(api.revokeDevice).toHaveBeenCalledWith("aps-1");
+      expect(listDevices).toHaveBeenCalledTimes(3);
+    });
+  });
+});

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -1,0 +1,257 @@
+import { useEffect, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import type { ApiClient } from "../lib/api";
+import { AppShell, Section } from "../components/AppShell";
+import { formatDate, readErrorMessage } from "../lib/ui";
+import type { AuthDevice, AuthPasskey, WebSession } from "../types";
+
+interface SettingsPageProps {
+  api: ApiClient;
+}
+
+export function SettingsPage({ api }: SettingsPageProps) {
+  const navigate = useNavigate();
+  const [session, setSession] = useState<WebSession | null>(null);
+  const [passkeys, setPasskeys] = useState<AuthPasskey[]>([]);
+  const [devices, setDevices] = useState<AuthDevice[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [signingOut, setSigningOut] = useState(false);
+  const [pendingPasskeyId, setPendingPasskeyId] = useState<string | null>(null);
+  const [pendingDeviceId, setPendingDeviceId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    void refresh();
+  }, []);
+
+  async function refresh(options: { quiet?: boolean } = {}): Promise<void> {
+    if (options.quiet) {
+      setRefreshing(true);
+    } else {
+      setLoading(true);
+    }
+
+    setError(null);
+
+    try {
+      const nextSession = await api.getAuthSession();
+      setSession(nextSession);
+
+      if (!nextSession) {
+        setPasskeys([]);
+        setDevices([]);
+        return;
+      }
+
+      const [nextPasskeys, nextDevices] = await Promise.all([
+        api.listPasskeys(),
+        api.listDevices(),
+      ]);
+
+      setPasskeys(nextPasskeys);
+      setDevices(nextDevices);
+    } catch (cause) {
+      setError(readErrorMessage(cause));
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }
+
+  async function handleRemovePasskey(credentialId: string): Promise<void> {
+    setPendingPasskeyId(credentialId);
+    setError(null);
+
+    try {
+      await api.removePasskey(credentialId);
+      await refresh({ quiet: true });
+    } catch (cause) {
+      setError(readErrorMessage(cause));
+    } finally {
+      setPendingPasskeyId(null);
+    }
+  }
+
+  async function handleForgetDevice(deviceId: string): Promise<void> {
+    setPendingDeviceId(deviceId);
+    setError(null);
+
+    try {
+      await api.revokeDevice(deviceId);
+      await refresh({ quiet: true });
+    } catch (cause) {
+      setError(readErrorMessage(cause));
+    } finally {
+      setPendingDeviceId(null);
+    }
+  }
+
+  async function handleSignOut(): Promise<void> {
+    setSigningOut(true);
+    setError(null);
+
+    try {
+      await api.signOut();
+      navigate("/auth");
+    } catch (cause) {
+      setError(readErrorMessage(cause));
+    } finally {
+      setSigningOut(false);
+    }
+  }
+
+  return (
+    <AppShell cta={<Link className="button button--ghost" to="/auth">Pair an agent</Link>}>
+      <div className="settings-layout">
+        <Section
+          eyebrow="Settings v1"
+          title="Your account, passkeys, and connected agents"
+          description="Use this page to verify what the auth system knows about you right now, remove devices you no longer trust, and launch the next pairing flow."
+          actions={
+            <div className="settings-actions">
+              <button className="button button--ghost" type="button" onClick={() => void refresh({ quiet: true })} disabled={loading || refreshing}>
+                {refreshing ? "Refreshing..." : "Refresh"}
+              </button>
+              <button type="button" onClick={() => void handleSignOut()} disabled={signingOut || loading}>
+                {signingOut ? "Signing out..." : "Sign out"}
+              </button>
+            </div>
+          }
+        >
+          {error ? <p className="error">{error}</p> : null}
+          {loading ? <p className="muted">Loading settings...</p> : null}
+
+          {!loading && !session ? (
+            <div className="card stack settings-empty-state">
+              <h3>Sign in to view your settings</h3>
+              <p className="muted">
+                Once you sign in with a passkey, this page will show your current session, passkeys, and paired agents or devices.
+              </p>
+              <div className="row wrap-gap">
+                <Link className="button" to="/auth">
+                  Sign in with passkey
+                </Link>
+                <Link className="button button--ghost" to="/">
+                  Back to forum
+                </Link>
+              </div>
+            </div>
+          ) : null}
+
+          {!loading && session ? (
+            <div className="settings-grid">
+              <section className="card stack settings-card">
+                <div>
+                  <p className="eyebrow">Current session</p>
+                  <h3>{session.actor.displayName ?? session.actor.handle}</h3>
+                </div>
+                <dl className="meta-list settings-meta-list">
+                  <div>
+                    <dt>Handle</dt>
+                    <dd>@{session.actor.handle}</dd>
+                  </div>
+                  <div>
+                    <dt>Actor type</dt>
+                    <dd>{session.actor.kind}</dd>
+                  </div>
+                  <div>
+                    <dt>Signed in</dt>
+                    <dd>{formatDate(session.createdAt)}</dd>
+                  </div>
+                  <div>
+                    <dt>Session expires</dt>
+                    <dd>{formatDate(session.expiresAt)}</dd>
+                  </div>
+                </dl>
+              </section>
+
+              <section className="card stack settings-card">
+                <div className="row between center wrap-gap">
+                  <div>
+                    <p className="eyebrow">Passkeys</p>
+                    <h3>Registered passkeys</h3>
+                  </div>
+                  <Link className="button button--ghost" to="/auth">
+                    Add another passkey
+                  </Link>
+                </div>
+                {passkeys.length === 0 ? (
+                  <p className="muted">No passkeys found for this account yet.</p>
+                ) : (
+                  <ul className="settings-list">
+                    {passkeys.map((passkey) => (
+                      <li key={passkey.credentialId} className="settings-list__item">
+                        <div>
+                          <strong>{passkey.label ?? "Unnamed passkey"}</strong>
+                          <p className="muted settings-list__meta">
+                            Added {formatDate(passkey.createdAt)}
+                            {passkey.lastUsedAt ? ` · last used ${formatDate(passkey.lastUsedAt)}` : ""}
+                          </p>
+                        </div>
+                        <button
+                          className="button button--ghost"
+                          type="button"
+                          disabled={pendingPasskeyId === passkey.credentialId}
+                          onClick={() => void handleRemovePasskey(passkey.credentialId)}
+                        >
+                          {pendingPasskeyId === passkey.credentialId ? "Removing..." : "Remove"}
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </section>
+
+              <section className="card stack settings-card">
+                <div className="row between center wrap-gap">
+                  <div>
+                    <p className="eyebrow">Agents and devices</p>
+                    <h3>Paired agents</h3>
+                  </div>
+                  <Link className="button button--ghost" to="/auth">
+                    Pair new agent
+                  </Link>
+                </div>
+                {devices.length === 0 ? (
+                  <p className="muted">No paired agents or devices yet.</p>
+                ) : (
+                  <ul className="settings-list">
+                    {devices.map((device) => (
+                      <li key={device.id} className="settings-list__item">
+                        <div>
+                          <strong>{device.deviceLabel}</strong>
+                          <p className="muted settings-list__meta">
+                            Status: {device.status} · paired {formatDate(device.createdAt)}
+                          </p>
+                        </div>
+                        <button
+                          className="button button--ghost"
+                          type="button"
+                          disabled={pendingDeviceId === device.id}
+                          onClick={() => void handleForgetDevice(device.id)}
+                        >
+                          {pendingDeviceId === device.id ? "Forgetting..." : "Forget"}
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </section>
+
+              <section className="card stack settings-card settings-card--wide">
+                <div>
+                  <p className="eyebrow">Preferences</p>
+                  <h3>Preferences will stay small for now</h3>
+                </div>
+                <p className="muted">
+                  This slice is focused on auth and testing visibility first. Preferences can grow later once account, passkey, and agent-state behavior feels solid.
+                </p>
+              </section>
+            </div>
+          ) : null}
+        </Section>
+      </div>
+    </AppShell>
+  );
+}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1641,6 +1641,67 @@ ul {
   border-color: rgba(16, 185, 129, 0.2);
 }
 
+.settings-layout {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.settings-actions {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.settings-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.settings-card {
+  gap: 1rem;
+}
+
+.settings-card--wide {
+  grid-column: 1 / -1;
+}
+
+.settings-meta-list {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.settings-meta-list div,
+.settings-list__item {
+  padding: 1rem;
+  border-radius: 1rem;
+  border: 1px solid var(--border-strong);
+  background: var(--surface-elevated);
+}
+
+.settings-list {
+  display: grid;
+  gap: 0.85rem;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.settings-list__item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.settings-list__meta {
+  margin: 0.35rem 0 0;
+}
+
+.settings-empty-state {
+  gap: 1rem;
+}
+
 .block-code {
   display: block;
   white-space: pre-wrap;
@@ -1652,10 +1713,19 @@ ul {
   .auth-steps {
     grid-template-columns: 1fr 1fr;
   }
+
+  .settings-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 @media (max-width: 560px) {
   .auth-steps {
     grid-template-columns: 1fr;
+  }
+
+  .settings-list__item {
+    align-items: flex-start;
+    flex-direction: column;
   }
 }

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -229,3 +229,20 @@ export interface WebSession {
   createdAt: string;
   expiresAt: string;
 }
+
+export interface AuthPasskey {
+  credentialId: string;
+  label?: string;
+  createdAt: string;
+  lastUsedAt?: string;
+  transports?: string[];
+}
+
+export interface AuthDevice {
+  id: string;
+  deviceLabel: string;
+  status: PairingStatus;
+  createdAt: string;
+  expiresAt: string;
+  redeemedAt?: string;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -241,6 +241,15 @@ export interface AuthPasskey {
   transports?: string[];
 }
 
+export interface AuthDevice {
+  id: string;
+  deviceLabel: string;
+  status: PairingSession["status"];
+  createdAt: string;
+  expiresAt: string;
+  redeemedAt?: string;
+}
+
 // Forum v2 model — additive to preserve v1 compatibility
 export type ContentType = "question" | "article";
 


### PR DESCRIPTION
## Summary
- add a signed-in settings hub for auth state, passkeys, and paired agents/devices
- add authenticated device listing and forget/revoke endpoints for the current user
- reuse the passkey management API from the previous slice and expose it through the web UI
- keep preferences intentionally minimal for now so the page stays focused on auth/testing visibility

## Testing
- npm test --workspace @theagentforum/api -- --run src/http.webauthn.test.ts
- npm test --workspace @theagentforum/web -- --run src/pages/SettingsPage.test.tsx src/pages/AuthPage.test.tsx src/pages/HomePage.test.tsx
- npm run typecheck --workspace @theagentforum/web

Part of #54
