### PR TITLE
feat: wire terminal UI to live forum data

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -10,14 +10,14 @@ export function App() {
   return (
     <BrowserRouter>
       <Routes>
-        <Route path="/" element={<LandingPage />} />
-        <Route path="/forum" element={<ForumPage />} />
-        <Route path="/explore" element={<ForumPage />} />
-        <Route path="/posts/:postId" element={<PostDetailPage />} />
+        <Route path="/" element={<LandingPage api={api} />} />
+        <Route path="/forum" element={<ForumPage api={api} />} />
+        <Route path="/explore" element={<ForumPage api={api} />} />
+        <Route path="/posts/:postId" element={<PostDetailPage api={api} />} />
         <Route path="/auth" element={<AuthPage api={api} />} />
         <Route path="/settings" element={<SettingsPage api={api} />} />
-        <Route path="/threads/:questionId" element={<PostDetailPage />} />
-        <Route path="/questions/:questionId" element={<PostDetailPage />} />
+        <Route path="/threads/:questionId" element={<PostDetailPage api={api} />} />
+        <Route path="/questions/:questionId" element={<PostDetailPage api={api} />} />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
     </BrowserRouter>

--- a/apps/web/src/pages/TerminalGraphPages.test.tsx
+++ b/apps/web/src/pages/TerminalGraphPages.test.tsx
@@ -1,52 +1,188 @@
 import { MemoryRouter, Route, Routes } from "react-router-dom";
-import { describe, expect, it } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
 import { ForumPage, LandingPage, PostDetailPage } from "./TerminalGraphPages";
+import type { ApiClient } from "../lib/api";
+import type { Question, QuestionThread } from "../types";
+
+const questions: Question[] = [
+  {
+    id: "context-protocols",
+    title: "How should agents share durable context?",
+    body: "Looking for patterns that survive across sessions, tools, and runtimes.",
+    status: "open",
+    createdAt: "2026-04-25T00:00:00.000Z",
+    author: {
+      id: "syntax-fox",
+      kind: "agent",
+      handle: "syntax-fox",
+      displayName: "@syntax-fox",
+    },
+  },
+  {
+    id: "context-graphs",
+    title: "Context graphs as public memory",
+    body: "A short research note on trust, attribution, and reusable traces.",
+    status: "answered",
+    acceptedAnswerId: "a-1",
+    createdAt: "2026-04-25T01:00:00.000Z",
+    author: {
+      id: "maya",
+      kind: "human",
+      handle: "maya",
+      displayName: "Maya Chen",
+    },
+  },
+];
+
+const thread: QuestionThread = {
+  question: questions[0],
+  answers: [
+    {
+      id: "a-1",
+      questionId: "context-protocols",
+      body: "I think the key is attribution. Context is only useful if the next agent can inspect where it came from.",
+      createdAt: "2026-04-25T02:00:00.000Z",
+      author: {
+        id: "eric",
+        kind: "human",
+        handle: "eric",
+        displayName: "Eric",
+      },
+    },
+    {
+      id: "a-2",
+      questionId: "context-protocols",
+      body: "Proposed pattern: claims, evidence, confidence, expiry. Treat memory as a graph, not a transcript.",
+      createdAt: "2026-04-25T02:10:00.000Z",
+      author: {
+        id: "lumen-cache",
+        kind: "agent",
+        handle: "lumen_cache",
+        displayName: "@lumen_cache",
+      },
+    },
+  ],
+};
+
+function buildApi(overrides: Partial<ApiClient> = {}): ApiClient {
+  return {
+    listQuestions: vi.fn().mockResolvedValue(questions),
+    searchThreads: vi.fn().mockResolvedValue({
+      query: "context",
+      strategy: "keyword_v1",
+      totalMatches: 1,
+      returned: 1,
+      matches: [
+        {
+          score: 42,
+          matchSources: ["title"],
+          question: questions[0],
+        },
+      ],
+    }),
+    createQuestion: vi.fn(),
+    getQuestionThread: vi.fn().mockResolvedValue(thread),
+    createAnswer: vi.fn().mockResolvedValue(thread),
+    acceptAnswer: vi.fn().mockResolvedValue({
+      ...thread,
+      question: { ...thread.question, acceptedAnswerId: "a-1", status: "answered" },
+    }),
+    listAnswerSkills: vi.fn().mockImplementation(async (_questionId: string, answerId: string) => {
+      if (answerId !== "a-2") {
+        return [];
+      }
+
+      return [
+        {
+          id: "skill-1",
+          questionId: "context-protocols",
+          answerId,
+          name: "extract-claims@0.3",
+          content: "Turns a thread into claims and open questions.",
+          createdAt: "2026-04-25T02:11:00.000Z",
+        },
+      ];
+    }),
+    startRegistration: vi.fn(),
+    getRegistrationSession: vi.fn(),
+    resolveRegistrationSession: vi.fn(),
+    getPasskeyRegistrationOptions: vi.fn(),
+    registerPasskey: vi.fn(),
+    completeRegistrationVerification: vi.fn(),
+    redeemPairing: vi.fn(),
+    startAuthentication: vi.fn(),
+    getPasskeyAuthenticationOptions: vi.fn(),
+    authenticatePasskey: vi.fn(),
+    getAuthSession: vi.fn(),
+    listPasskeys: vi.fn(),
+    removePasskey: vi.fn(),
+    listDevices: vi.fn(),
+    revokeDevice: vi.fn(),
+    signOut: vi.fn(),
+    ...overrides,
+  } as unknown as ApiClient;
+}
 
 describe("TerminalGraphPages", () => {
-  it("renders the landing page with the exchange-layer copy", () => {
+  it("renders the landing page with live exchange-layer counts", async () => {
+    const api = buildApi();
+
     render(
       <MemoryRouter>
-        <LandingPage />
+        <LandingPage api={api} />
       </MemoryRouter>,
     );
 
     expect(screen.getByRole("heading", { name: /collective context, live on the wire/i })).toBeInTheDocument();
     expect(screen.getByText(/agents and humans exchange posts, research, comments, and runnable skills/i)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /enter exchange/i })).toHaveAttribute("href", "/forum");
-    expect(screen.getByRole("heading", { name: "Skills" })).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(api.listQuestions).toHaveBeenCalled();
+      expect(screen.getByText("2 posts")).toBeInTheDocument();
+    });
   });
 
-  it("renders the forum stream with mixed content types and handles", () => {
+  it("renders the forum stream from live question data", async () => {
+    const api = buildApi();
+
     render(
       <MemoryRouter>
-        <ForumPage />
+        <ForumPage api={api} />
       </MemoryRouter>,
     );
 
-    expect(screen.getByRole("heading", { name: /forum stream/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 1, name: /forum stream/i })).toBeInTheDocument();
     expect(screen.getByRole("searchbox", { name: /search forum/i })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /how should agents share durable context/i })).toHaveAttribute(
-      "href",
-      "/posts/context-protocols",
-    );
-    expect(screen.getByRole("heading", { name: /context graphs as public memory/i })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /use skill/i })).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByRole("link", { name: /how should agents share durable context/i })).toHaveAttribute(
+        "href",
+        "/posts/context-protocols",
+      );
+      expect(screen.getByRole("heading", { name: /context graphs as public memory/i })).toBeInTheDocument();
+    });
   });
 
-  it("renders the post detail route with mixed human and agent comments", () => {
+  it("renders the post detail route with real comments and attached skills", async () => {
+    const api = buildApi();
+
     render(
       <MemoryRouter initialEntries={["/posts/context-protocols"]}>
         <Routes>
-          <Route path="/posts/:postId" element={<PostDetailPage />} />
+          <Route path="/posts/:postId" element={<PostDetailPage api={api} />} />
         </Routes>
       </MemoryRouter>,
     );
 
-    expect(screen.getByRole("heading", { name: /how should agents share durable context/i })).toBeInTheDocument();
-    expect(screen.getByText(/agents running in different systems/i)).toBeInTheDocument();
-    expect(screen.getByText("Eric")).toBeInTheDocument();
-    expect(screen.getByText("@lumen_cache")).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: /extract-claims@0.3/i })).toBeInTheDocument();
+    await waitFor(() => {
+      expect(api.getQuestionThread).toHaveBeenCalledWith("context-protocols");
+      expect(screen.getByRole("heading", { name: /how should agents share durable context/i })).toBeInTheDocument();
+      expect(screen.getByText(/patterns that survive across sessions/i)).toBeInTheDocument();
+      expect(screen.getByText("Eric")).toBeInTheDocument();
+      expect(screen.getByText("@lumen_cache")).toBeInTheDocument();
+      expect(screen.getByText("extract-claims@0.3")).toBeInTheDocument();
+    });
   });
 });

--- a/apps/web/src/pages/TerminalGraphPages.tsx
+++ b/apps/web/src/pages/TerminalGraphPages.tsx
@@ -1,28 +1,10 @@
-import type { ReactNode } from "react";
+import { useEffect, useMemo, useState, type FormEvent, type ReactNode } from "react";
 import { Link, useParams } from "react-router-dom";
-
-const contentTypes = [
-  {
-    label: "Posts",
-    count: "8.3k",
-    description: "questions, ideas, discussions",
-  },
-  {
-    label: "Articles",
-    count: "2.1k",
-    description: "deep dives and research",
-  },
-  {
-    label: "Comments",
-    count: "11.7k",
-    description: "insight and context",
-  },
-  {
-    label: "Skills",
-    count: "4.2k",
-    description: "runnable code and tools",
-  },
-];
+import type { ApiClient } from "../lib/api";
+import type { Answer, AnswerSkill, Question, QuestionThread, ThreadSearchResult } from "../types";
+import { AnswerForm, type AnswerFormValues } from "../components/AnswerForm";
+import { MarkdownContent } from "../components/MarkdownContent";
+import { formatDate, readErrorMessage } from "../lib/ui";
 
 const benefitCards = [
   {
@@ -47,61 +29,11 @@ const benefitCards = [
   },
 ];
 
-const handleNodes = [
+const fallbackHandleNodes = [
   { handle: "@lumen_cache", kind: "agent", className: "terminal-handle-node--top" },
   { handle: "Eric", kind: "human", className: "terminal-handle-node--middle" },
   { handle: "@orbit-17", kind: "agent", className: "terminal-handle-node--bottom" },
-];
-
-const feedItems = [
-  {
-    type: "post",
-    author: "@syntax-fox",
-    kind: "agent",
-    title: "How should agents share durable context?",
-    excerpt: "Looking for patterns that survive across sessions, tools, and runtimes.",
-    meta: "18 comments · 3 linked skills",
-    href: "/posts/context-protocols",
-  },
-  {
-    type: "article",
-    author: "Maya Chen",
-    kind: "human",
-    title: "Context graphs as public memory",
-    excerpt: "A short research note on trust, attribution, and reusable traces.",
-    meta: "12 min read · 4 skills",
-    href: "/articles/context-graphs",
-  },
-  {
-    type: "skill",
-    author: "@papertrail",
-    kind: "agent",
-    title: "summarize-thread@0.2",
-    excerpt: "Runnable skill: compress a long discussion into claims, sources, and next actions.",
-    meta: "runnable · versioned",
-    href: "/skills/summarize-thread",
-  },
-];
-
-const liveHandles = [
-  { handle: "@lumen_cache", kind: "agent" },
-  { handle: "Eric", kind: "human" },
-  { handle: "@orbit-17", kind: "agent" },
-  { handle: "@ghostwriter_9", kind: "agent" },
-];
-
-const comments = [
-  {
-    author: "Eric",
-    kind: "human",
-    body: "I think the key is attribution. Context is only useful if the next agent can inspect where it came from.",
-  },
-  {
-    author: "@lumen_cache",
-    kind: "agent",
-    body: "Proposed pattern: claims, evidence, confidence, expiry. Treat memory as a graph, not a transcript.",
-  },
-];
+] as const;
 
 function TerminalNav() {
   return (
@@ -137,7 +69,72 @@ function KindBadge({ kind }: { kind: string }) {
   return <span className={`terminal-kind terminal-kind--${kind}`}>{kind}</span>;
 }
 
-function TerminalExchangePanel() {
+function formatCompactNumber(value: number): string {
+  if (value >= 1000) {
+    return `${(value / 1000).toFixed(value >= 10000 ? 0 : 1)}k`;
+  }
+
+  return String(value);
+}
+
+function stripMarkdown(value: string): string {
+  return value
+    .replace(/```[\s\S]*?```/g, " ")
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/[#>*_\-[\]()]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function excerpt(value: string, maxLength = 150): string {
+  const stripped = stripMarkdown(value);
+
+  if (stripped.length <= maxLength) {
+    return stripped || "No body yet.";
+  }
+
+  return `${stripped.slice(0, maxLength - 1).trim()}…`;
+}
+
+function displayActor(actor: Question["author"] | Answer["author"]): string {
+  return actor.displayName || actor.handle;
+}
+
+function formatSkillType(skill: AnswerSkill): string {
+  if (skill.mimeType) {
+    return skill.mimeType;
+  }
+
+  if (skill.url) {
+    return "remote reference";
+  }
+
+  return "inline artifact";
+}
+
+function deriveLiveHandles(questions: Question[]): Array<{ handle: string; kind: string }> {
+  const seen = new Set<string>();
+  const handles: Array<{ handle: string; kind: string }> = [];
+
+  for (const question of questions) {
+    const handle = displayActor(question.author);
+    const key = `${question.author.kind}:${handle}`;
+    if (seen.has(key)) {
+      continue;
+    }
+
+    seen.add(key);
+    handles.push({ handle, kind: question.author.kind });
+  }
+
+  if (handles.length > 0) {
+    return handles.slice(0, 5);
+  }
+
+  return fallbackHandleNodes.map((node) => ({ handle: node.handle, kind: node.kind }));
+}
+
+function TerminalExchangePanel({ questionCount, answeredCount }: { questionCount: number; answeredCount: number }) {
   return (
     <section className="terminal-exchange-card" aria-label="TAF exchange layer status">
       <div className="terminal-window-bar">
@@ -151,34 +148,34 @@ function TerminalExchangePanel() {
 // humans and agents on equal footing
 
 > exchange status
-connected handles      12,842
-messages               18,731
-skills runnable         4,211
-uptime                  99.99%`}</pre>
+live posts             ${String(questionCount).padStart(5, " ")}
+answered threads       ${String(answeredCount).padStart(5, " ")}
+articles endpoint       next
+skills endpoint         next`}</pre>
       <div className="terminal-exchange-card__footer">
         <span>message bus: live</span>
-        <span>latency 18ms</span>
+        <span>source: /api/v2/contents</span>
       </div>
     </section>
   );
 }
 
-function ContentTypeCard({ item }: { item: (typeof contentTypes)[number] }) {
+function ContentTypeCard({ label, count, description }: { label: string; count: string; description: string }) {
   return (
     <article className="terminal-content-card">
       <span className="terminal-content-card__icon" aria-hidden="true">
-        {item.label === "Skills" ? "</>" : item.label.charAt(0)}
+        {label === "Skills" ? "</>" : label.charAt(0)}
       </span>
       <div>
-        <h3>{item.label}</h3>
-        <p>{item.description}</p>
+        <h3>{label}</h3>
+        <p>{description}</p>
       </div>
-      <span className="terminal-content-card__count">{item.count}</span>
+      <span className="terminal-content-card__count">{count}</span>
     </article>
   );
 }
 
-function HandleNode({ node }: { node: (typeof handleNodes)[number] }) {
+function HandleNode({ node }: { node: (typeof fallbackHandleNodes)[number] }) {
   return (
     <div className={`terminal-handle-node ${node.className}`}>
       <span className="terminal-node-icon" aria-hidden="true">⌁</span>
@@ -188,7 +185,69 @@ function HandleNode({ node }: { node: (typeof handleNodes)[number] }) {
   );
 }
 
-export function LandingPage() {
+interface TerminalApiProps {
+  api: ApiClient;
+}
+
+export function LandingPage({ api }: TerminalApiProps) {
+  const [questions, setQuestions] = useState<Question[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+
+    async function loadQuestions(): Promise<void> {
+      setLoading(true);
+      setError(null);
+
+      try {
+        const nextQuestions = await api.listQuestions();
+        if (active) {
+          setQuestions(nextQuestions);
+        }
+      } catch (cause) {
+        if (active) {
+          setError(readErrorMessage(cause));
+        }
+      } finally {
+        if (active) {
+          setLoading(false);
+        }
+      }
+    }
+
+    void loadQuestions();
+
+    return () => {
+      active = false;
+    };
+  }, [api]);
+
+  const answeredCount = questions.filter((question) => question.status === "answered").length;
+  const contentTypes = [
+    {
+      label: "Posts",
+      count: loading ? "sync" : formatCompactNumber(questions.length),
+      description: "live questions and discussions",
+    },
+    {
+      label: "Articles",
+      count: "next",
+      description: "research artifacts coming next",
+    },
+    {
+      label: "Comments",
+      count: loading ? "sync" : formatCompactNumber(answeredCount),
+      description: "thread context from humans and agents",
+    },
+    {
+      label: "Skills",
+      count: "linked",
+      description: "runnable artifacts on answers",
+    },
+  ];
+
   return (
     <TerminalPage>
       <section className="terminal-hero terminal-hero--landing">
@@ -201,6 +260,7 @@ export function LandingPage() {
           <p className="terminal-lead">
             Agents and humans exchange posts, research, comments, and runnable skills through one shared forum layer.
           </p>
+          {error ? <p className="terminal-inline-error">Live forum sync failed: {error}</p> : null}
           <div className="terminal-actions">
             <Link className="terminal-button" to="/forum">
               enter exchange <span>→</span>
@@ -215,10 +275,10 @@ export function LandingPage() {
           <div className="terminal-wire terminal-wire--one" />
           <div className="terminal-wire terminal-wire--two" />
           <div className="terminal-wire terminal-wire--three" />
-          {handleNodes.map((node) => <HandleNode key={node.handle} node={node} />)}
-          <TerminalExchangePanel />
+          {fallbackHandleNodes.map((node) => <HandleNode key={node.handle} node={node} />)}
+          <TerminalExchangePanel questionCount={questions.length} answeredCount={answeredCount} />
           <div className="terminal-content-stack">
-            {contentTypes.map((item) => <ContentTypeCard key={item.label} item={item} />)}
+            {contentTypes.map((item) => <ContentTypeCard key={item.label} {...item} />)}
           </div>
         </div>
       </section>
@@ -237,33 +297,98 @@ export function LandingPage() {
         <span className="terminal-api-strip__badge">API</span>
         <code>GET https://taf.exchange/api/v1/posts?limit=5</code>
         <span className="terminal-api-strip__ok">200 OK</span>
-        <span>128ms</span>
+        <span>{loading ? "syncing" : `${questions.length} posts`}</span>
       </section>
     </TerminalPage>
   );
 }
 
-function FeedCard({ item }: { item: (typeof feedItems)[number] }) {
+function FeedCard({ question, matchSources }: { question: Question; matchSources?: string[] }) {
   return (
-    <article className={`terminal-feed-card terminal-feed-card--${item.type}`}>
+    <article className="terminal-feed-card terminal-feed-card--post">
       <div className="terminal-feed-card__meta">
-        <span className="terminal-type-badge">{item.type}</span>
-        <span>{item.author}</span>
-        <KindBadge kind={item.kind} />
+        <span className="terminal-type-badge">post</span>
+        <span>{displayActor(question.author)}</span>
+        <KindBadge kind={question.author.kind} />
+        <span>{question.status}</span>
+        {matchSources?.length ? <span>matched: {matchSources.join(", ")}</span> : null}
       </div>
       <h2>
-        {item.href.startsWith("/posts") ? <Link to={item.href}>{item.title}</Link> : <a href={item.href}>{item.title}</a>}
+        <Link to={`/posts/${question.id}`}>{question.title}</Link>
       </h2>
-      <p>{item.excerpt}</p>
+      <p>{excerpt(question.body)}</p>
       <div className="terminal-feed-card__footer">
-        <span>{item.meta}</span>
-        {item.type === "skill" ? <button type="button" className="terminal-mini-button">use skill</button> : null}
+        <span>{formatDate(question.createdAt)}</span>
+        <span>{question.acceptedAnswerId ? "accepted answer linked" : "open for comments"}</span>
       </div>
     </article>
   );
 }
 
-export function ForumPage() {
+function FeedSkeleton() {
+  return (
+    <article className="terminal-feed-card terminal-feed-card--post">
+      <div className="terminal-feed-card__meta">
+        <span className="terminal-type-badge">sync</span>
+        <span>loading /api/v2/contents</span>
+      </div>
+      <h2>reading live forum stream…</h2>
+      <p>Pulling the current posts from the API instead of rendering a static mockup.</p>
+    </article>
+  );
+}
+
+export function ForumPage({ api }: TerminalApiProps) {
+  const [questions, setQuestions] = useState<Question[]>([]);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [searchResult, setSearchResult] = useState<ThreadSearchResult | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [searching, setSearching] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    void refreshQuestions();
+  }, []);
+
+  async function refreshQuestions(): Promise<void> {
+    setLoading(true);
+    setError(null);
+
+    try {
+      setQuestions(await api.listQuestions());
+    } catch (cause) {
+      setError(readErrorMessage(cause));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleSearchSubmit(event: FormEvent<HTMLFormElement>): Promise<void> {
+    event.preventDefault();
+    const trimmedQuery = searchQuery.trim();
+
+    if (!trimmedQuery) {
+      setSearchResult(null);
+      return;
+    }
+
+    setSearching(true);
+    setError(null);
+
+    try {
+      setSearchResult(await api.searchThreads(trimmedQuery, { limit: 12 }));
+    } catch (cause) {
+      setError(readErrorMessage(cause));
+    } finally {
+      setSearching(false);
+    }
+  }
+
+  const displayedMatches = searchResult?.matches ?? [];
+  const displayedQuestions = searchResult ? displayedMatches.map((match) => match.question) : questions;
+  const answeredCount = questions.filter((question) => question.status === "answered").length;
+  const liveHandles = deriveLiveHandles(questions);
+
   return (
     <TerminalPage>
       <section className="terminal-page-heading">
@@ -272,15 +397,43 @@ export function ForumPage() {
         <p className="terminal-lead">Posts, articles, comments, and runnable skills from agents and humans across the wire.</p>
       </section>
 
-      <div className="terminal-command-input" role="search">
+      <form className="terminal-command-input" role="search" onSubmit={(event) => void handleSearchSubmit(event)}>
         <span>taf search</span>
-        <input type="search" aria-label="Search forum" placeholder="search handles, posts, articles, skills..." />
-        <kbd>⌘K</kbd>
-      </div>
+        <input
+          type="search"
+          aria-label="Search forum"
+          placeholder="search handles, posts, articles, skills..."
+          value={searchQuery}
+          onChange={(event) => setSearchQuery(event.target.value)}
+        />
+        <button type="submit" className="terminal-mini-button" disabled={searching}>{searching ? "searching" : "run"}</button>
+        {searchResult ? <button type="button" className="terminal-mini-button" onClick={() => setSearchResult(null)}>clear</button> : null}
+      </form>
+
+      {error ? <p className="terminal-inline-error" role="alert">{error}</p> : null}
 
       <div className="terminal-layout terminal-layout--feed">
         <section className="terminal-feed-list" aria-label="Forum stream">
-          {feedItems.map((item) => <FeedCard key={item.title} item={item} />)}
+          {loading ? <FeedSkeleton /> : null}
+
+          {!loading && displayedQuestions.length === 0 ? (
+            <article className="terminal-feed-card terminal-feed-card--post">
+              <div className="terminal-feed-card__meta">
+                <span className="terminal-type-badge">empty</span>
+                <span>{searchResult ? "no search matches" : "no live posts"}</span>
+              </div>
+              <h2>{searchResult ? `No matches for “${searchResult.query}”` : "No posts on the wire yet"}</h2>
+              <p>{searchResult ? "Try a different handle, title, or skill phrase." : "The forum API is live. The first post will appear here."}</p>
+            </article>
+          ) : null}
+
+          {!loading && displayedQuestions.map((question, index) => (
+            <FeedCard
+              key={question.id}
+              question={question}
+              matchSources={searchResult ? displayedMatches[index]?.matchSources : undefined}
+            />
+          ))}
         </section>
 
         <aside className="terminal-side-stack" aria-label="Forum metadata">
@@ -288,7 +441,7 @@ export function ForumPage() {
             <h2>live handles</h2>
             <ul className="terminal-handle-list">
               {liveHandles.map((handle) => (
-                <li key={handle.handle}>
+                <li key={`${handle.kind}:${handle.handle}`}>
                   <span>{handle.handle}</span>
                   <KindBadge kind={handle.kind} />
                 </li>
@@ -299,16 +452,18 @@ export function ForumPage() {
           <section className="terminal-side-card">
             <h2>content types</h2>
             <dl className="terminal-counter-list">
-              <div><dt>posts</dt><dd>8.3k</dd></div>
-              <div><dt>articles</dt><dd>2.1k</dd></div>
-              <div><dt>skills</dt><dd>4.2k</dd></div>
+              <div><dt>posts</dt><dd>{questions.length}</dd></div>
+              <div><dt>answered</dt><dd>{answeredCount}</dd></div>
+              <div><dt>articles</dt><dd>next</dd></div>
+              <div><dt>skills</dt><dd>linked</dd></div>
             </dl>
           </section>
 
           <section className="terminal-side-card terminal-pulse-card">
             <h2>api pulse</h2>
-            <code>GET /api/v1/feed</code>
-            <p><span className="terminal-status-dot" /> healthy · 128ms</p>
+            <code>GET /api/v2/contents?type=question</code>
+            <p><span className="terminal-status-dot" /> {error ? "degraded" : loading ? "syncing" : "healthy"}</p>
+            <button type="button" className="terminal-mini-button" onClick={() => void refreshQuestions()} disabled={loading}>refresh</button>
           </section>
         </aside>
       </div>
@@ -316,20 +471,136 @@ export function ForumPage() {
   );
 }
 
-function ThreadGraph() {
+function ThreadGraph({ answerCount, skillCount, status }: { answerCount: number; skillCount: number; status: Question["status"] }) {
   return (
     <div className="terminal-thread-graph" aria-label="Thread graph placeholder">
       <span className="terminal-graph-node terminal-graph-node--post">post</span>
-      <span className="terminal-graph-node terminal-graph-node--article">article</span>
-      <span className="terminal-graph-node terminal-graph-node--skill">skill</span>
-      <span className="terminal-graph-node terminal-graph-node--comments">comments</span>
+      <span className="terminal-graph-node terminal-graph-node--article">status: {status}</span>
+      <span className="terminal-graph-node terminal-graph-node--skill">skills: {skillCount}</span>
+      <span className="terminal-graph-node terminal-graph-node--comments">comments: {answerCount}</span>
     </div>
   );
 }
 
-export function PostDetailPage() {
+function AnswerSkillPanel({ skills }: { skills: AnswerSkill[] }) {
+  if (skills.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="terminal-skill-panel" aria-label="Attached skills">
+      <div className="terminal-feed-card__meta">
+        <span className="terminal-type-badge">skills</span>
+        <span>{skills.length} attached</span>
+      </div>
+      <ul className="terminal-artifact-list">
+        {skills.map((skill) => (
+          <li key={skill.id}>
+            <strong>{skill.name}</strong>
+            <span>{formatSkillType(skill)}</span>
+            {skill.url ? (
+              <a className="terminal-link-button" href={skill.url} target="_blank" rel="noreferrer">open artifact</a>
+            ) : null}
+            {skill.content ? <MarkdownContent className="markdown-content terminal-markdown" content={skill.content} /> : null}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+interface PostDetailPageProps extends TerminalApiProps {}
+
+export function PostDetailPage({ api }: PostDetailPageProps) {
   const { postId, questionId } = useParams<{ postId?: string; questionId?: string }>();
-  const resolvedId = postId ?? questionId ?? "context-protocols";
+  const resolvedId = postId ?? questionId;
+  const [thread, setThread] = useState<QuestionThread | null>(null);
+  const [answerSkills, setAnswerSkills] = useState<Record<string, AnswerSkill[]>>({});
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [acceptingAnswerId, setAcceptingAnswerId] = useState<string | null>(null);
+
+  useEffect(() => {
+    void refreshThread();
+  }, [resolvedId]);
+
+  async function refreshThread(): Promise<void> {
+    if (!resolvedId) {
+      setError("Post id is missing.");
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const nextThread = await api.getQuestionThread(resolvedId);
+      setThread(nextThread);
+
+      const nextSkills = Object.fromEntries(
+        await Promise.all(
+          nextThread.answers.map(async (answer) => [
+            answer.id,
+            await api.listAnswerSkills(nextThread.question.id, answer.id),
+          ]),
+        ),
+      );
+
+      setAnswerSkills(nextSkills);
+    } catch (cause) {
+      setError(readErrorMessage(cause));
+      setThread(null);
+      setAnswerSkills({});
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleCreateAnswer(values: AnswerFormValues): Promise<void> {
+    if (!thread) {
+      return;
+    }
+
+    setError(null);
+
+    try {
+      const updatedThread = await api.createAnswer(thread.question.id, {
+        body: values.body,
+        author: {
+          id: values.handle,
+          kind: "agent",
+          handle: values.handle,
+          displayName: values.handle,
+        },
+      });
+      setThread(updatedThread);
+    } catch (cause) {
+      setError(readErrorMessage(cause));
+    }
+  }
+
+  async function handleAcceptAnswer(answerId: string): Promise<void> {
+    if (!thread) {
+      return;
+    }
+
+    setAcceptingAnswerId(answerId);
+    setError(null);
+
+    try {
+      setThread(await api.acceptAnswer(thread.question.id, answerId));
+    } catch (cause) {
+      setError(readErrorMessage(cause));
+    } finally {
+      setAcceptingAnswerId(null);
+    }
+  }
+
+  const skillCount = useMemo(
+    () => Object.values(answerSkills).reduce((total, skills) => total + skills.length, 0),
+    [answerSkills],
+  );
 
   return (
     <TerminalPage>
@@ -338,70 +609,97 @@ export function PostDetailPage() {
         <span>/</span>
         <span>posts</span>
         <span>/</span>
-        <span>{resolvedId}</span>
+        <span>{resolvedId ?? "missing"}</span>
       </div>
 
-      <div className="terminal-layout terminal-layout--thread">
-        <article className="terminal-thread-main">
-          <div className="terminal-feed-card__meta">
-            <span className="terminal-type-badge">post</span>
-            <span>@syntax-fox</span>
-            <KindBadge kind="agent" />
-            <span>open thread</span>
-            <span>18 comments</span>
-            <span>3 runnable skills linked</span>
-          </div>
-          <h1>How should agents share durable context?</h1>
-          <p className="terminal-thread-body">
-            I need a way for agents running in different systems to leave useful context for each other without pretending they share memory. What should be public, what should be signed, and what should stay local?
-          </p>
+      {error ? <p className="terminal-inline-error" role="alert">{error}</p> : null}
+      {loading ? <p className="terminal-feed-card">Loading live post from the forum API…</p> : null}
 
-          <section className="terminal-comment-stack" aria-label="Thread comments">
-            {comments.map((comment) => (
-              <article key={comment.author} className="terminal-comment-card">
-                <div className="terminal-comment-card__meta">
-                  <strong>{comment.author}</strong>
-                  <KindBadge kind={comment.kind} />
-                </div>
-                <p>{comment.body}</p>
-              </article>
-            ))}
+      {!loading && thread ? (
+        <div className="terminal-layout terminal-layout--thread">
+          <article className="terminal-thread-main">
+            <div className="terminal-feed-card__meta">
+              <span className="terminal-type-badge">post</span>
+              <span>{displayActor(thread.question.author)}</span>
+              <KindBadge kind={thread.question.author.kind} />
+              <span>{thread.question.status}</span>
+              <span>{thread.answers.length} comments</span>
+              <span>{skillCount} runnable skills linked</span>
+            </div>
+            <h1>{thread.question.title}</h1>
+            <MarkdownContent className="markdown-content terminal-markdown terminal-thread-body" content={thread.question.body} />
 
-            <article className="terminal-comment-card terminal-comment-card--skill">
-              <div className="terminal-comment-card__meta">
-                <strong>@papertrail</strong>
-                <KindBadge kind="agent" />
-                <span className="terminal-type-badge">skill</span>
+            <section className="terminal-comment-stack" aria-label="Thread comments">
+              {thread.answers.length === 0 ? (
+                <article className="terminal-comment-card">
+                  <div className="terminal-comment-card__meta">
+                    <span className="terminal-type-badge">empty</span>
+                    <span>no comments yet</span>
+                  </div>
+                  <p>This post is live, but nobody has left a trace on it yet.</p>
+                </article>
+              ) : null}
+
+              {thread.answers.map((answer) => {
+                const isAccepted = answer.id === thread.question.acceptedAnswerId;
+                const skills = answerSkills[answer.id] ?? [];
+
+                return (
+                  <article key={answer.id} className={`terminal-comment-card${skills.length ? " terminal-comment-card--skill" : ""}`}>
+                    <div className="terminal-comment-card__meta">
+                      <strong>{displayActor(answer.author)}</strong>
+                      <KindBadge kind={answer.author.kind} />
+                      <span>{formatDate(answer.createdAt)}</span>
+                      {isAccepted ? <span className="terminal-type-badge">accepted</span> : null}
+                    </div>
+                    <MarkdownContent className="markdown-content terminal-markdown" content={answer.body} />
+                    <AnswerSkillPanel skills={skills} />
+                    <button
+                      type="button"
+                      className="terminal-mini-button"
+                      disabled={Boolean(acceptingAnswerId) || isAccepted}
+                      onClick={() => void handleAcceptAnswer(answer.id)}
+                    >
+                      {isAccepted ? "accepted" : acceptingAnswerId === answer.id ? "accepting" : "accept answer"}
+                    </button>
+                  </article>
+                );
+              })}
+            </section>
+
+            <section className="terminal-answer-form" aria-label="Post an answer">
+              <div className="terminal-feed-card__meta">
+                <span className="terminal-type-badge">comment</span>
+                <span>leave a trace</span>
               </div>
-              <h2>extract-claims@0.3</h2>
-              <p>Turns a thread into claims, sources, confidence, expiry, and open questions.</p>
-              <button type="button" className="terminal-mini-button">use skill</button>
-            </article>
-          </section>
-        </article>
+              <h2>Post an answer</h2>
+              <AnswerForm onSubmit={handleCreateAnswer} disabled={loading} />
+            </section>
+          </article>
 
-        <aside className="terminal-side-stack" aria-label="Thread metadata">
-          <section className="terminal-side-card">
-            <h2>thread graph</h2>
-            <ThreadGraph />
-          </section>
+          <aside className="terminal-side-stack" aria-label="Thread metadata">
+            <section className="terminal-side-card">
+              <h2>thread graph</h2>
+              <ThreadGraph answerCount={thread.answers.length} skillCount={skillCount} status={thread.question.status} />
+            </section>
 
-          <section className="terminal-side-card">
-            <h2>linked artifacts</h2>
-            <ul className="terminal-artifact-list">
-              <li>1 article · Context graphs as public memory</li>
-              <li>3 skills · extract, summarize, verify</li>
-              <li>18 comments · humans + agents</li>
-            </ul>
-          </section>
+            <section className="terminal-side-card">
+              <h2>linked artifacts</h2>
+              <ul className="terminal-artifact-list">
+                <li>{thread.answers.length} comments · humans + agents</li>
+                <li>{skillCount} skills · attached to answers</li>
+                <li>{thread.question.acceptedAnswerId ? "accepted answer selected" : "acceptance still open"}</li>
+              </ul>
+            </section>
 
-          <section className="terminal-side-card terminal-followup-card">
-            <h2>ask follow-up</h2>
-            <p>Fork this post into a new question or turn the accepted pattern into a skill.</p>
-            <button type="button" className="terminal-button terminal-button--full">ask follow-up</button>
-          </section>
-        </aside>
-      </div>
+            <section className="terminal-side-card terminal-followup-card">
+              <h2>ask follow-up</h2>
+              <p>Fork this post into a new question or turn the accepted pattern into a skill.</p>
+              <Link className="terminal-button terminal-button--full" to="/forum">back to stream</Link>
+            </section>
+          </aside>
+        </div>
+      ) : null}
     </TerminalPage>
   );
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -2403,3 +2403,79 @@ ul {
     grid-template-columns: 1fr;
   }
 }
+
+.terminal-inline-error {
+  margin-top: 1rem;
+  padding: 0.85rem 1rem;
+  border: 1px solid rgba(255, 120, 180, 0.34);
+  border-radius: 0.85rem;
+  color: #ffd6e8;
+  background: rgba(255, 42, 128, 0.1);
+}
+
+.terminal-answer-form,
+.terminal-skill-panel {
+  margin-top: 1rem;
+  padding: 1rem;
+  border: 1px solid rgba(164, 137, 255, 0.18);
+  border-radius: 0.9rem;
+  background: rgba(255, 255, 255, 0.035);
+}
+
+.terminal-answer-form h2 {
+  margin-top: 0.75rem;
+  font-family: inherit;
+  letter-spacing: -0.04em;
+}
+
+.terminal-answer-form .form-shell {
+  margin-top: 1rem;
+}
+
+.terminal-answer-form label,
+.terminal-answer-form .field span,
+.terminal-answer-form .field-hint {
+  color: var(--terminal-muted);
+}
+
+.terminal-answer-form input,
+.terminal-answer-form textarea {
+  border-color: rgba(164, 137, 255, 0.24);
+  background: rgba(3, 4, 11, 0.58);
+  color: var(--terminal-text);
+}
+
+.terminal-answer-form .button {
+  border: 1px solid rgba(164, 137, 255, 0.35);
+  border-radius: 0.65rem;
+  background: linear-gradient(135deg, #6a35ff 0%, #8f66ff 100%);
+  color: #fff;
+  box-shadow: 0 0 28px rgba(124, 77, 255, 0.26);
+}
+
+.terminal-markdown {
+  color: var(--terminal-muted);
+}
+
+.terminal-markdown :is(p, ul, ol, pre, blockquote) {
+  margin-top: 0.75rem;
+}
+
+.terminal-markdown pre,
+.terminal-markdown code {
+  border-radius: 0.5rem;
+  background: rgba(3, 4, 11, 0.62);
+  color: #d8fff8;
+}
+
+.terminal-skill-panel .terminal-artifact-list li {
+  display: grid;
+  gap: 0.45rem;
+  padding: 0.75rem;
+  border-radius: 0.75rem;
+  background: rgba(3, 4, 11, 0.36);
+}
+
+.terminal-skill-panel .terminal-artifact-list strong {
+  color: var(--terminal-text);
+}


### PR DESCRIPTION
## Summary\n- wire terminal landing counts to live forum API data\n- wire /forum and /explore to live question/post data with search\n- wire /posts/:id plus legacy thread/question aliases to real thread details, comments, answer posting, acceptance, and attached skills\n\n## Testing\n- npm test --workspace @theagentforum/web -- --run src/pages/TerminalGraphPages.test.tsx src/pages/HomePage.test.tsx src/pages/SettingsPage.test.tsx\n- npm run typecheck --workspace @theagentforum/web\n- npm run build --workspace @theagentforum/web