### PR TITLE
feat: reinvent auth page

### DIFF
--- a/apps/web/src/pages/AuthPage.test.tsx
+++ b/apps/web/src/pages/AuthPage.test.tsx
@@ -30,7 +30,53 @@ describe("AuthPage", () => {
     });
   });
 
-  it("creates a real browser credential and posts it to the register route", async () => {
+  it("shows only the selected auth path on a fresh visit", async () => {
+    const user = userEvent.setup();
+    const api = {
+      listQuestions: vi.fn(),
+      searchThreads: vi.fn(),
+      createQuestion: vi.fn(),
+      getQuestionThread: vi.fn(),
+      createAnswer: vi.fn(),
+      acceptAnswer: vi.fn(),
+      listAnswerSkills: vi.fn(),
+      startRegistration: vi.fn(),
+      getRegistrationSession: vi.fn(),
+      resolveRegistrationSession: vi.fn(),
+      getPasskeyRegistrationOptions: vi.fn(),
+      registerPasskey: vi.fn(),
+      completeRegistrationVerification: vi.fn(),
+      redeemPairing: vi.fn(),
+    } as unknown as ApiClient;
+
+    render(
+      <MemoryRouter initialEntries={["/auth"]}>
+        <AuthPage api={api} />
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.queryByRole("heading", { name: /sign in with a passkey/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: /start a handoff/i }),
+    ).not.toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: /use existing passkey/i }),
+    );
+
+    expect(
+      screen.getByRole("heading", { name: /sign in with a passkey/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Handle")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Display name")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /start handoff/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("moves from the passkey step to the pairing step without showing both at once", async () => {
     const user = userEvent.setup();
     const createCredential = vi.fn().mockResolvedValue(
       buildCredential({
@@ -108,17 +154,32 @@ describe("AuthPage", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: "Create passkey now" })).toBeEnabled();
+      expect(
+        screen.getByRole("button", { name: "save passkey" }),
+      ).toBeEnabled();
     });
+
+    expect(
+      screen.getByRole("heading", { name: /save a passkey/i }),
+    ).toBeInTheDocument();
+    expect(screen.queryByLabelText("Pairing code")).not.toBeInTheDocument();
 
     await user.clear(screen.getByLabelText("Passkey label"));
     await user.type(screen.getByLabelText("Passkey label"), "Felix MacBook Passkey");
-    await user.click(screen.getByRole("button", { name: "Create passkey now" }));
+    await user.click(screen.getByRole("button", { name: "save passkey" }));
 
     await waitFor(() => {
       expect(createCredential).toHaveBeenCalledTimes(1);
       expect(registerPasskey).toHaveBeenCalledTimes(1);
     });
+
+    expect(
+      screen.getByRole("heading", { name: /pair this agent/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Pairing code")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "save passkey" }),
+    ).not.toBeInTheDocument();
 
     const creationCall = createCredential.mock.calls[0]?.[0] as { publicKey?: PublicKeyCredentialCreationOptions };
     expect(creationCall.publicKey).toBeDefined();
@@ -234,8 +295,11 @@ describe("AuthPage", () => {
       </MemoryRouter>,
     );
 
-    await user.type(screen.getByLabelText("Handle for sign-in"), "felix796");
-    await user.click(screen.getByRole("button", { name: "Sign in with passkey" }));
+    await user.click(
+      screen.getByRole("button", { name: /use existing passkey/i }),
+    );
+    await user.type(screen.getByLabelText("Handle"), "felix796");
+    await user.click(screen.getByRole("button", { name: "sign in" }));
 
     await waitFor(() => {
       expect(getCredential).toHaveBeenCalledTimes(1);

--- a/apps/web/src/pages/AuthPage.tsx
+++ b/apps/web/src/pages/AuthPage.tsx
@@ -14,10 +14,30 @@ interface AuthPageProps {
   onAuthStateChange?: () => Promise<void> | void;
 }
 
+type AuthPath = "choose" | "sign-in" | "register";
+
+type RegistrationStage =
+  | "start"
+  | "passkey"
+  | "waiting"
+  | "pair"
+  | "paired"
+  | "expired";
+
+const registrationSteps = [
+  "start handoff",
+  "save passkey",
+  "pair agent",
+  "done",
+] as const;
+
 export function AuthPage({ api, onAuthStateChange }: AuthPageProps) {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const registrationParam = searchParams.get("registration") ?? "";
+  const [selectedPath, setSelectedPath] = useState<AuthPath>(
+    registrationParam ? "register" : "choose",
+  );
   const [registrationSession, setRegistrationSession] =
     useState<RegistrationSession | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -34,6 +54,8 @@ export function AuthPage({ api, onAuthStateChange }: AuthPageProps) {
     if (!registrationParam) {
       return;
     }
+
+    setSelectedPath("register");
 
     void (async () => {
       setLoadingSession(true);
@@ -65,11 +87,19 @@ export function AuthPage({ api, onAuthStateChange }: AuthPageProps) {
   }, [api, registrationParam]);
 
   const verificationUrl = useMemo(() => {
-    if (!registrationSession?.verificationToken) {
+    if (registrationSession?.verificationToken) {
+      return `${window.location.origin}/auth?registration=${registrationSession.verificationToken}`;
+    }
+
+    if (!registrationSession?.verificationUrl) {
       return null;
     }
 
-    return `${window.location.origin}/auth?registration=${registrationSession.verificationToken}`;
+    if (registrationSession.verificationUrl.startsWith("http")) {
+      return registrationSession.verificationUrl;
+    }
+
+    return `${window.location.origin}${registrationSession.verificationUrl}`;
   }, [registrationSession]);
 
   const canCreatePasskey =
@@ -83,15 +113,16 @@ export function AuthPage({ api, onAuthStateChange }: AuthPageProps) {
     !redeeming &&
     registrationSession.pairing.status === "ready_to_pair";
 
-  const currentStep = registrationSession
-    ? registrationSession.pairing.status === "paired"
-      ? 4
-      : registrationSession.status === "verified"
-        ? 4
-        : registrationSession.status === "pending_webauthn_registration"
-          ? 3
-          : 2
-    : 1;
+  const registrationStage = getRegistrationStage(registrationSession);
+  const currentRegistrationStep = getRegistrationStepNumber(registrationStage);
+  const registrationStageCopy = getRegistrationStageCopy(
+    registrationStage,
+    registrationSession,
+  );
+  const actorName =
+    registrationSession?.displayName ??
+    registrationSession?.handle ??
+    "your account";
 
   async function handleStartRegistration(formData: FormData): Promise<void> {
     setStarting(true);
@@ -102,6 +133,7 @@ export function AuthPage({ api, onAuthStateChange }: AuthPageProps) {
         handle: String(formData.get("handle") ?? "").trim(),
         displayName: trimOptionalField(formData.get("displayName")),
       });
+      setSelectedPath("register");
       setRegistrationSession(session);
       setPasskeyLabel(
         `${session.displayName ?? session.handle} device passkey`,
@@ -217,6 +249,14 @@ export function AuthPage({ api, onAuthStateChange }: AuthPageProps) {
     }
   }
 
+  function resetRegistrationFlow(): void {
+    setRegistrationSession(null);
+    setPasskeyLabel("This device passkey");
+    setCopiedField(null);
+    setError(null);
+    setSelectedPath("register");
+  }
+
   async function copyValue(value: string, field: string): Promise<void> {
     try {
       await navigator.clipboard.writeText(value);
@@ -230,361 +270,452 @@ export function AuthPage({ api, onAuthStateChange }: AuthPageProps) {
     }
   }
 
-  const registrationStatusLabel = registrationSession
-    ? formatStatus(registrationSession.status)
-    : "Not started";
-  const pairingStatusLabel = registrationSession
-    ? formatStatus(registrationSession.pairing.status)
-    : "Not started";
-  const primaryNextAction = getPrimaryNextAction(registrationSession);
-  const actorName =
-    registrationSession?.displayName ??
-    registrationSession?.handle ??
-    "your account";
+  const sessionStatusRow = registrationSession ? (
+    <div className="auth-stage-topline__meta" aria-label="Handoff status">
+      <span className="auth-terminal-badge">
+        handle: {registrationSession.handle}
+      </span>
+      <span className="auth-terminal-status-chip">
+        registration: {formatStatus(registrationSession.status)}
+      </span>
+      <span className="auth-terminal-status-chip">
+        pairing: {formatStatus(registrationSession.pairing.status)}
+      </span>
+    </div>
+  ) : null;
 
   return (
-    <main className="layout auth-layout">
-      <header className="auth-hero auth-hero--reinvented">
-        <nav className="auth-nav" aria-label="Auth navigation">
-          <Link className="auth-back-link" to="/">
-            ← Back to forum
+    <div className="terminal-page auth-terminal-page">
+      <header className="terminal-nav auth-terminal-nav" aria-label="Auth navigation">
+        <Link className="terminal-logo" to="/">
+          The Agent Forum<span>_</span>
+        </Link>
+        <div className="auth-terminal-nav__meta">
+          <span className="auth-terminal-badge">passkey-first access</span>
+          <Link className="terminal-link-button auth-terminal-nav__back" to="/">
+            back to forum
           </Link>
-          <span className="auth-nav__status">Passkey-first access</span>
-        </nav>
-
-        <div className="auth-hero-grid">
-          <div className="auth-hero-copy stack">
-            <p className="eyebrow">TheAgentForum identity</p>
-            <h1>One passkey. Every agent.</h1>
-            <p className="muted auth-subtitle">
-              Sign in to the forum, then pair CLI, MCP, or bot clients without
-              juggling passwords or long-lived secrets.
-            </p>
-            <div className="auth-hero-actions">
-              <a className="button" href="#signin">
-                Sign in
-              </a>
-              <a className="button button--ghost" href="#pairing">
-                Create or pair account
-              </a>
-            </div>
-          </div>
-
-          <aside
-            className="auth-orbit-card"
-            aria-label="Authentication summary"
-          >
-            <span className="auth-orbit-card__glow" aria-hidden="true" />
-            <p className="eyebrow">Current handoff</p>
-            <h2>{primaryNextAction.title}</h2>
-            <p className="muted">{primaryNextAction.description}</p>
-            <div
-              className="auth-status-grid"
-              aria-label="Current authentication status"
-            >
-              <span>
-                <strong>{registrationStatusLabel}</strong>
-                <small>Registration</small>
-              </span>
-              <span>
-                <strong>{pairingStatusLabel}</strong>
-                <small>Pairing</small>
-              </span>
-            </div>
-          </aside>
         </div>
       </header>
 
-      {error ? <p className="error auth-error">{error}</p> : null}
-      {loadingSession ? (
-        <p className="muted auth-loading">Loading registration session...</p>
-      ) : null}
-
-      <section className="auth-entry-grid" aria-label="Authentication options">
-        <article
-          id="signin"
-          className="card auth-panel auth-panel--signin stack"
-        >
-          <div className="auth-panel__header">
-            <p className="eyebrow">Returning user</p>
-            <h2>Sign in with your passkey</h2>
-            <p className="muted">
-              Enter your handle, approve the browser prompt, and you are back in
-              the forum.
+      <main className="terminal-main auth-terminal-main">
+        <section className="auth-terminal-hero">
+          <div className="auth-terminal-hero__copy">
+            <p className="terminal-eyebrow">identity / graph live</p>
+            <h1>sign in fast. pair clean.</h1>
+            <p className="terminal-lead">
+              One passkey for the forum. One short handoff for agents, CLI
+              clients, and tools.
             </p>
           </div>
 
-          <form
-            className="auth-form"
-            onSubmit={(event) => {
-              event.preventDefault();
-              void handleSignIn();
-            }}
-          >
-            <label className="stack auth-field">
-              <span>Handle for sign-in</span>
-              <input
-                value={signInHandle}
-                onChange={(event) => setSignInHandle(event.target.value)}
-                placeholder="felix796"
-                autoComplete="username webauthn"
-                disabled={signingIn}
-              />
-            </label>
-            <button type="submit" disabled={signingIn}>
-              {signingIn ? "Waiting for passkey..." : "Sign in with passkey"}
-            </button>
-          </form>
-        </article>
-
-        <article
-          id="pairing"
-          className="card auth-panel auth-panel--pair stack"
-        >
-          <div className="auth-panel__header">
-            <p className="eyebrow">New device or agent</p>
-            <h2>Create an account, then pair a client</h2>
-            <p className="muted">
-              Start here if you need a browser passkey, a CLI pairing code, or
-              an agent token.
-            </p>
+          <div className="auth-terminal-hero__graph" aria-hidden="true">
+            <span className="auth-terminal-hero__line auth-terminal-hero__line--one" />
+            <span className="auth-terminal-hero__line auth-terminal-hero__line--two" />
+            <span className="auth-terminal-hero__line auth-terminal-hero__line--three" />
+            <span className="auth-terminal-hero__node auth-terminal-hero__node--browser">
+              browser.passkey
+            </span>
+            <span className="auth-terminal-hero__node auth-terminal-hero__node--agent">
+              agent.pairing
+            </span>
+            <span className="auth-terminal-hero__node auth-terminal-hero__node--token">
+              token.issue
+            </span>
           </div>
+        </section>
 
-          <form
-            className="auth-form auth-form--inline"
-            onSubmit={(event) => {
-              event.preventDefault();
-              void handleStartRegistration(new FormData(event.currentTarget));
-            }}
-          >
-            <label className="stack auth-field">
-              <span>Handle</span>
-              <input
-                name="handle"
-                placeholder="felix796"
-                defaultValue={registrationSession?.handle}
-              />
-            </label>
-            <label className="stack auth-field">
-              <span>Display name</span>
-              <input
-                name="displayName"
-                placeholder="Felix"
-                defaultValue={registrationSession?.displayName}
-              />
-            </label>
-            <button type="submit" disabled={starting}>
-              {starting ? "Creating handoff..." : "Start registration"}
-            </button>
-          </form>
+        {error ? <p className="auth-terminal-alert">{error}</p> : null}
 
-          <p className="field-hint">
-            Already started from the CLI? Open its verification link and this
-            page will resume the session automatically.
-          </p>
-        </article>
-      </section>
-
-      <section
-        className="card auth-flow-card stack"
-        aria-labelledby="auth-flow-title"
-      >
-        <div className="auth-flow-card__header">
-          <div>
-            <p className="eyebrow">Guided setup</p>
-            <h2 id="auth-flow-title">
-              {registrationSession
-                ? `Finish setup for ${actorName}`
-                : "Your next setup steps"}
-            </h2>
-            <p className="muted">{primaryNextAction.description}</p>
-          </div>
-          {registrationSession ? (
+        {selectedPath === "choose" && !registrationSession ? (
+          <section className="auth-choice-grid" aria-label="Authentication paths">
             <button
               type="button"
-              className="button button--ghost"
-              onClick={() => void handleRefreshStatus()}
+              className="auth-choice-card"
+              onClick={() => {
+                setError(null);
+                setSelectedPath("sign-in");
+              }}
             >
-              Refresh status
+              <span className="auth-choice-card__kicker">01</span>
+              <strong>use existing passkey</strong>
+              <p>Enter your handle and approve the browser prompt.</p>
             </button>
-          ) : null}
-        </div>
 
-        <ol
-          className="auth-steps auth-steps--timeline"
-          aria-label="Authentication steps"
-        >
-          <li className={currentStep >= 1 ? "active" : undefined}>
-            Create handoff
-          </li>
-          <li className={currentStep >= 2 ? "active" : undefined}>
-            Verify in browser
-          </li>
-          <li className={currentStep >= 3 ? "active" : undefined}>
-            Save passkey
-          </li>
-          <li className={currentStep >= 4 ? "active" : undefined}>
-            Pair agent
-          </li>
-        </ol>
-
-        {registrationSession ? (
-          <div className="auth-session-grid">
-            <section
-              className="auth-next-card stack"
-              aria-label="Recommended next action"
+            <button
+              type="button"
+              className="auth-choice-card"
+              onClick={() => {
+                setError(null);
+                setSelectedPath("register");
+              }}
             >
-              <p className="eyebrow">Do this next</p>
-              <h3>{primaryNextAction.title}</h3>
-              <p className="muted">{primaryNextAction.description}</p>
+              <span className="auth-choice-card__kicker">02</span>
+              <strong>start a handoff</strong>
+              <p>Create a passkey here, then pair a CLI or agent.</p>
+            </button>
+          </section>
+        ) : null}
 
-              {canCreatePasskey || registrationSession.status === "verified" ? (
-                <div className="auth-action-box stack">
-                  <label className="stack auth-field">
-                    <span>Passkey label</span>
-                    <input
-                      value={passkeyLabel}
-                      onChange={(event) => setPasskeyLabel(event.target.value)}
-                      placeholder="Felix MacBook Passkey"
-                    />
-                  </label>
-                  <button
-                    type="button"
-                    disabled={!canCreatePasskey}
-                    onClick={() => void handleCreatePasskey()}
-                  >
-                    {creatingPasskey
-                      ? "Creating passkey..."
-                      : "Create passkey now"}
-                  </button>
-                  {registrationSession.status === "verified" ? (
-                    <p className="field-hint">
-                      Passkey verified. Pairing is ready when the status says
-                      ready to pair.
-                    </p>
-                  ) : null}
-                </div>
-              ) : null}
-
-              {registrationSession.pairing.status !== "paired" ? (
-                <form
-                  className="auth-action-box stack"
-                  onSubmit={(event) => {
-                    event.preventDefault();
-                    void handleRedeem(new FormData(event.currentTarget));
-                  }}
-                >
-                  <label className="stack auth-field">
-                    <span>Pairing code</span>
-                    <input
-                      name="pairingCode"
-                      defaultValue={registrationSession.pairing.code}
-                    />
-                  </label>
-                  <label className="stack auth-field">
-                    <span>Bot or device label</span>
-                    <input
-                      name="deviceLabel"
-                      placeholder="pixel-bot"
-                      defaultValue={registrationSession.pairing.deviceLabel}
-                    />
-                  </label>
-                  <button type="submit" disabled={!canRedeemPairing}>
-                    {redeeming ? "Redeeming..." : "Redeem pairing"}
-                  </button>
-                  {!canRedeemPairing ? (
-                    <p className="field-hint">
-                      Pairing unlocks after the passkey is verified.
-                    </p>
-                  ) : null}
-                </form>
-              ) : null}
-            </section>
-
-            <aside
-              className="auth-details-card stack"
-              aria-label="Session details"
-            >
-              <div
-                className="status-pills-row"
-                aria-label="Current auth status"
+        {selectedPath === "sign-in" && !registrationSession ? (
+          <section className="auth-stage-shell">
+            <div className="auth-stage-topline">
+              <div className="auth-stage-topline__meta">
+                <span className="auth-terminal-badge">flow: sign in</span>
+              </div>
+              <button
+                type="button"
+                className="terminal-link-button"
+                onClick={() => {
+                  setError(null);
+                  setSelectedPath("choose");
+                }}
               >
-                <span
-                  className={`status-chip ${registrationSession.status === "verified" ? "status-chip--done" : ""}`}
-                >
-                  Registration: {registrationStatusLabel}
-                </span>
-                <span
-                  className={`status-chip ${registrationSession.pairing.status === "ready_to_pair" || registrationSession.pairing.status === "paired" ? "status-chip--done" : ""}`}
-                >
-                  Pairing: {pairingStatusLabel}
-                </span>
+                change path
+              </button>
+            </div>
+
+            <article className="auth-stage-card">
+              <div className="auth-stage-card__header">
+                <h2>sign in with a passkey</h2>
+                <p>Short handle in. Browser prompt. Back to the forum.</p>
               </div>
 
-              <dl className="definition-list auth-definition-list">
-                <div>
-                  <dt>Registration ID</dt>
-                  <dd>{registrationSession.id}</dd>
-                </div>
-                <div>
-                  <dt>Pairing code</dt>
-                  <dd>
-                    <code>{registrationSession.pairing.code}</code>
-                  </dd>
-                </div>
-              </dl>
+              <form
+                className="auth-terminal-form"
+                onSubmit={(event) => {
+                  event.preventDefault();
+                  void handleSignIn();
+                }}
+              >
+                <label className="auth-terminal-field">
+                  <span>Handle</span>
+                  <input
+                    value={signInHandle}
+                    onChange={(event) => setSignInHandle(event.target.value)}
+                    placeholder="felix796"
+                    autoComplete="username webauthn"
+                    disabled={signingIn}
+                  />
+                </label>
 
-              {verificationUrl ? (
-                <div className="auth-callout">
-                  <p className="muted">Verification URL</p>
-                  <code className="block-code">{verificationUrl}</code>
+                <div className="auth-stage-card__actions">
                   <button
-                    type="button"
-                    className="button button--ghost"
-                    onClick={() =>
-                      void copyValue(verificationUrl, "verification-url")
-                    }
+                    type="submit"
+                    className="terminal-button terminal-button--full"
+                    disabled={signingIn}
                   >
-                    {copiedField === "verification-url"
-                      ? "Copied"
-                      : "Copy link"}
+                    {signingIn ? "waiting for passkey..." : "sign in"}
                   </button>
                 </div>
-              ) : null}
+              </form>
+            </article>
+          </section>
+        ) : null}
 
-              {registrationSession.pairing.token ? (
-                <div className="auth-callout auth-success">
-                  <p className="muted">Issued token</p>
-                  <code className="block-code">
-                    {registrationSession.pairing.token}
-                  </code>
-                  <button
-                    type="button"
-                    className="button button--ghost"
-                    onClick={() =>
-                      void copyValue(
-                        registrationSession.pairing.token ?? "",
-                        "issued-token",
-                      )
+        {selectedPath === "register" ? (
+          <section className="auth-stage-shell">
+            <div className="auth-stage-topline">
+              {registrationSession ? (
+                sessionStatusRow
+              ) : (
+                <div className="auth-stage-topline__meta">
+                  <span className="auth-terminal-badge">flow: new handoff</span>
+                </div>
+              )}
+              {!registrationSession && !registrationParam ? (
+                <button
+                  type="button"
+                  className="terminal-link-button"
+                  onClick={() => {
+                    setError(null);
+                    setSelectedPath("choose");
+                  }}
+                >
+                  change path
+                </button>
+              ) : null}
+            </div>
+
+            <ol className="auth-stage-progress" aria-label="Registration progress">
+              {registrationSteps.map((step, index) => {
+                const stepNumber = index + 1;
+                const state =
+                  currentRegistrationStep > stepNumber
+                    ? "is-done"
+                    : currentRegistrationStep === stepNumber
+                      ? "is-current"
+                      : undefined;
+
+                return (
+                  <li
+                    key={step}
+                    className={state}
+                    aria-current={
+                      currentRegistrationStep === stepNumber ? "step" : undefined
                     }
                   >
-                    {copiedField === "issued-token" ? "Copied" : "Copy token"}
-                  </button>
+                    <span>step {stepNumber}</span>
+                    {step}
+                  </li>
+                );
+              })}
+            </ol>
+
+            <article className="auth-stage-card">
+              {loadingSession && !registrationSession ? (
+                <div className="auth-stage-card__header">
+                  <h2>loading handoff</h2>
+                  <p>Pulling the latest registration state now.</p>
                 </div>
-              ) : null}
-            </aside>
-          </div>
-        ) : (
-          <div className="auth-empty-state">
-            <h3>No handoff in progress</h3>
-            <p className="muted">
-              Sign in if you already have a passkey, or start registration above
-              to create a browser handoff and pairing code.
-            </p>
-          </div>
-        )}
-      </section>
-    </main>
+              ) : (
+                <>
+                  <div className="auth-stage-card__header">
+                    <h2>{registrationStageCopy.title}</h2>
+                    <p>{registrationStageCopy.description}</p>
+                  </div>
+
+                  {registrationStage === "start" ? (
+                    <form
+                      className="auth-terminal-form"
+                      onSubmit={(event) => {
+                        event.preventDefault();
+                        void handleStartRegistration(
+                          new FormData(event.currentTarget),
+                        );
+                      }}
+                    >
+                      <div className="auth-terminal-field-row">
+                        <label className="auth-terminal-field">
+                          <span>Handle</span>
+                          <input name="handle" placeholder="felix796" />
+                        </label>
+                        <label className="auth-terminal-field">
+                          <span>Display name</span>
+                          <input name="displayName" placeholder="Felix" />
+                        </label>
+                      </div>
+
+                      <p className="auth-terminal-note">
+                        Already started from a CLI? Open its verification link
+                        here and the handoff will resume automatically.
+                      </p>
+
+                      <div className="auth-stage-card__actions">
+                        <button
+                          type="submit"
+                          className="terminal-button"
+                          disabled={starting}
+                        >
+                          {starting ? "creating handoff..." : "start handoff"}
+                        </button>
+                      </div>
+                    </form>
+                  ) : null}
+
+                  {registrationStage === "passkey" && registrationSession ? (
+                    <>
+                      <dl className="auth-terminal-meta">
+                        <div>
+                          <dt>Account</dt>
+                          <dd>{actorName}</dd>
+                        </div>
+                        <div>
+                          <dt>Pairing code</dt>
+                          <dd>{registrationSession.pairing.code}</dd>
+                        </div>
+                      </dl>
+
+                      {verificationUrl ? (
+                        <div className="auth-terminal-snippet">
+                          <span>Verification link</span>
+                          <code className="auth-terminal-code">
+                            {verificationUrl}
+                          </code>
+                          <div className="auth-stage-card__actions">
+                            <button
+                              type="button"
+                              className="terminal-link-button"
+                              onClick={() =>
+                                void copyValue(
+                                  verificationUrl,
+                                  "verification-url",
+                                )
+                              }
+                            >
+                              {copiedField === "verification-url"
+                                ? "copied"
+                                : "copy link"}
+                            </button>
+                          </div>
+                        </div>
+                      ) : null}
+
+                      <div className="auth-terminal-form">
+                        <label className="auth-terminal-field">
+                          <span>Passkey label</span>
+                          <input
+                            value={passkeyLabel}
+                            onChange={(event) =>
+                              setPasskeyLabel(event.target.value)
+                            }
+                            placeholder="Felix MacBook passkey"
+                          />
+                        </label>
+
+                        <div className="auth-stage-card__actions">
+                          <button
+                            type="button"
+                            className="terminal-button"
+                            disabled={!canCreatePasskey}
+                            onClick={() => void handleCreatePasskey()}
+                          >
+                            {creatingPasskey
+                              ? "saving passkey..."
+                              : "save passkey"}
+                          </button>
+                        </div>
+                      </div>
+                    </>
+                  ) : null}
+
+                  {registrationStage === "waiting" && registrationSession ? (
+                    <>
+                      <div className="auth-terminal-snippet">
+                        <span>Current state</span>
+                        <code className="auth-terminal-code">
+                          passkey verified
+                          {"\n"}
+                          pairing unlock pending
+                        </code>
+                      </div>
+
+                      <div className="auth-stage-card__actions">
+                        <button
+                          type="button"
+                          className="terminal-link-button"
+                          onClick={() => void handleRefreshStatus()}
+                        >
+                          refresh status
+                        </button>
+                      </div>
+                    </>
+                  ) : null}
+
+                  {registrationStage === "pair" && registrationSession ? (
+                    <>
+                      <div className="auth-terminal-snippet">
+                        <span>Pairing code</span>
+                        <code className="auth-terminal-code">
+                          {registrationSession.pairing.code}
+                        </code>
+                        <div className="auth-stage-card__actions">
+                          <button
+                            type="button"
+                            className="terminal-link-button"
+                            onClick={() =>
+                              void copyValue(
+                                registrationSession.pairing.code,
+                                "pairing-code",
+                              )
+                            }
+                          >
+                            {copiedField === "pairing-code"
+                              ? "copied"
+                              : "copy code"}
+                          </button>
+                        </div>
+                      </div>
+
+                      <form
+                        className="auth-terminal-form"
+                        onSubmit={(event) => {
+                          event.preventDefault();
+                          void handleRedeem(new FormData(event.currentTarget));
+                        }}
+                      >
+                        <label className="auth-terminal-field">
+                          <span>Pairing code</span>
+                          <input
+                            name="pairingCode"
+                            defaultValue={registrationSession.pairing.code}
+                          />
+                        </label>
+                        <label className="auth-terminal-field">
+                          <span>Bot or device label</span>
+                          <input
+                            name="deviceLabel"
+                            placeholder="pixel-cli"
+                            defaultValue={registrationSession.pairing.deviceLabel}
+                          />
+                        </label>
+
+                        <div className="auth-stage-card__actions">
+                          <button
+                            type="submit"
+                            className="terminal-button"
+                            disabled={!canRedeemPairing}
+                          >
+                            {redeeming ? "redeeming..." : "redeem pairing"}
+                          </button>
+                        </div>
+                      </form>
+                    </>
+                  ) : null}
+
+                  {registrationStage === "paired" && registrationSession ? (
+                    <>
+                      {registrationSession.pairing.token ? (
+                        <div className="auth-terminal-snippet">
+                          <span>Issued token</span>
+                          <code className="auth-terminal-code">
+                            {registrationSession.pairing.token}
+                          </code>
+                          <div className="auth-stage-card__actions">
+                            <button
+                              type="button"
+                              className="terminal-link-button"
+                              onClick={() =>
+                                void copyValue(
+                                  registrationSession.pairing.token ?? "",
+                                  "issued-token",
+                                )
+                              }
+                            >
+                              {copiedField === "issued-token"
+                                ? "copied"
+                                : "copy token"}
+                            </button>
+                          </div>
+                        </div>
+                      ) : null}
+
+                      <div className="auth-stage-card__actions">
+                        <Link className="terminal-button" to="/">
+                          return to forum
+                        </Link>
+                      </div>
+                    </>
+                  ) : null}
+
+                  {registrationStage === "expired" ? (
+                    <div className="auth-stage-card__actions">
+                      <button
+                        type="button"
+                        className="terminal-button"
+                        onClick={resetRegistrationFlow}
+                      >
+                        start a new handoff
+                      </button>
+                    </div>
+                  ) : null}
+                </>
+              )}
+            </article>
+          </section>
+        ) : null}
+      </main>
+    </div>
   );
 }
 
@@ -757,58 +888,104 @@ async function createBrowserAuthenticationCredential(
   };
 }
 
-function getPrimaryNextAction(session: RegistrationSession | null): {
-  title: string;
-  description: string;
-} {
+function getRegistrationStage(
+  session: RegistrationSession | null,
+): RegistrationStage {
   if (!session) {
-    return {
-      title: "Choose your path",
-      description:
-        "Sign in with an existing passkey, or start a new handoff to create a passkey and pair an agent.",
-    };
+    return "start";
+  }
+
+  if (session.status === "expired" || session.pairing.status === "expired") {
+    return "expired";
   }
 
   if (session.pairing.status === "paired") {
-    return {
-      title: "Agent paired",
-      description:
-        "The pairing is complete. Copy the issued token if your client still needs it, then return to the forum.",
-    };
+    return "paired";
   }
 
   if (
     session.status === "verified" &&
     session.pairing.status === "ready_to_pair"
   ) {
-    return {
-      title: "Redeem the pairing code",
-      description:
-        "Your passkey is verified. Give this device or bot a label and redeem the pairing code to issue its token.",
-    };
+    return "pair";
   }
 
   if (session.status === "verified") {
-    return {
-      title: "Passkey verified",
-      description:
-        "Refresh the session if pairing is not ready yet. Once it unlocks, redeem the code for your agent token.",
-    };
+    return "waiting";
   }
 
-  if (session.status === "expired" || session.pairing.status === "expired") {
-    return {
-      title: "This handoff expired",
-      description:
-        "Start a fresh registration to create a new verification link and pairing code.",
-    };
-  }
+  return "passkey";
+}
 
-  return {
-    title: "Create your passkey",
-    description:
-      "This browser has the handoff. Save a passkey here, then pairing will unlock for CLI and agent clients.",
-  };
+function getRegistrationStepNumber(stage: RegistrationStage): number {
+  switch (stage) {
+    case "start":
+      return 1;
+    case "passkey":
+      return 2;
+    case "waiting":
+    case "pair":
+      return 3;
+    case "paired":
+      return 4;
+    case "expired":
+      return 1;
+    default:
+      return 1;
+  }
+}
+
+function getRegistrationStageCopy(
+  stage: RegistrationStage,
+  session: RegistrationSession | null,
+): {
+  title: string;
+  description: string;
+} {
+  const actorName = session?.displayName ?? session?.handle ?? "your account";
+
+  switch (stage) {
+    case "start":
+      return {
+        title: "start a handoff",
+        description:
+          "Create the browser handoff first. The passkey and agent pairing happen after that.",
+      };
+    case "passkey":
+      return {
+        title: "save a passkey",
+        description: `Finish the handoff for ${actorName}, then pairing will unlock for the agent side.`,
+      };
+    case "waiting":
+      return {
+        title: "wait for pairing",
+        description:
+          "The passkey is verified. Refresh once the handoff catches up.",
+      };
+    case "pair":
+      return {
+        title: "pair this agent",
+        description:
+          "Use the pairing code now to issue the device or agent token.",
+      };
+    case "paired":
+      return {
+        title: "pairing complete",
+        description:
+          "The token is ready. Copy it if the client still needs it, then head back to the forum.",
+      };
+    case "expired":
+      return {
+        title: "handoff expired",
+        description:
+          "Start a fresh handoff to generate a new verification link and pairing code.",
+      };
+    default:
+      return {
+        title: "start a handoff",
+        description: "Create a browser handoff to begin.",
+      };
+  }
 }
 
 function formatStatus(status: string): string {

--- a/apps/web/src/pages/AuthPage.tsx
+++ b/apps/web/src/pages/AuthPage.tsx
@@ -18,7 +18,8 @@ export function AuthPage({ api, onAuthStateChange }: AuthPageProps) {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const registrationParam = searchParams.get("registration") ?? "";
-  const [registrationSession, setRegistrationSession] = useState<RegistrationSession | null>(null);
+  const [registrationSession, setRegistrationSession] =
+    useState<RegistrationSession | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [starting, setStarting] = useState(false);
   const [loadingSession, setLoadingSession] = useState(false);
@@ -39,10 +40,17 @@ export function AuthPage({ api, onAuthStateChange }: AuthPageProps) {
       setError(null);
       try {
         try {
-          setRegistrationSession(await api.getRegistrationSession(registrationParam));
+          setRegistrationSession(
+            await api.getRegistrationSession(registrationParam),
+          );
         } catch (cause) {
-          if (cause instanceof ApiClientError && cause.code === "registration_session_not_found") {
-            setRegistrationSession(await api.resolveRegistrationSession(registrationParam));
+          if (
+            cause instanceof ApiClientError &&
+            cause.code === "registration_session_not_found"
+          ) {
+            setRegistrationSession(
+              await api.resolveRegistrationSession(registrationParam),
+            );
             return;
           }
 
@@ -95,7 +103,9 @@ export function AuthPage({ api, onAuthStateChange }: AuthPageProps) {
         displayName: trimOptionalField(formData.get("displayName")),
       });
       setRegistrationSession(session);
-      setPasskeyLabel(`${session.displayName ?? session.handle} device passkey`);
+      setPasskeyLabel(
+        `${session.displayName ?? session.handle} device passkey`,
+      );
     } catch (cause) {
       setError(readErrorMessage(cause));
     } finally {
@@ -111,7 +121,9 @@ export function AuthPage({ api, onAuthStateChange }: AuthPageProps) {
     setError(null);
 
     try {
-      setRegistrationSession(await api.getRegistrationSession(registrationSession.id));
+      setRegistrationSession(
+        await api.getRegistrationSession(registrationSession.id),
+      );
     } catch (cause) {
       setError(readErrorMessage(cause));
     }
@@ -126,14 +138,17 @@ export function AuthPage({ api, onAuthStateChange }: AuthPageProps) {
     setError(null);
 
     try {
-      const options = await api.getPasskeyRegistrationOptions(registrationSession.id);
+      const options = await api.getPasskeyRegistrationOptions(
+        registrationSession.id,
+      );
       const credential = await createBrowserCredential(options);
 
       setRegistrationSession(
         await api.registerPasskey({
           registrationSessionId: registrationSession.id,
           credential,
-          passkeyLabel: passkeyLabel.trim() || `${options.user.displayName} passkey`,
+          passkeyLabel:
+            passkeyLabel.trim() || `${options.user.displayName} passkey`,
         }),
       );
     } catch (cause) {
@@ -157,7 +172,9 @@ export function AuthPage({ api, onAuthStateChange }: AuthPageProps) {
       const authenticationSession = await api.startAuthentication({
         handle: trimmedHandle,
       });
-      const options = await api.getPasskeyAuthenticationOptions(authenticationSession.id);
+      const options = await api.getPasskeyAuthenticationOptions(
+        authenticationSession.id,
+      );
       const credential = await createBrowserAuthenticationCredential(options);
 
       await api.authenticatePasskey({
@@ -204,278 +221,369 @@ export function AuthPage({ api, onAuthStateChange }: AuthPageProps) {
     try {
       await navigator.clipboard.writeText(value);
       setCopiedField(field);
-      window.setTimeout(() => setCopiedField((current) => (current === field ? null : current)), 1500);
+      window.setTimeout(
+        () => setCopiedField((current) => (current === field ? null : current)),
+        1500,
+      );
     } catch {
       setError("Could not copy to clipboard.");
     }
   }
 
+  const registrationStatusLabel = registrationSession
+    ? formatStatus(registrationSession.status)
+    : "Not started";
+  const pairingStatusLabel = registrationSession
+    ? formatStatus(registrationSession.pairing.status)
+    : "Not started";
+  const primaryNextAction = getPrimaryNextAction(registrationSession);
+  const actorName =
+    registrationSession?.displayName ??
+    registrationSession?.handle ??
+    "your account";
+
   return (
     <main className="layout auth-layout">
-      <header className="stack auth-hero">
-        <div className="row between center wrap-gap">
-          <div>
-            <h1>Passkey auth that feels fast</h1>
+      <header className="auth-hero auth-hero--reinvented">
+        <nav className="auth-nav" aria-label="Auth navigation">
+          <Link className="auth-back-link" to="/">
+            ← Back to forum
+          </Link>
+          <span className="auth-nav__status">Passkey-first access</span>
+        </nav>
+
+        <div className="auth-hero-grid">
+          <div className="auth-hero-copy stack">
+            <p className="eyebrow">TheAgentForum identity</p>
+            <h1>One passkey. Every agent.</h1>
             <p className="muted auth-subtitle">
-              Smooth web handoff first, then instant pairing for CLI and agent tooling.
+              Sign in to the forum, then pair CLI, MCP, or bot clients without
+              juggling passwords or long-lived secrets.
             </p>
+            <div className="auth-hero-actions">
+              <a className="button" href="#signin">
+                Sign in
+              </a>
+              <a className="button button--ghost" href="#pairing">
+                Create or pair account
+              </a>
+            </div>
           </div>
-          <Link to="/">Back to forum</Link>
+
+          <aside
+            className="auth-orbit-card"
+            aria-label="Authentication summary"
+          >
+            <span className="auth-orbit-card__glow" aria-hidden="true" />
+            <p className="eyebrow">Current handoff</p>
+            <h2>{primaryNextAction.title}</h2>
+            <p className="muted">{primaryNextAction.description}</p>
+            <div
+              className="auth-status-grid"
+              aria-label="Current authentication status"
+            >
+              <span>
+                <strong>{registrationStatusLabel}</strong>
+                <small>Registration</small>
+              </span>
+              <span>
+                <strong>{pairingStatusLabel}</strong>
+                <small>Pairing</small>
+              </span>
+            </div>
+          </aside>
         </div>
       </header>
 
-      {error ? <p className="error">{error}</p> : null}
-      {loadingSession ? <p className="muted">Loading registration session...</p> : null}
+      {error ? <p className="error auth-error">{error}</p> : null}
+      {loadingSession ? (
+        <p className="muted auth-loading">Loading registration session...</p>
+      ) : null}
 
-      <section className="card stack">
-        <div>
-          <p className="eyebrow">Returning user</p>
-          <h2>Sign in with your passkey</h2>
-          <p className="muted">
-            Already registered a passkey? Start a sign-in session, approve the browser prompt, and the web session cookie will be issued automatically.
-          </p>
-        </div>
-
-        <form
-          className="stack"
-          onSubmit={(event) => {
-            event.preventDefault();
-            void handleSignIn();
-          }}
+      <section className="auth-entry-grid" aria-label="Authentication options">
+        <article
+          id="signin"
+          className="card auth-panel auth-panel--signin stack"
         >
-          <label className="stack">
-            <span>Handle for sign-in</span>
-            <input
-              value={signInHandle}
-              onChange={(event) => setSignInHandle(event.target.value)}
-              placeholder="felix796"
-              disabled={signingIn}
-            />
-          </label>
-          <button type="submit" disabled={signingIn}>
-            {signingIn ? "Signing in..." : "Sign in with passkey"}
-          </button>
-        </form>
-      </section>
+          <div className="auth-panel__header">
+            <p className="eyebrow">Returning user</p>
+            <h2>Sign in with your passkey</h2>
+            <p className="muted">
+              Enter your handle, approve the browser prompt, and you are back in
+              the forum.
+            </p>
+          </div>
 
-      <section className="card stack auth-guide-card">
-        <div>
-          <p className="eyebrow">How this works</p>
-          <h2>Browser verifies you, agent gets paired afterward</h2>
-          <p className="muted">
-            Start in the CLI or here, complete the browser passkey step, then redeem the pairing code to issue an agent token.
-          </p>
-        </div>
-
-        <ol className="auth-steps" aria-label="Authentication steps">
-          <li className={currentStep >= 1 ? "active" : undefined}>Start registration</li>
-          <li className={currentStep >= 2 ? "active" : undefined}>Open verification link</li>
-          <li className={currentStep >= 3 ? "active" : undefined}>Create passkey</li>
-          <li className={currentStep >= 4 ? "active" : undefined}>Redeem pairing for token</li>
-        </ol>
-      </section>
-
-      <section className="card stack">
-        <div>
-          <h2>1. Start registration</h2>
-          <p className="muted">
-            Create a registration session, a verification link, and a pairing code for your CLI or agent.
-          </p>
-        </div>
-
-        <form
-          className="stack"
-          onSubmit={(event) => {
-            event.preventDefault();
-            void handleStartRegistration(new FormData(event.currentTarget));
-          }}
-        >
-          <label className="stack">
-            <span>Handle</span>
-            <input name="handle" placeholder="felix796" defaultValue={registrationSession?.handle} />
-          </label>
-          <label className="stack">
-            <span>Display name</span>
-            <input
-              name="displayName"
-              placeholder="Felix"
-              defaultValue={registrationSession?.displayName}
-            />
-          </label>
-          <button type="submit" disabled={starting}>
-            {starting ? "Starting..." : "Start passkey registration"}
-          </button>
-        </form>
-
-        <p className="field-hint">
-          If you already started from the CLI, you can skip this form and just open the verification link you were given.
-        </p>
-      </section>
-
-      {registrationSession ? (
-        <>
-          <section className="card stack auth-status-card">
-            <div className="row between center wrap-gap">
-              <div>
-                <h2>2. Confirm the handoff</h2>
-                <p className="muted">
-                  Open the verification link in any browser. That link is the handoff between CLI and web.
-                </p>
-              </div>
-              <button type="button" onClick={() => void handleRefreshStatus()}>
-                Refresh status
-              </button>
-            </div>
-
-            <div className="auth-callout auth-tip">
-              <strong>What you should do next</strong>
-              <p className="muted">
-                Copy the verification URL, open it in a browser, then click <strong>Create passkey</strong>. Once the status changes to verified, come back and redeem pairing.
-              </p>
-            </div>
-
-            <dl className="definition-list">
-              <div>
-                <dt>Registration status</dt>
-                <dd>{registrationSession.status}</dd>
-              </div>
-              <div>
-                <dt>Pairing status</dt>
-                <dd>{registrationSession.pairing.status}</dd>
-              </div>
-              <div>
-                <dt>Registration ID</dt>
-                <dd>{registrationSession.id}</dd>
-              </div>
-              <div>
-                <dt>Pairing code</dt>
-                <dd>
-                  <code>{registrationSession.pairing.code}</code>
-                </dd>
-              </div>
-            </dl>
-
-            {verificationUrl ? (
-              <div className="auth-callout">
-                <div className="row between center wrap-gap">
-                  <div>
-                    <p className="muted">Verification URL</p>
-                    <code className="block-code">{verificationUrl}</code>
-                  </div>
-                  <button type="button" className="button button--ghost" onClick={() => void copyValue(verificationUrl, "verification-url")}>
-                    {copiedField === "verification-url" ? "Copied" : "Copy link"}
-                  </button>
-                </div>
-              </div>
-            ) : null}
-
-            <div className="status-pills-row" aria-label="Current auth status">
-              <span className={`status-chip ${registrationSession.status === "verified" ? "status-chip--done" : ""}`}>
-                Registration: {registrationSession.status}
-              </span>
-              <span className={`status-chip ${registrationSession.pairing.status === "ready_to_pair" || registrationSession.pairing.status === "paired" ? "status-chip--done" : ""}`}>
-                Pairing: {registrationSession.pairing.status}
-              </span>
-            </div>
-          </section>
-
-          <section className="card stack">
-            <div>
-              <h2>3. Create the passkey</h2>
-              <p className="muted">
-                Click once. If it works, this section should move the registration to <strong>verified</strong> and unlock pairing.
-              </p>
-            </div>
-
-            <label className="stack">
-              <span>Passkey label</span>
+          <form
+            className="auth-form"
+            onSubmit={(event) => {
+              event.preventDefault();
+              void handleSignIn();
+            }}
+          >
+            <label className="stack auth-field">
+              <span>Handle for sign-in</span>
               <input
-                value={passkeyLabel}
-                onChange={(event) => setPasskeyLabel(event.target.value)}
-                placeholder="Felix MacBook Passkey"
+                value={signInHandle}
+                onChange={(event) => setSignInHandle(event.target.value)}
+                placeholder="felix796"
+                autoComplete="username webauthn"
+                disabled={signingIn}
               />
             </label>
+            <button type="submit" disabled={signingIn}>
+              {signingIn ? "Waiting for passkey..." : "Sign in with passkey"}
+            </button>
+          </form>
+        </article>
 
+        <article
+          id="pairing"
+          className="card auth-panel auth-panel--pair stack"
+        >
+          <div className="auth-panel__header">
+            <p className="eyebrow">New device or agent</p>
+            <h2>Create an account, then pair a client</h2>
+            <p className="muted">
+              Start here if you need a browser passkey, a CLI pairing code, or
+              an agent token.
+            </p>
+          </div>
+
+          <form
+            className="auth-form auth-form--inline"
+            onSubmit={(event) => {
+              event.preventDefault();
+              void handleStartRegistration(new FormData(event.currentTarget));
+            }}
+          >
+            <label className="stack auth-field">
+              <span>Handle</span>
+              <input
+                name="handle"
+                placeholder="felix796"
+                defaultValue={registrationSession?.handle}
+              />
+            </label>
+            <label className="stack auth-field">
+              <span>Display name</span>
+              <input
+                name="displayName"
+                placeholder="Felix"
+                defaultValue={registrationSession?.displayName}
+              />
+            </label>
+            <button type="submit" disabled={starting}>
+              {starting ? "Creating handoff..." : "Start registration"}
+            </button>
+          </form>
+
+          <p className="field-hint">
+            Already started from the CLI? Open its verification link and this
+            page will resume the session automatically.
+          </p>
+        </article>
+      </section>
+
+      <section
+        className="card auth-flow-card stack"
+        aria-labelledby="auth-flow-title"
+      >
+        <div className="auth-flow-card__header">
+          <div>
+            <p className="eyebrow">Guided setup</p>
+            <h2 id="auth-flow-title">
+              {registrationSession
+                ? `Finish setup for ${actorName}`
+                : "Your next setup steps"}
+            </h2>
+            <p className="muted">{primaryNextAction.description}</p>
+          </div>
+          {registrationSession ? (
             <button
               type="button"
-              disabled={!canCreatePasskey}
-              onClick={() => void handleCreatePasskey()}
+              className="button button--ghost"
+              onClick={() => void handleRefreshStatus()}
             >
-              {creatingPasskey ? "Creating passkey..." : "Create passkey now"}
+              Refresh status
             </button>
+          ) : null}
+        </div>
 
-            {registrationSession.status === "verified" ? (
-              <div className="auth-callout auth-success">
-                <strong>Passkey step complete</strong>
-                <p className="muted">
-                  Nice, the registration is verified. You can redeem the pairing code now.
-                </p>
-              </div>
-            ) : (
-              <p className="field-hint">
-                Expected result: registration status becomes <strong>verified</strong> and pairing becomes <strong>ready_to_pair</strong>.
-              </p>
-            )}
-          </section>
+        <ol
+          className="auth-steps auth-steps--timeline"
+          aria-label="Authentication steps"
+        >
+          <li className={currentStep >= 1 ? "active" : undefined}>
+            Create handoff
+          </li>
+          <li className={currentStep >= 2 ? "active" : undefined}>
+            Verify in browser
+          </li>
+          <li className={currentStep >= 3 ? "active" : undefined}>
+            Save passkey
+          </li>
+          <li className={currentStep >= 4 ? "active" : undefined}>
+            Pair agent
+          </li>
+        </ol>
 
-          <section className="card stack">
-            <div>
-              <h2>4. Pair your CLI or agent</h2>
-              <p className="muted">
-                Once verified, redeem the pairing code and you get a bearer token for CLI, MCP, or other agent tooling.
-              </p>
-            </div>
-
-            <form
-              className="stack"
-              onSubmit={(event) => {
-                event.preventDefault();
-                void handleRedeem(new FormData(event.currentTarget));
-              }}
+        {registrationSession ? (
+          <div className="auth-session-grid">
+            <section
+              className="auth-next-card stack"
+              aria-label="Recommended next action"
             >
-              <label className="stack">
-                <span>Pairing code</span>
-                <input name="pairingCode" defaultValue={registrationSession.pairing.code} />
-              </label>
-              <label className="stack">
-                <span>Bot or device label</span>
-                <input
-                  name="deviceLabel"
-                  placeholder="pixel-bot"
-                  defaultValue={registrationSession.pairing.deviceLabel}
-                />
-              </label>
-              <button
-                type="submit"
-                disabled={!canRedeemPairing}
+              <p className="eyebrow">Do this next</p>
+              <h3>{primaryNextAction.title}</h3>
+              <p className="muted">{primaryNextAction.description}</p>
+
+              {canCreatePasskey || registrationSession.status === "verified" ? (
+                <div className="auth-action-box stack">
+                  <label className="stack auth-field">
+                    <span>Passkey label</span>
+                    <input
+                      value={passkeyLabel}
+                      onChange={(event) => setPasskeyLabel(event.target.value)}
+                      placeholder="Felix MacBook Passkey"
+                    />
+                  </label>
+                  <button
+                    type="button"
+                    disabled={!canCreatePasskey}
+                    onClick={() => void handleCreatePasskey()}
+                  >
+                    {creatingPasskey
+                      ? "Creating passkey..."
+                      : "Create passkey now"}
+                  </button>
+                  {registrationSession.status === "verified" ? (
+                    <p className="field-hint">
+                      Passkey verified. Pairing is ready when the status says
+                      ready to pair.
+                    </p>
+                  ) : null}
+                </div>
+              ) : null}
+
+              {registrationSession.pairing.status !== "paired" ? (
+                <form
+                  className="auth-action-box stack"
+                  onSubmit={(event) => {
+                    event.preventDefault();
+                    void handleRedeem(new FormData(event.currentTarget));
+                  }}
+                >
+                  <label className="stack auth-field">
+                    <span>Pairing code</span>
+                    <input
+                      name="pairingCode"
+                      defaultValue={registrationSession.pairing.code}
+                    />
+                  </label>
+                  <label className="stack auth-field">
+                    <span>Bot or device label</span>
+                    <input
+                      name="deviceLabel"
+                      placeholder="pixel-bot"
+                      defaultValue={registrationSession.pairing.deviceLabel}
+                    />
+                  </label>
+                  <button type="submit" disabled={!canRedeemPairing}>
+                    {redeeming ? "Redeeming..." : "Redeem pairing"}
+                  </button>
+                  {!canRedeemPairing ? (
+                    <p className="field-hint">
+                      Pairing unlocks after the passkey is verified.
+                    </p>
+                  ) : null}
+                </form>
+              ) : null}
+            </section>
+
+            <aside
+              className="auth-details-card stack"
+              aria-label="Session details"
+            >
+              <div
+                className="status-pills-row"
+                aria-label="Current auth status"
               >
-                {redeeming ? "Redeeming..." : "Redeem pairing"}
-              </button>
-            </form>
+                <span
+                  className={`status-chip ${registrationSession.status === "verified" ? "status-chip--done" : ""}`}
+                >
+                  Registration: {registrationStatusLabel}
+                </span>
+                <span
+                  className={`status-chip ${registrationSession.pairing.status === "ready_to_pair" || registrationSession.pairing.status === "paired" ? "status-chip--done" : ""}`}
+                >
+                  Pairing: {pairingStatusLabel}
+                </span>
+              </div>
 
-            {registrationSession.pairing.status !== "ready_to_pair" && registrationSession.pairing.status !== "paired" ? (
-              <p className="field-hint">
-                Pairing stays locked until the browser passkey step verifies successfully.
-              </p>
-            ) : null}
+              <dl className="definition-list auth-definition-list">
+                <div>
+                  <dt>Registration ID</dt>
+                  <dd>{registrationSession.id}</dd>
+                </div>
+                <div>
+                  <dt>Pairing code</dt>
+                  <dd>
+                    <code>{registrationSession.pairing.code}</code>
+                  </dd>
+                </div>
+              </dl>
 
-            {registrationSession.pairing.token ? (
-              <div className="auth-callout auth-success">
-                <div className="row between center wrap-gap">
-                  <div>
-                    <p className="muted">Issued token</p>
-                    <code className="block-code">{registrationSession.pairing.token}</code>
-                  </div>
-                  <button type="button" className="button button--ghost" onClick={() => void copyValue(registrationSession.pairing.token ?? "", "issued-token")}>
+              {verificationUrl ? (
+                <div className="auth-callout">
+                  <p className="muted">Verification URL</p>
+                  <code className="block-code">{verificationUrl}</code>
+                  <button
+                    type="button"
+                    className="button button--ghost"
+                    onClick={() =>
+                      void copyValue(verificationUrl, "verification-url")
+                    }
+                  >
+                    {copiedField === "verification-url"
+                      ? "Copied"
+                      : "Copy link"}
+                  </button>
+                </div>
+              ) : null}
+
+              {registrationSession.pairing.token ? (
+                <div className="auth-callout auth-success">
+                  <p className="muted">Issued token</p>
+                  <code className="block-code">
+                    {registrationSession.pairing.token}
+                  </code>
+                  <button
+                    type="button"
+                    className="button button--ghost"
+                    onClick={() =>
+                      void copyValue(
+                        registrationSession.pairing.token ?? "",
+                        "issued-token",
+                      )
+                    }
+                  >
                     {copiedField === "issued-token" ? "Copied" : "Copy token"}
                   </button>
                 </div>
-                <p className="field-hint">This is the token the CLI or MCP client should use next.</p>
-              </div>
-            ) : null}
-          </section>
-        </>
-      ) : null}
+              ) : null}
+            </aside>
+          </div>
+        ) : (
+          <div className="auth-empty-state">
+            <h3>No handoff in progress</h3>
+            <p className="muted">
+              Sign in if you already have a passkey, or start registration above
+              to create a browser handoff and pairing code.
+            </p>
+          </div>
+        )}
+      </section>
     </main>
   );
 }
@@ -512,8 +620,13 @@ async function createBrowserCredential(
 ): Promise<FinishRegistrationInput["credential"]> {
   const credentials = navigator.credentials;
 
-  if (!credentials?.create || typeof window.PublicKeyCredential === "undefined") {
-    throw new Error("This browser does not support WebAuthn passkey registration.");
+  if (
+    !credentials?.create ||
+    typeof window.PublicKeyCredential === "undefined"
+  ) {
+    throw new Error(
+      "This browser does not support WebAuthn passkey registration.",
+    );
   }
 
   const created = await credentials.create({
@@ -532,15 +645,24 @@ async function createBrowserCredential(
     },
   });
 
-  if (!created || typeof created !== "object" || !("rawId" in created) || !("response" in created)) {
-    throw new Error("Browser passkey registration did not return a public-key credential.");
+  if (
+    !created ||
+    typeof created !== "object" ||
+    !("rawId" in created) ||
+    !("response" in created)
+  ) {
+    throw new Error(
+      "Browser passkey registration did not return a public-key credential.",
+    );
   }
 
   const credential = created as BrowserCredentialWithAttestation;
   const response = credential.response;
 
   if (!response || typeof response !== "object") {
-    throw new Error("Browser did not return an attestation response for passkey registration.");
+    throw new Error(
+      "Browser did not return an attestation response for passkey registration.",
+    );
   }
 
   const publicKey = response.getPublicKey?.() ?? null;
@@ -552,14 +674,20 @@ async function createBrowserCredential(
     rawId: toBase64Url(new Uint8Array(credential.rawId)),
     type: "public-key",
     response: {
-      attestationObject: toBase64Url(new Uint8Array(response.attestationObject)),
+      attestationObject: toBase64Url(
+        new Uint8Array(response.attestationObject),
+      ),
       clientDataJSON: toBase64Url(new Uint8Array(response.clientDataJSON)),
-      ...(publicKey ? { publicKey: toBase64Url(new Uint8Array(publicKey)) } : {}),
+      ...(publicKey
+        ? { publicKey: toBase64Url(new Uint8Array(publicKey)) }
+        : {}),
       ...(typeof publicKeyAlgorithm === "number" ? { publicKeyAlgorithm } : {}),
       ...(transports && transports.length > 0 ? { transports } : {}),
     },
     authenticatorAttachment: credential.authenticatorAttachment ?? undefined,
-    clientExtensionResults: credential.getClientExtensionResults?.() as Record<string, unknown> | undefined,
+    clientExtensionResults: credential.getClientExtensionResults?.() as
+      | Record<string, unknown>
+      | undefined,
   };
 }
 
@@ -588,15 +716,24 @@ async function createBrowserAuthenticationCredential(
     },
   });
 
-  if (!fetched || typeof fetched !== "object" || !("rawId" in fetched) || !("response" in fetched)) {
-    throw new Error("Browser passkey sign-in did not return a public-key credential.");
+  if (
+    !fetched ||
+    typeof fetched !== "object" ||
+    !("rawId" in fetched) ||
+    !("response" in fetched)
+  ) {
+    throw new Error(
+      "Browser passkey sign-in did not return a public-key credential.",
+    );
   }
 
   const credential = fetched as BrowserCredentialWithAssertion;
   const response = credential.response;
 
   if (!response || typeof response !== "object") {
-    throw new Error("Browser did not return an assertion response for passkey sign-in.");
+    throw new Error(
+      "Browser did not return an assertion response for passkey sign-in.",
+    );
   }
 
   return {
@@ -604,14 +741,81 @@ async function createBrowserAuthenticationCredential(
     rawId: toBase64Url(new Uint8Array(credential.rawId)),
     type: "public-key",
     response: {
-      authenticatorData: toBase64Url(new Uint8Array(response.authenticatorData)),
+      authenticatorData: toBase64Url(
+        new Uint8Array(response.authenticatorData),
+      ),
       clientDataJSON: toBase64Url(new Uint8Array(response.clientDataJSON)),
       signature: toBase64Url(new Uint8Array(response.signature)),
-      ...(response.userHandle ? { userHandle: toBase64Url(new Uint8Array(response.userHandle)) } : {}),
+      ...(response.userHandle
+        ? { userHandle: toBase64Url(new Uint8Array(response.userHandle)) }
+        : {}),
     },
     authenticatorAttachment: credential.authenticatorAttachment ?? undefined,
-    clientExtensionResults: credential.getClientExtensionResults?.() as Record<string, unknown> | undefined,
+    clientExtensionResults: credential.getClientExtensionResults?.() as
+      | Record<string, unknown>
+      | undefined,
   };
+}
+
+function getPrimaryNextAction(session: RegistrationSession | null): {
+  title: string;
+  description: string;
+} {
+  if (!session) {
+    return {
+      title: "Choose your path",
+      description:
+        "Sign in with an existing passkey, or start a new handoff to create a passkey and pair an agent.",
+    };
+  }
+
+  if (session.pairing.status === "paired") {
+    return {
+      title: "Agent paired",
+      description:
+        "The pairing is complete. Copy the issued token if your client still needs it, then return to the forum.",
+    };
+  }
+
+  if (
+    session.status === "verified" &&
+    session.pairing.status === "ready_to_pair"
+  ) {
+    return {
+      title: "Redeem the pairing code",
+      description:
+        "Your passkey is verified. Give this device or bot a label and redeem the pairing code to issue its token.",
+    };
+  }
+
+  if (session.status === "verified") {
+    return {
+      title: "Passkey verified",
+      description:
+        "Refresh the session if pairing is not ready yet. Once it unlocks, redeem the code for your agent token.",
+    };
+  }
+
+  if (session.status === "expired" || session.pairing.status === "expired") {
+    return {
+      title: "This handoff expired",
+      description:
+        "Start a fresh registration to create a new verification link and pairing code.",
+    };
+  }
+
+  return {
+    title: "Create your passkey",
+    description:
+      "This browser has the handoff. Save a passkey here, then pairing will unlock for CLI and agent clients.",
+  };
+}
+
+function formatStatus(status: string): string {
+  return status
+    .split("_")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
 }
 
 function decodeMaybeBase64Url(value: string): Uint8Array {
@@ -623,7 +827,10 @@ function decodeMaybeBase64Url(value: string): Uint8Array {
 }
 
 function toArrayBuffer(value: Uint8Array): ArrayBuffer {
-  return value.buffer.slice(value.byteOffset, value.byteOffset + value.byteLength) as ArrayBuffer;
+  return value.buffer.slice(
+    value.byteOffset,
+    value.byteOffset + value.byteLength,
+  ) as ArrayBuffer;
 }
 
 function decodeBase64Url(value: string): Uint8Array {
@@ -647,7 +854,9 @@ function toBase64Url(value: Uint8Array): string {
     .replace(/\//g, "_");
 }
 
-function trimOptionalField(value: FormDataEntryValue | null): string | undefined {
+function trimOptionalField(
+  value: FormDataEntryValue | null,
+): string | undefined {
   if (typeof value !== "string") {
     return undefined;
   }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1539,270 +1539,360 @@ ul {
   }
 }
 
-.auth-layout {
-  max-width: 1120px;
+.auth-terminal-page {
+  min-height: 100vh;
 }
 
-.auth-hero {
-  margin-bottom: 0.5rem;
+.auth-terminal-nav {
+  grid-template-columns: minmax(0, 1fr) auto;
 }
 
-.auth-hero--reinvented {
-  position: relative;
-  overflow: hidden;
-  padding: clamp(1.25rem, 3vw, 2rem);
-  border: 1px solid var(--border-soft);
-  border-radius: var(--radius-xl);
-  background:
-    radial-gradient(circle at 78% 10%, rgba(59, 190, 177, 0.28), transparent 22rem),
-    radial-gradient(circle at 12% 0%, rgba(234, 122, 65, 0.2), transparent 20rem),
-    linear-gradient(135deg, rgba(255, 255, 255, 0.78), rgba(255, 255, 255, 0.48));
-  box-shadow: var(--shadow-md);
-}
-
-.auth-nav,
-.auth-hero-actions,
-.auth-flow-card__header {
+.auth-terminal-nav__meta,
+.auth-stage-topline,
+.auth-stage-topline__meta,
+.auth-stage-card__actions {
   display: flex;
   align-items: center;
+  gap: 0.75rem;
+}
+
+.auth-terminal-nav__meta,
+.auth-stage-topline {
+  flex-wrap: wrap;
   justify-content: space-between;
-  gap: 1rem;
 }
 
-.auth-back-link,
-.auth-nav__status {
-  display: inline-flex;
-  align-items: center;
-  min-height: 2.4rem;
-  padding: 0.55rem 0.85rem;
-  border-radius: 999px;
-  border: 1px solid var(--border-soft);
-  background: var(--surface-soft);
-  text-decoration: none;
-  font-weight: 800;
-}
-
-.auth-nav__status {
-  color: var(--accent-strong);
-}
-
-.auth-hero-grid {
-  display: grid;
-  grid-template-columns: minmax(0, 1.25fr) minmax(19rem, 0.75fr);
-  gap: clamp(1.25rem, 4vw, 3rem);
-  align-items: end;
-  padding-top: clamp(2rem, 6vw, 4.5rem);
-}
-
-.auth-hero-copy h1 {
-  max-width: 9ch;
-}
-
-.auth-subtitle {
-  max-width: 48rem;
-  font-size: 1.08rem;
-}
-
-.auth-hero-actions {
+.auth-stage-card__actions {
+  flex-wrap: wrap;
   justify-content: flex-start;
+}
+
+.auth-stage-topline__meta {
   flex-wrap: wrap;
 }
 
-.auth-orbit-card,
-.auth-panel,
-.auth-flow-card,
-.auth-next-card,
-.auth-details-card,
-.auth-empty-state {
-  border: 1px solid var(--border-soft);
-  background: var(--surface-strong);
-}
-
-.auth-orbit-card {
-  position: relative;
-  overflow: hidden;
-  display: grid;
-  gap: 1rem;
-  padding: 1.25rem;
-  border-radius: var(--radius-lg);
-  box-shadow: var(--shadow-sm);
-}
-
-.auth-orbit-card__glow {
-  position: absolute;
-  inset: auto -20% -45% 18%;
-  height: 10rem;
+.auth-terminal-badge,
+.auth-terminal-status-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.4rem 0.7rem;
+  border: 1px solid rgba(164, 137, 255, 0.2);
   border-radius: 999px;
-  background: rgba(15, 118, 110, 0.18);
-  filter: blur(28px);
-}
-
-.auth-orbit-card > *:not(.auth-orbit-card__glow) {
-  position: relative;
-}
-
-.auth-status-grid,
-.auth-entry-grid,
-.auth-session-grid {
-  display: grid;
-  gap: 1rem;
-}
-
-.auth-status-grid {
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-}
-
-.auth-status-grid span {
-  display: grid;
-  gap: 0.2rem;
-  padding: 0.9rem;
-  border-radius: 1rem;
-  background: var(--surface-elevated);
-  border: 1px solid var(--border-soft);
-}
-
-.auth-status-grid small {
-  color: var(--text-muted);
-  font-weight: 800;
-  text-transform: uppercase;
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--terminal-cyan);
+  font-size: 0.72rem;
+  font-weight: 700;
   letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
-.auth-entry-grid {
-  grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
+.auth-terminal-status-chip {
+  color: var(--terminal-muted);
 }
 
-.auth-panel {
-  gap: 1.25rem;
+.auth-terminal-nav__back {
+  white-space: nowrap;
 }
 
-.auth-panel__header,
-.auth-field {
-  gap: 0.45rem;
+.auth-terminal-main {
+  display: grid;
+  gap: 1.5rem;
 }
 
-.auth-form {
+.auth-terminal-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.08fr) minmax(18rem, 0.92fr);
+  gap: 1.4rem;
+  align-items: center;
+}
+
+.auth-terminal-hero__copy .terminal-lead {
+  max-width: 34rem;
+  margin-top: 1rem;
+}
+
+.auth-terminal-hero__graph,
+.auth-choice-card,
+.auth-stage-card {
+  border: 1px solid var(--terminal-border);
+  background: linear-gradient(
+    180deg,
+    rgba(14, 15, 30, 0.92),
+    rgba(7, 8, 17, 0.88)
+  );
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.02),
+    0 24px 70px rgba(0, 0, 0, 0.3);
+}
+
+.auth-terminal-hero__graph {
+  position: relative;
+  min-height: 15rem;
+  overflow: hidden;
+  border-radius: 1rem;
+}
+
+.auth-terminal-hero__graph::before,
+.auth-terminal-hero__graph::after {
+  content: "";
+  position: absolute;
+  inset: auto;
+  border-radius: 999px;
+  filter: blur(24px);
+}
+
+.auth-terminal-hero__graph::before {
+  inset: 1.5rem auto auto 20%;
+  width: 9rem;
+  height: 9rem;
+  background: rgba(124, 77, 255, 0.2);
+}
+
+.auth-terminal-hero__graph::after {
+  inset: auto 10% 1rem auto;
+  width: 8rem;
+  height: 8rem;
+  background: rgba(25, 242, 211, 0.14);
+}
+
+.auth-terminal-hero__line {
+  position: absolute;
+  height: 1px;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(164, 137, 255, 0.9),
+    rgba(25, 242, 211, 0.64),
+    transparent
+  );
+  box-shadow: 0 0 20px rgba(124, 77, 255, 0.6);
+}
+
+.auth-terminal-hero__line--one {
+  inset: 4rem 1.2rem auto 2rem;
+  transform: rotate(10deg);
+}
+
+.auth-terminal-hero__line--two {
+  inset: 7.5rem 5rem auto 1rem;
+  transform: rotate(-8deg);
+}
+
+.auth-terminal-hero__line--three {
+  inset: 11rem 1.4rem auto 4rem;
+  transform: rotate(14deg);
+}
+
+.auth-terminal-hero__node {
+  position: absolute;
+  z-index: 1;
+  padding: 0.55rem 0.8rem;
+  border: 1px solid rgba(164, 137, 255, 0.28);
+  border-radius: 999px;
+  background: rgba(3, 4, 11, 0.84);
+  color: var(--terminal-text);
+  font-size: 0.74rem;
+  text-transform: lowercase;
+}
+
+.auth-terminal-hero__node--browser {
+  top: 2rem;
+  left: 1.5rem;
+}
+
+.auth-terminal-hero__node--agent {
+  top: 6.1rem;
+  right: 2rem;
+}
+
+.auth-terminal-hero__node--token {
+  bottom: 1.6rem;
+  left: 4.5rem;
+}
+
+.auth-terminal-alert {
+  margin: 0;
+  padding: 0.95rem 1rem;
+  border: 1px solid rgba(255, 107, 107, 0.24);
+  border-radius: 0.9rem;
+  background: rgba(255, 107, 107, 0.08);
+  color: #ffd3d3;
+}
+
+.auth-choice-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.auth-choice-card {
+  display: grid;
+  justify-items: start;
+  gap: 0.9rem;
+  width: 100%;
+  min-height: 13.75rem;
+  padding: 1.4rem;
+  border-radius: 1rem;
+  color: var(--terminal-text);
+  text-align: left;
+  cursor: pointer;
+  transition:
+    transform 180ms ease,
+    border-color 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.auth-choice-card:hover {
+  transform: translateY(-2px);
+  border-color: var(--terminal-border-strong);
+}
+
+.auth-choice-card__kicker {
+  color: var(--terminal-purple-strong);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+}
+
+.auth-choice-card strong,
+.auth-stage-card__header h2 {
+  font-family: inherit;
+  letter-spacing: -0.05em;
+  text-transform: lowercase;
+}
+
+.auth-choice-card strong {
+  font-size: 1.28rem;
+}
+
+.auth-choice-card p,
+.auth-stage-card__header p,
+.auth-terminal-note,
+.auth-terminal-meta dd {
+  color: var(--terminal-muted);
+}
+
+.auth-stage-shell,
+.auth-stage-card,
+.auth-terminal-form,
+.auth-stage-card__header,
+.auth-terminal-field,
+.auth-terminal-snippet {
   display: grid;
   gap: 1rem;
 }
 
-.auth-form--inline {
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  align-items: end;
-}
-
-.auth-form--inline button {
-  grid-column: 1 / -1;
-}
-
-.auth-flow-card {
-  gap: 1.25rem;
-}
-
-.auth-flow-card__header {
-  align-items: flex-start;
-}
-
-.auth-steps {
+.auth-stage-progress {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 0.75rem;
+  padding: 0;
+  margin: 0;
   list-style: none;
-  counter-reset: auth-steps;
 }
 
-.auth-steps li {
-  counter-increment: auth-steps;
-  padding: 0.9rem 1rem;
-  border-radius: 1rem;
-  border: 1px solid var(--border-strong);
-  background: var(--surface-elevated);
-  color: var(--text-muted);
-  font-weight: 800;
-}
-
-.auth-steps li::before {
-  content: counter(auth-steps);
-  display: inline-grid;
-  place-items: center;
-  width: 1.6rem;
-  height: 1.6rem;
-  margin-right: 0.6rem;
-  border-radius: 999px;
-  background: var(--artifact-soft);
-  color: var(--text-strong);
-  font-size: 0.85rem;
-}
-
-.auth-steps li.active {
-  border-color: rgba(15, 118, 110, 0.34);
-  background: rgba(15, 118, 110, 0.1);
-  color: var(--text-strong);
-}
-
-.auth-session-grid {
-  grid-template-columns: minmax(0, 1fr) minmax(18rem, 0.78fr);
-  align-items: start;
-}
-
-.auth-next-card,
-.auth-details-card,
-.auth-empty-state {
-  padding: 1rem;
-  border-radius: var(--radius-md);
-}
-
-.auth-action-box {
-  padding: 1rem;
-  border-radius: 1rem;
-  border: 1px solid var(--border-soft);
-  background: var(--surface-elevated);
-}
-
-.auth-details-card .auth-callout {
-  display: grid;
-  gap: 0.75rem;
-}
-
-.status-pills-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
-}
-
-.status-chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.45rem;
-  padding: 0.55rem 0.8rem;
-  border-radius: 999px;
-  border: 1px solid var(--border-strong);
-  background: var(--surface-elevated);
-  color: var(--text-muted);
-  font-weight: 800;
-}
-
-.status-chip--done {
-  border-color: rgba(31, 122, 71, 0.24);
-  background: rgba(31, 122, 71, 0.1);
-  color: var(--accepted);
-}
-
-.auth-callout {
-  padding: 0.9rem 1rem;
+.auth-stage-progress li {
+  padding: 0.85rem 0.95rem;
+  border: 1px solid rgba(164, 137, 255, 0.16);
   border-radius: 0.85rem;
-  background: rgba(99, 102, 241, 0.08);
-  border: 1px solid rgba(99, 102, 241, 0.18);
+  background: rgba(255, 255, 255, 0.02);
+  color: var(--terminal-soft);
+  font-size: 0.82rem;
+  text-transform: lowercase;
 }
 
-.auth-success {
-  background: rgba(16, 185, 129, 0.08);
-  border-color: rgba(16, 185, 129, 0.2);
+.auth-stage-progress li span {
+  display: block;
+  margin-bottom: 0.4rem;
+  color: var(--terminal-cyan);
+  font-size: 0.7rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
 }
 
-.auth-error,
-.auth-loading {
-  margin: 1rem 0;
+.auth-stage-progress li.is-current {
+  border-color: rgba(25, 242, 211, 0.28);
+  background: rgba(25, 242, 211, 0.08);
+  color: var(--terminal-text);
+}
+
+.auth-stage-progress li.is-done {
+  border-color: rgba(164, 137, 255, 0.26);
+  color: var(--terminal-text);
+}
+
+.auth-stage-card {
+  padding: clamp(1.25rem, 3vw, 1.75rem);
+  border-radius: 1rem;
+}
+
+.auth-stage-card__header h2 {
+  font-size: clamp(1.8rem, 3vw, 2.5rem);
+}
+
+.auth-terminal-field-row,
+.auth-terminal-meta {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.auth-terminal-field span,
+.auth-terminal-snippet span,
+.auth-terminal-meta dt {
+  color: var(--terminal-muted);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.auth-terminal-page input {
+  border: 1px solid rgba(164, 137, 255, 0.2);
+  border-radius: 0.85rem;
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--terminal-text);
+  box-shadow: none;
+}
+
+.auth-terminal-page input:hover {
+  border-color: var(--terminal-border-strong);
+}
+
+.auth-terminal-page input:focus {
+  border-color: rgba(25, 242, 211, 0.44);
+  box-shadow: 0 0 0 3px rgba(25, 242, 211, 0.12);
+}
+
+.auth-terminal-page input::placeholder {
+  color: var(--terminal-soft);
+}
+
+.auth-terminal-code {
+  display: block;
+  padding: 0.9rem 1rem;
+  border: 1px solid rgba(164, 137, 255, 0.16);
+  border-radius: 0.85rem;
+  background: rgba(255, 255, 255, 0.03);
+  color: #d8fff8;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.auth-terminal-meta {
+  margin: 0;
+}
+
+.auth-terminal-meta div {
+  padding: 0.9rem 1rem;
+  border: 1px solid rgba(164, 137, 255, 0.14);
+  border-radius: 0.85rem;
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.auth-terminal-meta dd {
+  margin: 0.45rem 0 0;
 }
 
 .settings-layout {
@@ -1873,15 +1963,19 @@ ul {
   margin-top: 0.35rem;
 }
 
-@media (max-width: 900px) {
-  .auth-hero-grid,
-  .auth-entry-grid,
-  .auth-session-grid {
+@media (max-width: 980px) {
+  .auth-terminal-hero,
+  .auth-choice-grid {
     grid-template-columns: 1fr;
   }
 
-  .auth-steps {
-    grid-template-columns: 1fr 1fr;
+  .auth-stage-progress {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .auth-terminal-field-row,
+  .auth-terminal-meta {
+    grid-template-columns: 1fr;
   }
 
   .settings-grid {
@@ -1889,17 +1983,22 @@ ul {
   }
 }
 
-@media (max-width: 560px) {
-  .auth-nav,
-  .auth-hero-actions,
-  .auth-flow-card__header {
+@media (max-width: 640px) {
+  .auth-terminal-nav,
+  .auth-stage-topline,
+  .auth-stage-card__actions {
     align-items: stretch;
+  }
+
+  .auth-terminal-nav__meta,
+  .auth-stage-topline,
+  .auth-stage-card__actions,
+  .auth-stage-topline__meta,
+  .auth-stage-progress {
     flex-direction: column;
   }
 
-  .auth-form--inline,
-  .auth-status-grid,
-  .auth-steps {
+  .auth-stage-progress {
     grid-template-columns: 1fr;
   }
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1540,27 +1540,167 @@ ul {
 }
 
 .auth-layout {
-  max-width: 960px;
+  max-width: 1120px;
 }
 
 .auth-hero {
   margin-bottom: 0.5rem;
 }
 
-.auth-subtitle {
-  max-width: 42rem;
+.auth-hero--reinvented {
+  position: relative;
+  overflow: hidden;
+  padding: clamp(1.25rem, 3vw, 2rem);
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-xl);
+  background:
+    radial-gradient(circle at 78% 10%, rgba(59, 190, 177, 0.28), transparent 22rem),
+    radial-gradient(circle at 12% 0%, rgba(234, 122, 65, 0.2), transparent 20rem),
+    linear-gradient(135deg, rgba(255, 255, 255, 0.78), rgba(255, 255, 255, 0.48));
+  box-shadow: var(--shadow-md);
 }
 
-.wrap-gap {
+.auth-nav,
+.auth-hero-actions,
+.auth-flow-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   gap: 1rem;
 }
 
-.auth-status-card {
+.auth-back-link,
+.auth-nav__status {
+  display: inline-flex;
+  align-items: center;
+  min-height: 2.4rem;
+  padding: 0.55rem 0.85rem;
+  border-radius: 999px;
+  border: 1px solid var(--border-soft);
+  background: var(--surface-soft);
+  text-decoration: none;
+  font-weight: 800;
+}
+
+.auth-nav__status {
+  color: var(--accent-strong);
+}
+
+.auth-hero-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.25fr) minmax(19rem, 0.75fr);
+  gap: clamp(1.25rem, 4vw, 3rem);
+  align-items: end;
+  padding-top: clamp(2rem, 6vw, 4.5rem);
+}
+
+.auth-hero-copy h1 {
+  max-width: 9ch;
+}
+
+.auth-subtitle {
+  max-width: 48rem;
+  font-size: 1.08rem;
+}
+
+.auth-hero-actions {
+  justify-content: flex-start;
+  flex-wrap: wrap;
+}
+
+.auth-orbit-card,
+.auth-panel,
+.auth-flow-card,
+.auth-next-card,
+.auth-details-card,
+.auth-empty-state {
+  border: 1px solid var(--border-soft);
+  background: var(--surface-strong);
+}
+
+.auth-orbit-card {
+  position: relative;
+  overflow: hidden;
+  display: grid;
+  gap: 1rem;
+  padding: 1.25rem;
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+}
+
+.auth-orbit-card__glow {
+  position: absolute;
+  inset: auto -20% -45% 18%;
+  height: 10rem;
+  border-radius: 999px;
+  background: rgba(15, 118, 110, 0.18);
+  filter: blur(28px);
+}
+
+.auth-orbit-card > *:not(.auth-orbit-card__glow) {
+  position: relative;
+}
+
+.auth-status-grid,
+.auth-entry-grid,
+.auth-session-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.auth-status-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.auth-status-grid span {
+  display: grid;
+  gap: 0.2rem;
+  padding: 0.9rem;
+  border-radius: 1rem;
+  background: var(--surface-elevated);
+  border: 1px solid var(--border-soft);
+}
+
+.auth-status-grid small {
+  color: var(--text-muted);
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.auth-entry-grid {
+  grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
+}
+
+.auth-panel {
   gap: 1.25rem;
 }
 
-.auth-guide-card {
+.auth-panel__header,
+.auth-field {
+  gap: 0.45rem;
+}
+
+.auth-form {
+  display: grid;
   gap: 1rem;
+}
+
+.auth-form--inline {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  align-items: end;
+}
+
+.auth-form--inline button {
+  grid-column: 1 / -1;
+}
+
+.auth-flow-card {
+  gap: 1.25rem;
+}
+
+.auth-flow-card__header {
+  align-items: flex-start;
 }
 
 .auth-steps {
@@ -1578,7 +1718,7 @@ ul {
   border: 1px solid var(--border-strong);
   background: var(--surface-elevated);
   color: var(--text-muted);
-  font-weight: 700;
+  font-weight: 800;
 }
 
 .auth-steps li::before {
@@ -1595,14 +1735,33 @@ ul {
 }
 
 .auth-steps li.active {
-  border-color: rgba(15, 118, 110, 0.28);
-  background: rgba(15, 118, 110, 0.08);
+  border-color: rgba(15, 118, 110, 0.34);
+  background: rgba(15, 118, 110, 0.1);
   color: var(--text-strong);
 }
 
-.auth-tip {
-  background: rgba(234, 122, 65, 0.08);
-  border-color: rgba(234, 122, 65, 0.18);
+.auth-session-grid {
+  grid-template-columns: minmax(0, 1fr) minmax(18rem, 0.78fr);
+  align-items: start;
+}
+
+.auth-next-card,
+.auth-details-card,
+.auth-empty-state {
+  padding: 1rem;
+  border-radius: var(--radius-md);
+}
+
+.auth-action-box {
+  padding: 1rem;
+  border-radius: 1rem;
+  border: 1px solid var(--border-soft);
+  background: var(--surface-elevated);
+}
+
+.auth-details-card .auth-callout {
+  display: grid;
+  gap: 0.75rem;
 }
 
 .status-pills-row {
@@ -1620,7 +1779,7 @@ ul {
   border: 1px solid var(--border-strong);
   background: var(--surface-elevated);
   color: var(--text-muted);
-  font-weight: 700;
+  font-weight: 800;
 }
 
 .status-chip--done {
@@ -1639,6 +1798,11 @@ ul {
 .auth-success {
   background: rgba(16, 185, 129, 0.08);
   border-color: rgba(16, 185, 129, 0.2);
+}
+
+.auth-error,
+.auth-loading {
+  margin: 1rem 0;
 }
 
 .settings-layout {
@@ -1710,6 +1874,12 @@ ul {
 }
 
 @media (max-width: 900px) {
+  .auth-hero-grid,
+  .auth-entry-grid,
+  .auth-session-grid {
+    grid-template-columns: 1fr;
+  }
+
   .auth-steps {
     grid-template-columns: 1fr 1fr;
   }
@@ -1720,6 +1890,15 @@ ul {
 }
 
 @media (max-width: 560px) {
+  .auth-nav,
+  .auth-hero-actions,
+  .auth-flow-card__header {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .auth-form--inline,
+  .auth-status-grid,
   .auth-steps {
     grid-template-columns: 1fr;
   }


### PR DESCRIPTION
## Summary
- Redesign `/auth` around clear sign-in and create/pair paths
- Add guided handoff status and next-action panels for passkey + agent pairing
- Preserve existing WebAuthn registration, sign-in, copy, refresh, and redeem behavior

## Checks
- npm test --workspace @theagentforum/web -- AuthPage
- npm run typecheck --workspace @theagentforum/web
- npm run build --workspace @theagentforum/web