### PR TITLE
Improve auth-gated forum UX

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,25 +1,57 @@
-import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
+import {
+  BrowserRouter,
+  Navigate,
+  Route,
+  Routes,
+  useLocation,
+  type Location,
+} from "react-router-dom";
+import { AuthProvider } from "./auth/AuthContext";
 import { createApiClient } from "./lib/api";
 import { AuthPage } from "./pages/AuthPage";
+import { MyAgentsPage } from "./pages/MyAgentsPage";
+import { ProfilePage } from "./pages/ProfilePage";
 import { SettingsPage } from "./pages/SettingsPage";
 import { ForumPage, LandingPage, PostDetailPage } from "./pages/TerminalGraphPages";
 
 const api = createApiClient();
 
-export function App() {
+function AppRoutes() {
+  const location = useLocation();
+  const state = location.state as { backgroundLocation?: Location } | undefined;
+  const backgroundLocation = state?.backgroundLocation;
+
   return (
-    <BrowserRouter>
-      <Routes>
+    <>
+      <Routes location={backgroundLocation ?? location}>
         <Route path="/" element={<LandingPage api={api} />} />
         <Route path="/forum" element={<ForumPage api={api} />} />
         <Route path="/explore" element={<ForumPage api={api} />} />
         <Route path="/posts/:postId" element={<PostDetailPage api={api} />} />
         <Route path="/auth" element={<AuthPage api={api} />} />
         <Route path="/settings" element={<SettingsPage api={api} />} />
+        <Route path="/profile" element={<ProfilePage />} />
+        <Route path="/my-agents" element={<MyAgentsPage api={api} />} />
         <Route path="/threads/:questionId" element={<PostDetailPage api={api} />} />
         <Route path="/questions/:questionId" element={<PostDetailPage api={api} />} />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
+
+      {backgroundLocation ? (
+        <Routes>
+          <Route path="/auth" element={<AuthPage api={api} presentation="modal" />} />
+        </Routes>
+      ) : null}
+    </>
+  );
+}
+
+export function App() {
+  return (
+    <BrowserRouter>
+      <AuthProvider api={api}>
+        <AppRoutes />
+      </AuthProvider>
     </BrowserRouter>
   );
 }

--- a/apps/web/src/auth/AuthContext.tsx
+++ b/apps/web/src/auth/AuthContext.tsx
@@ -1,0 +1,90 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type PropsWithChildren,
+} from "react";
+import type { ApiClient } from "../lib/api";
+import { readErrorMessage } from "../lib/ui";
+import type { WebSession } from "../types";
+
+interface AuthContextValue {
+  session: WebSession | null;
+  ready: boolean;
+  refreshing: boolean;
+  error: string | null;
+  refreshSession(): Promise<WebSession | null>;
+  signOut(): Promise<void>;
+}
+
+const defaultAuthContextValue: AuthContextValue = {
+  session: null,
+  ready: true,
+  refreshing: false,
+  error: null,
+  refreshSession: async () => null,
+  signOut: async () => undefined,
+};
+
+const AuthContext = createContext<AuthContextValue>(defaultAuthContextValue);
+
+interface AuthProviderProps extends PropsWithChildren {
+  api: ApiClient;
+}
+
+export function AuthProvider({ api, children }: AuthProviderProps) {
+  const [session, setSession] = useState<WebSession | null>(null);
+  const [ready, setReady] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refreshSession = useCallback(async (): Promise<WebSession | null> => {
+    setRefreshing(true);
+    setError(null);
+
+    try {
+      const nextSession = await api.getAuthSession();
+      setSession(nextSession);
+      return nextSession;
+    } catch (cause) {
+      setSession(null);
+      setError(readErrorMessage(cause));
+      return null;
+    } finally {
+      setReady(true);
+      setRefreshing(false);
+    }
+  }, [api]);
+
+  const signOut = useCallback(async (): Promise<void> => {
+    await api.signOut();
+    setSession(null);
+    setError(null);
+    setReady(true);
+  }, [api]);
+
+  useEffect(() => {
+    void refreshSession();
+  }, [refreshSession]);
+
+  const value = useMemo<AuthContextValue>(
+    () => ({
+      session,
+      ready,
+      refreshing,
+      error,
+      refreshSession,
+      signOut,
+    }),
+    [error, ready, refreshSession, refreshing, session, signOut],
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth() {
+  return useContext(AuthContext);
+}

--- a/apps/web/src/components/AnswerForm.tsx
+++ b/apps/web/src/components/AnswerForm.tsx
@@ -2,17 +2,20 @@ import { FormEvent, useState } from "react";
 
 export interface AnswerFormValues {
   body: string;
-  handle: string;
 }
 
 interface AnswerFormProps {
   onSubmit(values: AnswerFormValues): Promise<void> | void;
   disabled?: boolean;
+  authorLabel?: string;
 }
 
-export function AnswerForm({ onSubmit, disabled = false }: AnswerFormProps) {
+export function AnswerForm({
+  onSubmit,
+  disabled = false,
+  authorLabel,
+}: AnswerFormProps) {
   const [body, setBody] = useState("");
-  const [handle, setHandle] = useState("pixel");
   const [submitting, setSubmitting] = useState(false);
   const answerHintId = "answer-body-hint";
 
@@ -21,10 +24,9 @@ export function AnswerForm({ onSubmit, disabled = false }: AnswerFormProps) {
 
     const payload = {
       body: body.trim(),
-      handle: handle.trim(),
     };
 
-    if (!payload.body || !payload.handle) {
+    if (!payload.body) {
       return;
     }
 
@@ -42,6 +44,10 @@ export function AnswerForm({ onSubmit, disabled = false }: AnswerFormProps) {
 
   return (
     <form className="stack form-shell" onSubmit={handleSubmit}>
+      {authorLabel ? (
+        <p className="form-author-badge">Replying as {authorLabel}</p>
+      ) : null}
+
       <div className="field">
         <label htmlFor="answer-body">Answer</label>
         <textarea
@@ -57,17 +63,6 @@ export function AnswerForm({ onSubmit, disabled = false }: AnswerFormProps) {
           Favor concrete steps, tradeoffs, and details another reader can reuse.
         </small>
       </div>
-
-      <label className="field" htmlFor="answer-handle">
-        <span>Your handle</span>
-        <input
-          id="answer-handle"
-          value={handle}
-          onChange={(event) => setHandle(event.target.value)}
-          placeholder="pixel"
-          disabled={isDisabled}
-        />
-      </label>
 
       <button type="submit" className="button" disabled={isDisabled}>
         {submitting ? "Posting..." : "Post answer"}

--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -1,5 +1,6 @@
 import type { PropsWithChildren, ReactNode } from "react";
 import { Link } from "react-router-dom";
+import { AuthControls } from "./AuthControls";
 
 interface AppShellProps extends PropsWithChildren {
   cta?: ReactNode;
@@ -31,6 +32,7 @@ export function AppShell({ children, cta }: AppShellProps) {
             <Link to="/settings">Settings</Link>
             <a href="/skill.md">Agent pack</a>
             {cta}
+            <AuthControls />
           </nav>
         </div>
       </header>

--- a/apps/web/src/components/AuthControls.tsx
+++ b/apps/web/src/components/AuthControls.tsx
@@ -1,0 +1,101 @@
+import { useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { useAuth } from "../auth/AuthContext";
+import {
+  buildAuthPath,
+  buildPairingAuthPath,
+  useAuthNavigation,
+} from "../lib/auth-routing";
+import { describeActor, getActorInitials } from "../lib/ui";
+
+interface AuthControlsProps {
+  variant?: "default" | "terminal";
+}
+
+export function AuthControls({ variant = "default" }: AuthControlsProps) {
+  const auth = useAuth();
+  const navigate = useNavigate();
+  const { openAuth, returnTo } = useAuthNavigation();
+  const [signingOut, setSigningOut] = useState(false);
+
+  if (!auth.session) {
+    return (
+      <div className={`auth-header-actions auth-header-actions--${variant}`}>
+        <button
+          type="button"
+          className={variant === "terminal" ? "terminal-link-button" : "button button--ghost"}
+          onClick={() => openAuth({ mode: "signin" })}
+        >
+          Sign in
+        </button>
+        <button
+          type="button"
+          className={variant === "terminal" ? "terminal-button" : "button"}
+          onClick={() => openAuth({ mode: "signup" })}
+        >
+          Sign up
+        </button>
+      </div>
+    );
+  }
+
+  const actor = auth.session.actor;
+  const actorName = describeActor(actor);
+
+  async function handleSignOut(): Promise<void> {
+    setSigningOut(true);
+
+    try {
+      await auth.signOut();
+      navigate(returnTo, { replace: true });
+    } finally {
+      setSigningOut(false);
+    }
+  }
+
+  return (
+    <details className={`auth-menu auth-menu--${variant}`}>
+      <summary className="auth-menu__trigger">
+        <span className="auth-menu__avatar" aria-hidden="true">
+          {getActorInitials(actor)}
+        </span>
+        <span className="auth-menu__label">
+          <strong>{actorName}</strong>
+          <small>{actor.handle}</small>
+        </span>
+      </summary>
+
+      <div className="auth-menu__panel" role="menu" aria-label="Profile menu">
+        <Link role="menuitem" to="/settings">
+          Settings
+        </Link>
+        <Link role="menuitem" to="/profile">
+          My Profile
+        </Link>
+        <Link role="menuitem" to="/my-agents">
+          My Agents
+        </Link>
+        <Link
+          role="menuitem"
+          to={buildPairingAuthPath("/my-agents")}
+        >
+          Pair an agent
+        </Link>
+        <Link
+          role="menuitem"
+          to={buildAuthPath("/settings", { mode: "signup" })}
+        >
+          Add a passkey
+        </Link>
+        <button
+          type="button"
+          role="menuitem"
+          onClick={() => void handleSignOut()}
+          disabled={signingOut}
+        >
+          {signingOut ? "Signing out..." : "Sign out"}
+        </button>
+      </div>
+    </details>
+  );
+}

--- a/apps/web/src/components/AuthRequiredPanel.tsx
+++ b/apps/web/src/components/AuthRequiredPanel.tsx
@@ -1,0 +1,64 @@
+import { useAuth } from "../auth/AuthContext";
+import { useAuthNavigation } from "../lib/auth-routing";
+
+interface AuthRequiredPanelProps {
+  title: string;
+  description: string;
+  surface?: "default" | "terminal";
+  loading?: boolean;
+}
+
+export function AuthRequiredPanel({
+  title,
+  description,
+  surface = "default",
+  loading = false,
+}: AuthRequiredPanelProps) {
+  const { openAuth } = useAuthNavigation();
+  const auth = useAuth();
+
+  if (auth.session) {
+    return null;
+  }
+
+  const classes = [
+    "auth-required-panel",
+    surface === "terminal" ? "auth-required-panel--terminal" : null,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <section className={classes} aria-label={title}>
+      <span className="auth-required-panel__icon" aria-hidden="true">
+        lock
+      </span>
+      <div className="auth-required-panel__copy">
+        <h3>{loading ? "Checking access" : title}</h3>
+        <p>
+          {loading
+            ? "Loading your session before we decide which tools to unlock."
+            : description}
+        </p>
+      </div>
+      <div className="auth-required-panel__actions">
+        <button
+          type="button"
+          className={surface === "terminal" ? "terminal-link-button" : "button button--ghost"}
+          onClick={() => openAuth({ mode: "signin" })}
+          disabled={loading}
+        >
+          Sign in
+        </button>
+        <button
+          type="button"
+          className={surface === "terminal" ? "terminal-button" : "button"}
+          onClick={() => openAuth({ mode: "signup" })}
+          disabled={loading}
+        >
+          Sign up
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/CreateQuestionForm.test.tsx
+++ b/apps/web/src/components/CreateQuestionForm.test.tsx
@@ -8,12 +8,12 @@ describe("CreateQuestionForm", () => {
     const onSubmit = vi.fn().mockResolvedValue(undefined);
     const user = userEvent.setup();
 
-    render(<CreateQuestionForm onSubmit={onSubmit} />);
+    render(<CreateQuestionForm onSubmit={onSubmit} authorLabel="Felix" />);
+
+    expect(screen.getByText("Posting as Felix")).toBeInTheDocument();
 
     await user.type(screen.getByLabelText("Title"), "  How to test forms?  ");
     await user.type(screen.getByLabelText("Body"), "  Add realistic checks.  ");
-    await user.clear(screen.getByLabelText("Your handle"));
-    await user.type(screen.getByLabelText("Your handle"), "  felix796  ");
 
     await user.click(screen.getByRole("button", { name: "Post question" }));
 
@@ -24,7 +24,6 @@ describe("CreateQuestionForm", () => {
     expect(onSubmit).toHaveBeenCalledWith({
       title: "How to test forms?",
       body: "Add realistic checks.",
-      handle: "felix796",
     });
   });
 });

--- a/apps/web/src/components/CreateQuestionForm.tsx
+++ b/apps/web/src/components/CreateQuestionForm.tsx
@@ -3,18 +3,21 @@ import { FormEvent, useState } from "react";
 export interface CreateQuestionFormValues {
   title: string;
   body: string;
-  handle: string;
 }
 
 interface CreateQuestionFormProps {
   onSubmit(values: CreateQuestionFormValues): Promise<void> | void;
   disabled?: boolean;
+  authorLabel?: string;
 }
 
-export function CreateQuestionForm({ onSubmit, disabled = false }: CreateQuestionFormProps) {
+export function CreateQuestionForm({
+  onSubmit,
+  disabled = false,
+  authorLabel,
+}: CreateQuestionFormProps) {
   const [title, setTitle] = useState("");
   const [body, setBody] = useState("");
-  const [handle, setHandle] = useState("felix796");
   const [submitting, setSubmitting] = useState(false);
   const bodyHintId = "create-question-body-hint";
 
@@ -24,10 +27,9 @@ export function CreateQuestionForm({ onSubmit, disabled = false }: CreateQuestio
     const payload = {
       title: title.trim(),
       body: body.trim(),
-      handle: handle.trim(),
     };
 
-    if (!payload.title || !payload.body || !payload.handle) {
+    if (!payload.title || !payload.body) {
       return;
     }
 
@@ -46,29 +48,20 @@ export function CreateQuestionForm({ onSubmit, disabled = false }: CreateQuestio
 
   return (
     <form className="stack form-shell" onSubmit={handleSubmit}>
-      <div className="form-grid">
-        <label className="field" htmlFor="question-title">
-          <span>Title</span>
-          <input
-            id="question-title"
-            value={title}
-            onChange={(event) => setTitle(event.target.value)}
-            placeholder="How should an agent structure memory cleanup?"
-            disabled={isDisabled}
-          />
-        </label>
+      {authorLabel ? (
+        <p className="form-author-badge">Posting as {authorLabel}</p>
+      ) : null}
 
-        <label className="field" htmlFor="question-handle">
-          <span>Your handle</span>
-          <input
-            id="question-handle"
-            value={handle}
-            onChange={(event) => setHandle(event.target.value)}
-            placeholder="felix796"
-            disabled={isDisabled}
-          />
-        </label>
-      </div>
+      <label className="field" htmlFor="question-title">
+        <span>Title</span>
+        <input
+          id="question-title"
+          value={title}
+          onChange={(event) => setTitle(event.target.value)}
+          placeholder="How should an agent structure memory cleanup?"
+          disabled={isDisabled}
+        />
+      </label>
 
       <div className="field">
         <label htmlFor="question-body">Body</label>

--- a/apps/web/src/lib/auth-routing.ts
+++ b/apps/web/src/lib/auth-routing.ts
@@ -1,0 +1,59 @@
+import { useLocation, useNavigate } from "react-router-dom";
+
+export type AuthMode = "signin" | "signup";
+
+interface OpenAuthOptions {
+  mode?: AuthMode;
+}
+
+export function buildAuthPath(
+  returnTo: string,
+  options: OpenAuthOptions = {},
+): string {
+  const searchParams = new URLSearchParams();
+  searchParams.set("returnTo", returnTo);
+
+  if (options.mode) {
+    searchParams.set("mode", options.mode);
+  }
+
+  return `/auth?${searchParams.toString()}`;
+}
+
+export function buildPairingAuthPath(returnTo?: string): string {
+  const searchParams = new URLSearchParams();
+  searchParams.set("flow", "pairing");
+
+  if (returnTo) {
+    searchParams.set("returnTo", returnTo);
+  }
+
+  return `/auth?${searchParams.toString()}`;
+}
+
+export function readSafeReturnTo(value: string | null | undefined): string {
+  if (!value || !value.startsWith("/")) {
+    return "/";
+  }
+
+  return value;
+}
+
+export function useAuthNavigation() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const returnTo = `${location.pathname}${location.search}${location.hash}`;
+
+  function openAuth(options: OpenAuthOptions = {}): void {
+    navigate(buildAuthPath(returnTo, options), {
+      state: {
+        backgroundLocation: location,
+      },
+    });
+  }
+
+  return {
+    returnTo,
+    openAuth,
+  };
+}

--- a/apps/web/src/lib/ui.ts
+++ b/apps/web/src/lib/ui.ts
@@ -1,4 +1,5 @@
 import { ApiClientError } from "./api";
+import type { Actor } from "../types";
 
 export function readErrorMessage(cause: unknown): string {
   if (cause instanceof ApiClientError) {
@@ -20,4 +21,36 @@ export function formatDate(isoDate: string): string {
   }
 
   return value.toLocaleString();
+}
+
+export function describeActor(actor: Actor): string {
+  return actor.displayName || actor.handle;
+}
+
+export function getActorInitials(actor: Actor): string {
+  const label = describeActor(actor).replace(/[@._-]+/g, " ").trim();
+  const parts = label.split(/\s+/).filter(Boolean);
+
+  if (parts.length === 0) {
+    return "?";
+  }
+
+  return parts
+    .slice(0, 2)
+    .map((part) => part.charAt(0).toUpperCase())
+    .join("");
+}
+
+export function deriveDisplayNameFromIdentifier(identifier: string): string {
+  const localPart = identifier.split("@")[0] ?? identifier;
+  const cleaned = localPart.replace(/[._-]+/g, " ").trim();
+
+  if (!cleaned) {
+    return identifier;
+  }
+
+  return cleaned
+    .split(/\s+/)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(" ");
 }

--- a/apps/web/src/pages/AuthPage.test.tsx
+++ b/apps/web/src/pages/AuthPage.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ApiClient } from "../lib/api";
 import { AuthPage } from "./AuthPage";
@@ -30,50 +30,243 @@ describe("AuthPage", () => {
     });
   });
 
-  it("shows only the selected auth path on a fresh visit", async () => {
-    const user = userEvent.setup();
-    const api = {
-      listQuestions: vi.fn(),
-      searchThreads: vi.fn(),
-      createQuestion: vi.fn(),
-      getQuestionThread: vi.fn(),
-      createAnswer: vi.fn(),
-      acceptAnswer: vi.fn(),
-      listAnswerSkills: vi.fn(),
-      startRegistration: vi.fn(),
-      getRegistrationSession: vi.fn(),
-      resolveRegistrationSession: vi.fn(),
-      getPasskeyRegistrationOptions: vi.fn(),
-      registerPasskey: vi.fn(),
-      completeRegistrationVerification: vi.fn(),
-      redeemPairing: vi.fn(),
-    } as unknown as ApiClient;
-
+  it("renders the email-first passkey flow by default", () => {
     render(
       <MemoryRouter initialEntries={["/auth"]}>
-        <AuthPage api={api} />
+        <AuthPage api={buildApi()} />
       </MemoryRouter>,
     );
 
     expect(
-      screen.queryByRole("heading", { name: /sign in with a passkey/i }),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole("heading", { name: /start a handoff/i }),
-    ).not.toBeInTheDocument();
+      screen.getByRole("heading", { name: /sign in with email and a passkey/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Email")).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Sign in" })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByRole("tab", { name: "Sign up" })).toHaveAttribute("aria-selected", "false");
+    expect(screen.getByRole("button", { name: /continue with passkey/i })).toBeInTheDocument();
+  });
 
-    await user.click(
-      screen.getByRole("button", { name: /use existing passkey/i }),
+  it("signs in with a passkey and returns to the requested route", async () => {
+    const user = userEvent.setup();
+    const getCredential = vi.fn().mockResolvedValue(
+      buildAuthenticationCredential({
+        credentialId: Uint8Array.from([1, 2, 3, 4]),
+        clientDataJson: new TextEncoder().encode(
+          JSON.stringify({
+            type: "webauthn.get",
+            challenge: "AQIDBA",
+            origin: window.location.origin,
+          }),
+        ),
+        authenticatorData: Uint8Array.from([9, 8, 7, 6]),
+        signature: Uint8Array.from([4, 3, 2, 1]),
+      }),
     );
 
-    expect(
-      screen.getByRole("heading", { name: /sign in with a passkey/i }),
-    ).toBeInTheDocument();
-    expect(screen.getByLabelText("Handle")).toBeInTheDocument();
-    expect(screen.queryByLabelText("Display name")).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole("button", { name: /start handoff/i }),
-    ).not.toBeInTheDocument();
+    Object.defineProperty(navigator, "credentials", {
+      configurable: true,
+      value: {
+        get: getCredential,
+      },
+    });
+
+    const api = buildApi({
+      startAuthentication: vi.fn().mockResolvedValue({
+        id: "aas-1",
+        handle: "eric@example.com",
+        displayName: "Eric",
+        status: "awaiting_authentication",
+        challenge: "AQIDBA",
+        createdAt: "2026-03-26T00:00:00.000Z",
+        expiresAt: "2026-03-26T00:15:00.000Z",
+      }),
+      getPasskeyAuthenticationOptions: vi.fn().mockResolvedValue({
+        authenticationSessionId: "aas-1",
+        challenge: "AQIDBA",
+        rpId: "localhost",
+        allowCredentials: [{ id: "AQIDBA", type: "public-key", transports: ["internal"] }],
+        timeout: 60000,
+        userVerification: "required",
+      }),
+      authenticatePasskey: vi.fn().mockResolvedValue({
+        id: "aas-1",
+        handle: "eric@example.com",
+        displayName: "Eric",
+        status: "verified",
+        challenge: "AQIDBA",
+        verificationMethod: "webauthn",
+        passkeyLabel: "Eric passkey",
+        createdAt: "2026-03-26T00:00:00.000Z",
+        expiresAt: "2026-03-26T00:15:00.000Z",
+        verifiedAt: "2026-03-26T00:01:00.000Z",
+      }),
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/auth?mode=signin&returnTo=/done"]}>
+        <Routes>
+          <Route path="/auth" element={<AuthPage api={api} />} />
+          <Route path="/done" element={<p>done</p>} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await user.type(screen.getByLabelText("Email"), "Eric@Example.com");
+    await user.click(screen.getByRole("button", { name: /continue with passkey/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("done")).toBeInTheDocument();
+    });
+
+    expect(api.startAuthentication).toHaveBeenCalledWith({
+      handle: "eric@example.com",
+    });
+    expect(api.authenticatePasskey).toHaveBeenCalledWith({
+      authenticationSessionId: "aas-1",
+      credential: {
+        id: "AQIDBA",
+        rawId: "AQIDBA",
+        type: "public-key",
+        response: {
+          authenticatorData: "CQgHBg",
+          clientDataJSON: toBase64Url(
+            new TextEncoder().encode(
+              JSON.stringify({
+                type: "webauthn.get",
+                challenge: "AQIDBA",
+                origin: window.location.origin,
+              }),
+            ),
+          ),
+          signature: "BAMCAQ",
+        },
+        authenticatorAttachment: "platform",
+        clientExtensionResults: { credProps: { rk: true } },
+      },
+    });
+  });
+
+  it("creates a passkey account, then signs in and returns to the requested route", async () => {
+    const user = userEvent.setup();
+    const createCredential = vi.fn().mockResolvedValue(
+      buildCredential({
+        credentialId: Uint8Array.from([1, 2, 3, 4]),
+        clientDataJson: new TextEncoder().encode(
+          JSON.stringify({
+            type: "webauthn.create",
+            challenge: "AQIDBA",
+            origin: window.location.origin,
+          }),
+        ),
+        attestationObject: Uint8Array.from([9, 8, 7, 6]),
+        publicKey: Uint8Array.from([4, 3, 2, 1]),
+        publicKeyAlgorithm: -7,
+        transports: ["internal"],
+      }),
+    );
+    const getCredential = vi.fn().mockResolvedValue(
+      buildAuthenticationCredential({
+        credentialId: Uint8Array.from([1, 2, 3, 4]),
+        clientDataJson: new TextEncoder().encode(
+          JSON.stringify({
+            type: "webauthn.get",
+            challenge: "AQIDBA",
+            origin: window.location.origin,
+          }),
+        ),
+        authenticatorData: Uint8Array.from([9, 8, 7, 6]),
+        signature: Uint8Array.from([4, 3, 2, 1]),
+      }),
+    );
+
+    Object.defineProperty(navigator, "credentials", {
+      configurable: true,
+      value: {
+        create: createCredential,
+        get: getCredential,
+      },
+    });
+
+    const api = buildApi({
+      startRegistration: vi.fn().mockResolvedValue(buildRegistrationSession()),
+      getPasskeyRegistrationOptions: vi.fn().mockResolvedValue({
+        registrationSessionId: "ars-1",
+        rp: { id: "localhost", name: "TheAgentForum" },
+        user: {
+          id: "BQYHCA",
+          name: "eric@example.com",
+          displayName: "Eric",
+        },
+        challenge: "AQIDBA",
+        pubKeyCredParams: [{ type: "public-key", alg: -7 }],
+        timeout: 60000,
+        attestation: "none",
+        authenticatorSelection: {
+          residentKey: "preferred",
+          userVerification: "preferred",
+        },
+      }),
+      registerPasskey: vi.fn().mockResolvedValue({
+        ...buildRegistrationSession(),
+        status: "verified",
+        verificationMethod: "webauthn",
+        passkeyLabel: "Eric passkey",
+        verifiedAt: "2026-03-26T00:01:00.000Z",
+      }),
+      startAuthentication: vi.fn().mockResolvedValue({
+        id: "aas-1",
+        handle: "eric@example.com",
+        displayName: "Eric",
+        status: "awaiting_authentication",
+        challenge: "AQIDBA",
+        createdAt: "2026-03-26T00:00:00.000Z",
+        expiresAt: "2026-03-26T00:15:00.000Z",
+      }),
+      getPasskeyAuthenticationOptions: vi.fn().mockResolvedValue({
+        authenticationSessionId: "aas-1",
+        challenge: "AQIDBA",
+        rpId: "localhost",
+        allowCredentials: [{ id: "AQIDBA", type: "public-key", transports: ["internal"] }],
+        timeout: 60000,
+        userVerification: "required",
+      }),
+      authenticatePasskey: vi.fn().mockResolvedValue({
+        id: "aas-1",
+        handle: "eric@example.com",
+        displayName: "Eric",
+        status: "verified",
+        challenge: "AQIDBA",
+        verificationMethod: "webauthn",
+        passkeyLabel: "Eric passkey",
+        createdAt: "2026-03-26T00:00:00.000Z",
+        expiresAt: "2026-03-26T00:15:00.000Z",
+        verifiedAt: "2026-03-26T00:01:00.000Z",
+      }),
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/auth?mode=signup&returnTo=/done"]}>
+        <Routes>
+          <Route path="/auth" element={<AuthPage api={api} />} />
+          <Route path="/done" element={<p>done</p>} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await user.click(screen.getByRole("tab", { name: "Sign up" }));
+    await user.type(screen.getByLabelText("Email"), "eric@example.com");
+    await user.click(screen.getByRole("button", { name: /create passkey/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("done")).toBeInTheDocument();
+    });
+
+    expect(api.startRegistration).toHaveBeenCalledWith({
+      handle: "eric@example.com",
+      displayName: "Eric",
+    });
+    expect(api.registerPasskey).toHaveBeenCalled();
+    expect(api.authenticatePasskey).toHaveBeenCalled();
   });
 
   it("moves from the passkey step to the pairing step without showing both at once", async () => {
@@ -106,7 +299,7 @@ describe("AuthPage", () => {
       ...buildRegistrationSession(),
       status: "verified",
       verificationMethod: "webauthn",
-      passkeyLabel: "Felix MacBook Passkey",
+      passkeyLabel: "Eric passkey",
       verifiedAt: "2026-03-26T00:01:00.000Z",
       pairing: {
         ...buildRegistrationSession().pairing,
@@ -114,24 +307,15 @@ describe("AuthPage", () => {
       },
     });
 
-    const api = {
-      listQuestions: vi.fn(),
-      searchThreads: vi.fn(),
-      createQuestion: vi.fn(),
-      getQuestionThread: vi.fn(),
-      createAnswer: vi.fn(),
-      acceptAnswer: vi.fn(),
-      listAnswerSkills: vi.fn(),
-      startRegistration: vi.fn(),
+    const api = buildApi({
       getRegistrationSession: vi.fn().mockResolvedValue(buildRegistrationSession()),
-      resolveRegistrationSession: vi.fn(),
       getPasskeyRegistrationOptions: vi.fn().mockResolvedValue({
         registrationSessionId: "ars-1",
         rp: { id: "localhost", name: "TheAgentForum" },
         user: {
           id: "BQYHCA",
-          name: "felix796",
-          displayName: "Felix",
+          name: "eric@example.com",
+          displayName: "Eric",
         },
         challenge: "AQIDBA",
         pubKeyCredParams: [{ type: "public-key", alg: -7 }],
@@ -143,9 +327,7 @@ describe("AuthPage", () => {
         },
       }),
       registerPasskey,
-      completeRegistrationVerification: vi.fn(),
-      redeemPairing: vi.fn(),
-    } as unknown as ApiClient;
+    });
 
     render(
       <MemoryRouter initialEntries={["/auth?registration=ars-1"]}>
@@ -154,190 +336,59 @@ describe("AuthPage", () => {
     );
 
     await waitFor(() => {
-      expect(
-        screen.getByRole("button", { name: "save passkey" }),
-      ).toBeEnabled();
+      expect(screen.getByRole("button", { name: "save passkey" })).toBeEnabled();
     });
 
-    expect(
-      screen.getByRole("heading", { name: /save a passkey/i }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /save a passkey/i })).toBeInTheDocument();
     expect(screen.queryByLabelText("Pairing code")).not.toBeInTheDocument();
 
     await user.clear(screen.getByLabelText("Passkey label"));
-    await user.type(screen.getByLabelText("Passkey label"), "Felix MacBook Passkey");
+    await user.type(screen.getByLabelText("Passkey label"), "Eric passkey");
     await user.click(screen.getByRole("button", { name: "save passkey" }));
 
     await waitFor(() => {
-      expect(createCredential).toHaveBeenCalledTimes(1);
-      expect(registerPasskey).toHaveBeenCalledTimes(1);
+      expect(screen.getByRole("heading", { name: /pair this agent/i })).toBeInTheDocument();
     });
 
-    expect(
-      screen.getByRole("heading", { name: /pair this agent/i }),
-    ).toBeInTheDocument();
     expect(screen.getByLabelText("Pairing code")).toBeInTheDocument();
-    expect(
-      screen.queryByRole("button", { name: "save passkey" }),
-    ).not.toBeInTheDocument();
-
-    const creationCall = createCredential.mock.calls[0]?.[0] as { publicKey?: PublicKeyCredentialCreationOptions };
-    expect(creationCall.publicKey).toBeDefined();
-    expect(Array.from(new Uint8Array(creationCall.publicKey?.challenge as ArrayBuffer))).toEqual([
-      1, 2, 3, 4,
-    ]);
-    expect(Array.from(new Uint8Array(creationCall.publicKey?.user.id as ArrayBuffer))).toEqual([
-      5, 6, 7, 8,
-    ]);
-
-    expect(registerPasskey).toHaveBeenCalledWith({
-      registrationSessionId: "ars-1",
-      credential: {
-        id: "AQIDBA",
-        rawId: "AQIDBA",
-        type: "public-key",
-        response: {
-          attestationObject: "CQgHBg",
-          clientDataJSON: toBase64Url(
-            new TextEncoder().encode(
-              JSON.stringify({
-                type: "webauthn.create",
-                challenge: "AQIDBA",
-                origin: window.location.origin,
-              }),
-            ),
-          ),
-          publicKey: "BAMCAQ",
-          publicKeyAlgorithm: -7,
-          transports: ["internal"],
-        },
-        authenticatorAttachment: "platform",
-        clientExtensionResults: { credProps: { rk: true } },
-      },
-      passkeyLabel: "Felix MacBook Passkey",
-    });
-  });
-
-  it("starts passkey sign-in and refreshes auth state after authentication succeeds", async () => {
-    const user = userEvent.setup();
-    const getCredential = vi.fn().mockResolvedValue(
-      buildAuthenticationCredential({
-        credentialId: Uint8Array.from([1, 2, 3, 4]),
-        clientDataJson: new TextEncoder().encode(
-          JSON.stringify({
-            type: "webauthn.get",
-            challenge: "AQIDBA",
-            origin: window.location.origin,
-          }),
-        ),
-        authenticatorData: Uint8Array.from([9, 8, 7, 6]),
-        signature: Uint8Array.from([4, 3, 2, 1]),
-      }),
-    );
-
-    Object.defineProperty(navigator, "credentials", {
-      configurable: true,
-      value: {
-        get: getCredential,
-      },
-    });
-
-    const onAuthStateChange = vi.fn().mockResolvedValue(undefined);
-    const api = {
-      listQuestions: vi.fn(),
-      searchThreads: vi.fn(),
-      createQuestion: vi.fn(),
-      getQuestionThread: vi.fn(),
-      createAnswer: vi.fn(),
-      acceptAnswer: vi.fn(),
-      listAnswerSkills: vi.fn(),
-      startRegistration: vi.fn(),
-      getRegistrationSession: vi.fn(),
-      resolveRegistrationSession: vi.fn(),
-      getPasskeyRegistrationOptions: vi.fn(),
-      registerPasskey: vi.fn(),
-      completeRegistrationVerification: vi.fn(),
-      redeemPairing: vi.fn(),
-      startAuthentication: vi.fn().mockResolvedValue({
-        id: "aas-1",
-        handle: "felix796",
-        displayName: "Felix",
-        status: "awaiting_authentication",
-        challenge: "AQIDBA",
-        createdAt: "2026-03-26T00:00:00.000Z",
-        expiresAt: "2026-03-26T00:15:00.000Z",
-      }),
-      getPasskeyAuthenticationOptions: vi.fn().mockResolvedValue({
-        authenticationSessionId: "aas-1",
-        challenge: "AQIDBA",
-        rpId: "localhost",
-        allowCredentials: [{ id: "AQIDBA", type: "public-key", transports: ["internal"] }],
-        timeout: 60000,
-        userVerification: "required",
-      }),
-      authenticatePasskey: vi.fn().mockResolvedValue({
-        id: "aas-1",
-        handle: "felix796",
-        displayName: "Felix",
-        status: "verified",
-        challenge: "AQIDBA",
-        verificationMethod: "webauthn",
-        passkeyLabel: "Felix MacBook Passkey",
-        createdAt: "2026-03-26T00:00:00.000Z",
-        expiresAt: "2026-03-26T00:15:00.000Z",
-        verifiedAt: "2026-03-26T00:01:00.000Z",
-      }),
-    } as unknown as ApiClient;
-
-    render(
-      <MemoryRouter initialEntries={["/auth"]}>
-        <AuthPage api={api} onAuthStateChange={onAuthStateChange} />
-      </MemoryRouter>,
-    );
-
-    await user.click(
-      screen.getByRole("button", { name: /use existing passkey/i }),
-    );
-    await user.type(screen.getByLabelText("Handle"), "felix796");
-    await user.click(screen.getByRole("button", { name: "sign in" }));
-
-    await waitFor(() => {
-      expect(getCredential).toHaveBeenCalledTimes(1);
-      expect(onAuthStateChange).toHaveBeenCalledTimes(1);
-    });
-
-    expect(api.startAuthentication).toHaveBeenCalledWith({ handle: "felix796" });
-    expect(api.authenticatePasskey).toHaveBeenCalledWith({
-      authenticationSessionId: "aas-1",
-      credential: {
-        id: "AQIDBA",
-        rawId: "AQIDBA",
-        type: "public-key",
-        response: {
-          authenticatorData: "CQgHBg",
-          clientDataJSON: toBase64Url(
-            new TextEncoder().encode(
-              JSON.stringify({
-                type: "webauthn.get",
-                challenge: "AQIDBA",
-                origin: window.location.origin,
-              }),
-            ),
-          ),
-          signature: "BAMCAQ",
-        },
-        authenticatorAttachment: "platform",
-        clientExtensionResults: { credProps: { rk: true } },
-      },
-    });
+    expect(screen.queryByRole("button", { name: "save passkey" })).not.toBeInTheDocument();
   });
 });
+
+function buildApi(overrides: Partial<ApiClient> = {}): ApiClient {
+  return {
+    listQuestions: vi.fn(),
+    searchThreads: vi.fn(),
+    createQuestion: vi.fn(),
+    getQuestionThread: vi.fn(),
+    createAnswer: vi.fn(),
+    acceptAnswer: vi.fn(),
+    listAnswerSkills: vi.fn(),
+    startRegistration: vi.fn(),
+    getRegistrationSession: vi.fn(),
+    resolveRegistrationSession: vi.fn(),
+    getPasskeyRegistrationOptions: vi.fn(),
+    registerPasskey: vi.fn(),
+    completeRegistrationVerification: vi.fn(),
+    redeemPairing: vi.fn(),
+    startAuthentication: vi.fn(),
+    getPasskeyAuthenticationOptions: vi.fn(),
+    authenticatePasskey: vi.fn(),
+    getAuthSession: vi.fn().mockResolvedValue(null),
+    listPasskeys: vi.fn(),
+    removePasskey: vi.fn(),
+    listDevices: vi.fn(),
+    revokeDevice: vi.fn(),
+    signOut: vi.fn(),
+    ...overrides,
+  } as unknown as ApiClient;
+}
 
 function buildRegistrationSession() {
   return {
     id: "ars-1",
-    handle: "felix796",
-    displayName: "Felix",
+    handle: "eric@example.com",
+    displayName: "Eric",
     status: "pending_webauthn_registration" as const,
     challenge: "AQIDBA",
     verificationUrl: "/auth?registration=verify-token-1",

--- a/apps/web/src/pages/AuthPage.tsx
+++ b/apps/web/src/pages/AuthPage.tsx
@@ -1,6 +1,17 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { Link, useNavigate, useSearchParams } from "react-router-dom";
-import { ApiClientError, type ApiClient } from "../lib/api";
+import { useAuth } from "../auth/AuthContext";
+import type { ApiClient } from "../lib/api";
+import {
+  buildAuthPath,
+  buildPairingAuthPath,
+  readSafeReturnTo,
+} from "../lib/auth-routing";
+import {
+  deriveDisplayNameFromIdentifier,
+  describeActor,
+  readErrorMessage,
+} from "../lib/ui";
 import type {
   FinishAuthenticationInput,
   FinishRegistrationInput,
@@ -11,10 +22,10 @@ import type {
 
 interface AuthPageProps {
   api: ApiClient;
-  onAuthStateChange?: () => Promise<void> | void;
+  presentation?: "page" | "modal";
 }
 
-type AuthPath = "choose" | "sign-in" | "register";
+type AuthMode = "signin" | "signup";
 
 type RegistrationStage =
   | "start"
@@ -31,13 +42,321 @@ const registrationSteps = [
   "done",
 ] as const;
 
-export function AuthPage({ api, onAuthStateChange }: AuthPageProps) {
-  const navigate = useNavigate();
+export function AuthPage({ api, presentation = "page" }: AuthPageProps) {
+  const auth = useAuth();
   const [searchParams] = useSearchParams();
   const registrationParam = searchParams.get("registration") ?? "";
-  const [selectedPath, setSelectedPath] = useState<AuthPath>(
-    registrationParam ? "register" : "choose",
+  const flow = searchParams.get("flow");
+  const returnTo = readSafeReturnTo(searchParams.get("returnTo"));
+
+  if (registrationParam || flow === "pairing") {
+    return (
+      <PairingAuthPage
+        api={api}
+        presentation={presentation}
+        registrationParam={registrationParam}
+        returnTo={returnTo}
+      />
+    );
+  }
+
+  return (
+    <EmailPasskeyAuthPage
+      api={api}
+      presentation={presentation}
+      returnTo={returnTo}
+      onAuthStateChange={auth.refreshSession}
+      sessionName={auth.session ? describeActor(auth.session.actor) : null}
+      isAuthenticated={Boolean(auth.session)}
+    />
   );
+}
+
+interface EmailPasskeyAuthPageProps {
+  api: ApiClient;
+  presentation: "page" | "modal";
+  returnTo: string;
+  onAuthStateChange: () => Promise<unknown>;
+  sessionName: string | null;
+  isAuthenticated: boolean;
+}
+
+function EmailPasskeyAuthPage({
+  api,
+  presentation,
+  returnTo,
+  onAuthStateChange,
+  sessionName,
+  isAuthenticated,
+}: EmailPasskeyAuthPageProps) {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const requestedMode = readRequestedMode(searchParams.get("mode"));
+  const [mode, setMode] = useState<AuthMode>(requestedMode ?? "signin");
+  const [identifier, setIdentifier] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (requestedMode) {
+      setMode(requestedMode);
+    }
+  }, [requestedMode]);
+
+  const isSignedInState = isAuthenticated && !requestedMode;
+
+  function closeAuth(): void {
+    navigate(returnTo, { replace: true });
+  }
+
+  async function finishPasskeySignIn(nextIdentifier: string): Promise<void> {
+    const authenticationSession = await api.startAuthentication({
+      handle: nextIdentifier,
+    });
+    const options = await api.getPasskeyAuthenticationOptions(authenticationSession.id);
+    const credential = await createBrowserAuthenticationCredential(options);
+
+    await api.authenticatePasskey({
+      authenticationSessionId: authenticationSession.id,
+      credential,
+    });
+
+    await onAuthStateChange();
+    navigate(returnTo, { replace: true });
+  }
+
+  async function handleSignIn(): Promise<void> {
+    const nextIdentifier = normalizeIdentifier(identifier);
+
+    if (!nextIdentifier) {
+      setError("Enter your email to continue.");
+      return;
+    }
+
+    setBusy(true);
+    setError(null);
+    setStatusMessage(null);
+
+    try {
+      await finishPasskeySignIn(nextIdentifier);
+    } catch (cause) {
+      setError(readErrorMessage(cause));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleSignUp(): Promise<void> {
+    const nextIdentifier = normalizeIdentifier(identifier);
+
+    if (!isValidEmail(nextIdentifier)) {
+      setError("Enter a valid email to create an account.");
+      return;
+    }
+
+    setBusy(true);
+    setError(null);
+    setStatusMessage("Saving your passkey.");
+
+    try {
+      const displayName = deriveDisplayNameFromIdentifier(nextIdentifier);
+      // TODO: split private sign-in email from public account handle in the backend contract.
+      const registrationSession = await api.startRegistration({
+        handle: nextIdentifier,
+        displayName,
+      });
+      const options = await api.getPasskeyRegistrationOptions(registrationSession.id);
+      const credential = await createBrowserCredential(options);
+
+      await api.registerPasskey({
+        registrationSessionId: registrationSession.id,
+        credential,
+        passkeyLabel: `${displayName} passkey`,
+      });
+
+      setStatusMessage("Passkey saved. Finishing sign in.");
+      await finishPasskeySignIn(nextIdentifier);
+    } catch (cause) {
+      setError(readErrorMessage(cause));
+      setStatusMessage(null);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const content = (
+    <div className="auth-entry-shell">
+      <div className="auth-entry-copy">
+        <p className="auth-entry-eyebrow">Account access</p>
+        <h1>Sign in with email and a passkey.</h1>
+        <p className="auth-entry-lead">
+          Use the email tied to your passkey. We only unlock posting, replies,
+          and account tools after you authenticate.
+        </p>
+        <div className="auth-entry-pills" aria-hidden="true">
+          <span>email first</span>
+          <span>passkey only</span>
+          <span>no provider clutter</span>
+        </div>
+      </div>
+
+      <section className="auth-entry-card">
+        <div className="auth-entry-card__topline">
+          <span className="auth-entry-badge">
+            {mode === "signin" ? "Sign in" : "Create account"}
+          </span>
+          {presentation === "modal" ? (
+            <button
+              type="button"
+              className="auth-entry-close"
+              onClick={closeAuth}
+              aria-label="Close sign in dialog"
+            >
+              close
+            </button>
+          ) : (
+            <Link className="auth-entry-back" to={returnTo}>
+              back
+            </Link>
+          )}
+        </div>
+
+        {isSignedInState ? (
+          <div className="auth-entry-state">
+            <h2>You are already signed in.</h2>
+            <p>
+              {sessionName ? `You are signed in as ${sessionName}.` : "Your session is active."}
+            </p>
+            <div className="auth-entry-actions">
+              <Link className="button" to="/settings">
+                Open settings
+              </Link>
+              <Link className="button button--ghost" to="/my-agents">
+                My Agents
+              </Link>
+              <Link
+                className="button button--ghost"
+                to={buildAuthPath(returnTo, { mode: "signup" })}
+              >
+                Add a passkey
+              </Link>
+            </div>
+          </div>
+        ) : (
+          <>
+            <div className="auth-entry-tabs" role="tablist" aria-label="Authentication mode">
+              <button
+                type="button"
+                role="tab"
+                aria-selected={mode === "signin"}
+                className={mode === "signin" ? "is-active" : undefined}
+                onClick={() => {
+                  setMode("signin");
+                  setError(null);
+                  setStatusMessage(null);
+                }}
+              >
+                Sign in
+              </button>
+              <button
+                type="button"
+                role="tab"
+                aria-selected={mode === "signup"}
+                className={mode === "signup" ? "is-active" : undefined}
+                onClick={() => {
+                  setMode("signup");
+                  setError(null);
+                  setStatusMessage(null);
+                }}
+              >
+                Sign up
+              </button>
+            </div>
+
+            {error ? <p className="auth-entry-error">{error}</p> : null}
+            {statusMessage ? <p className="auth-entry-status">{statusMessage}</p> : null}
+
+            <div className="auth-entry-form">
+              <label className="field" htmlFor="auth-identifier">
+                <span>Email</span>
+                <input
+                  id="auth-identifier"
+                  type="text"
+                  autoComplete={mode === "signin" ? "username webauthn" : "email"}
+                  inputMode="email"
+                  value={identifier}
+                  onChange={(event) => setIdentifier(event.target.value)}
+                  placeholder="eric@example.com"
+                  disabled={busy}
+                />
+              </label>
+
+              {mode === "signup" ? (
+                <p className="auth-entry-note">
+                  Alpha note: this email is also your current account identifier
+                  until profile handles split from sign-in email.
+                </p>
+              ) : (
+                <p className="auth-entry-note">
+                  Legacy passkey accounts can still use their existing handle.
+                </p>
+              )}
+
+              <div className="auth-entry-actions">
+                <button
+                  type="button"
+                  className="button"
+                  onClick={() => void (mode === "signin" ? handleSignIn() : handleSignUp())}
+                  disabled={busy}
+                >
+                  {busy
+                    ? mode === "signin"
+                      ? "Waiting for passkey..."
+                      : "Preparing passkey..."
+                    : mode === "signin"
+                      ? "Continue with passkey"
+                      : "Create passkey"}
+                </button>
+                <Link
+                  className="button button--ghost"
+                  to={buildPairingAuthPath(returnTo)}
+                >
+                  Pair an agent instead
+                </Link>
+              </div>
+            </div>
+          </>
+        )}
+      </section>
+    </div>
+  );
+
+  if (presentation === "modal") {
+    return (
+      <ModalFrame onClose={closeAuth} title="Sign in">
+        {content}
+      </ModalFrame>
+    );
+  }
+
+  return <PageFrame>{content}</PageFrame>;
+}
+
+interface PairingAuthPageProps {
+  api: ApiClient;
+  presentation: "page" | "modal";
+  registrationParam: string;
+  returnTo: string;
+}
+
+function PairingAuthPage({
+  api,
+  presentation,
+  registrationParam,
+  returnTo,
+}: PairingAuthPageProps) {
+  const navigate = useNavigate();
   const [registrationSession, setRegistrationSession] =
     useState<RegistrationSession | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -45,8 +364,8 @@ export function AuthPage({ api, onAuthStateChange }: AuthPageProps) {
   const [loadingSession, setLoadingSession] = useState(false);
   const [creatingPasskey, setCreatingPasskey] = useState(false);
   const [redeeming, setRedeeming] = useState(false);
-  const [signingIn, setSigningIn] = useState(false);
-  const [signInHandle, setSignInHandle] = useState("");
+  const [identifier, setIdentifier] = useState("");
+  const [displayName, setDisplayName] = useState("");
   const [passkeyLabel, setPasskeyLabel] = useState("This device passkey");
   const [copiedField, setCopiedField] = useState<string | null>(null);
 
@@ -55,28 +374,15 @@ export function AuthPage({ api, onAuthStateChange }: AuthPageProps) {
       return;
     }
 
-    setSelectedPath("register");
-
     void (async () => {
       setLoadingSession(true);
       setError(null);
+
       try {
         try {
-          setRegistrationSession(
-            await api.getRegistrationSession(registrationParam),
-          );
-        } catch (cause) {
-          if (
-            cause instanceof ApiClientError &&
-            cause.code === "registration_session_not_found"
-          ) {
-            setRegistrationSession(
-              await api.resolveRegistrationSession(registrationParam),
-            );
-            return;
-          }
-
-          throw cause;
+          setRegistrationSession(await api.getRegistrationSession(registrationParam));
+        } catch {
+          setRegistrationSession(await api.resolveRegistrationSession(registrationParam));
         }
       } catch (cause) {
         setError(readErrorMessage(cause));
@@ -124,20 +430,24 @@ export function AuthPage({ api, onAuthStateChange }: AuthPageProps) {
     registrationSession?.handle ??
     "your account";
 
-  async function handleStartRegistration(formData: FormData): Promise<void> {
+  async function handleStartRegistration(): Promise<void> {
+    const nextIdentifier = normalizeIdentifier(identifier);
+
+    if (!nextIdentifier) {
+      setError("Enter the account email or handle for this pairing.");
+      return;
+    }
+
     setStarting(true);
     setError(null);
 
     try {
       const session = await api.startRegistration({
-        handle: String(formData.get("handle") ?? "").trim(),
-        displayName: trimOptionalField(formData.get("displayName")),
+        handle: nextIdentifier,
+        displayName: displayName.trim() || deriveDisplayNameFromIdentifier(nextIdentifier),
       });
-      setSelectedPath("register");
       setRegistrationSession(session);
-      setPasskeyLabel(
-        `${session.displayName ?? session.handle} device passkey`,
-      );
+      setPasskeyLabel(`${session.displayName ?? session.handle} device passkey`);
     } catch (cause) {
       setError(readErrorMessage(cause));
     } finally {
@@ -190,38 +500,6 @@ export function AuthPage({ api, onAuthStateChange }: AuthPageProps) {
     }
   }
 
-  async function handleSignIn(): Promise<void> {
-    const trimmedHandle = signInHandle.trim();
-    if (!trimmedHandle) {
-      setError("Handle is required for sign-in.");
-      return;
-    }
-
-    setSigningIn(true);
-    setError(null);
-
-    try {
-      const authenticationSession = await api.startAuthentication({
-        handle: trimmedHandle,
-      });
-      const options = await api.getPasskeyAuthenticationOptions(
-        authenticationSession.id,
-      );
-      const credential = await createBrowserAuthenticationCredential(options);
-
-      await api.authenticatePasskey({
-        authenticationSessionId: authenticationSession.id,
-        credential,
-      });
-      await onAuthStateChange?.();
-      navigate("/");
-    } catch (cause) {
-      setError(readErrorMessage(cause));
-    } finally {
-      setSigningIn(false);
-    }
-  }
-
   async function handleRedeem(formData: FormData): Promise<void> {
     if (!registrationSession) {
       return;
@@ -254,7 +532,6 @@ export function AuthPage({ api, onAuthStateChange }: AuthPageProps) {
     setPasskeyLabel("This device passkey");
     setCopiedField(null);
     setError(null);
-    setSelectedPath("register");
   }
 
   async function copyValue(value: string, field: string): Promise<void> {
@@ -271,12 +548,12 @@ export function AuthPage({ api, onAuthStateChange }: AuthPageProps) {
   }
 
   const sessionStatusRow = registrationSession ? (
-    <div className="auth-stage-topline__meta" aria-label="Handoff status">
+    <div className="auth-stage-topline__meta" aria-label="Pairing status">
       <span className="auth-terminal-badge">
-        handle: {registrationSession.handle}
+        account: {registrationSession.handle}
       </span>
       <span className="auth-terminal-status-chip">
-        registration: {formatStatus(registrationSession.status)}
+        passkey: {formatStatus(registrationSession.status)}
       </span>
       <span className="auth-terminal-status-chip">
         pairing: {formatStatus(registrationSession.pairing.status)}
@@ -284,28 +561,32 @@ export function AuthPage({ api, onAuthStateChange }: AuthPageProps) {
     </div>
   ) : null;
 
-  return (
+  const content = (
     <div className="terminal-page auth-terminal-page">
-      <header className="terminal-nav auth-terminal-nav" aria-label="Auth navigation">
-        <Link className="terminal-logo" to="/">
+      <header className="terminal-nav auth-terminal-nav" aria-label="Pairing navigation">
+        <Link className="terminal-logo" to={returnTo}>
           The Agent Forum<span>_</span>
         </Link>
         <div className="auth-terminal-nav__meta">
-          <span className="auth-terminal-badge">passkey-first access</span>
-          <Link className="terminal-link-button auth-terminal-nav__back" to="/">
-            back to forum
-          </Link>
+          <span className="auth-terminal-badge">agent pairing</span>
+          <button
+            type="button"
+            className="terminal-link-button auth-terminal-nav__back"
+            onClick={() => navigate(returnTo, { replace: true })}
+          >
+            back
+          </button>
         </div>
       </header>
 
       <main className="terminal-main auth-terminal-main">
         <section className="auth-terminal-hero">
           <div className="auth-terminal-hero__copy">
-            <p className="terminal-eyebrow">identity / graph live</p>
-            <h1>sign in fast. pair clean.</h1>
+            <p className="terminal-eyebrow">passkey + token handoff</p>
+            <h1>pair an agent without losing account control.</h1>
             <p className="terminal-lead">
-              One passkey for the forum. One short handoff for agents, CLI
-              clients, and tools.
+              Create or resume a pairing handoff, save a passkey in the browser,
+              then issue a scoped token for the agent or device.
             </p>
           </div>
 
@@ -327,287 +608,112 @@ export function AuthPage({ api, onAuthStateChange }: AuthPageProps) {
 
         {error ? <p className="auth-terminal-alert">{error}</p> : null}
 
-        {selectedPath === "choose" && !registrationSession ? (
-          <section className="auth-choice-grid" aria-label="Authentication paths">
-            <button
-              type="button"
-              className="auth-choice-card"
-              onClick={() => {
-                setError(null);
-                setSelectedPath("sign-in");
-              }}
-            >
-              <span className="auth-choice-card__kicker">01</span>
-              <strong>use existing passkey</strong>
-              <p>Enter your handle and approve the browser prompt.</p>
-            </button>
-
-            <button
-              type="button"
-              className="auth-choice-card"
-              onClick={() => {
-                setError(null);
-                setSelectedPath("register");
-              }}
-            >
-              <span className="auth-choice-card__kicker">02</span>
-              <strong>start a handoff</strong>
-              <p>Create a passkey here, then pair a CLI or agent.</p>
-            </button>
-          </section>
-        ) : null}
-
-        {selectedPath === "sign-in" && !registrationSession ? (
-          <section className="auth-stage-shell">
-            <div className="auth-stage-topline">
+        <section className="auth-stage-shell">
+          <div className="auth-stage-topline">
+            {registrationSession ? (
+              sessionStatusRow
+            ) : (
               <div className="auth-stage-topline__meta">
-                <span className="auth-terminal-badge">flow: sign in</span>
+                <span className="auth-terminal-badge">pairing flow</span>
               </div>
-              <button
-                type="button"
-                className="terminal-link-button"
-                onClick={() => {
-                  setError(null);
-                  setSelectedPath("choose");
-                }}
-              >
-                change path
-              </button>
-            </div>
+            )}
+          </div>
 
-            <article className="auth-stage-card">
-              <div className="auth-stage-card__header">
-                <h2>sign in with a passkey</h2>
-                <p>Short handle in. Browser prompt. Back to the forum.</p>
-              </div>
+          <ol className="auth-stage-progress" aria-label="Pairing progress">
+            {registrationSteps.map((step, index) => {
+              const stepNumber = index + 1;
+              const state =
+                currentRegistrationStep > stepNumber
+                  ? "is-done"
+                  : currentRegistrationStep === stepNumber
+                    ? "is-current"
+                    : undefined;
 
-              <form
-                className="auth-terminal-form"
-                onSubmit={(event) => {
-                  event.preventDefault();
-                  void handleSignIn();
-                }}
-              >
-                <label className="auth-terminal-field">
-                  <span>Handle</span>
-                  <input
-                    value={signInHandle}
-                    onChange={(event) => setSignInHandle(event.target.value)}
-                    placeholder="felix796"
-                    autoComplete="username webauthn"
-                    disabled={signingIn}
-                  />
-                </label>
-
-                <div className="auth-stage-card__actions">
-                  <button
-                    type="submit"
-                    className="terminal-button terminal-button--full"
-                    disabled={signingIn}
-                  >
-                    {signingIn ? "waiting for passkey..." : "sign in"}
-                  </button>
-                </div>
-              </form>
-            </article>
-          </section>
-        ) : null}
-
-        {selectedPath === "register" ? (
-          <section className="auth-stage-shell">
-            <div className="auth-stage-topline">
-              {registrationSession ? (
-                sessionStatusRow
-              ) : (
-                <div className="auth-stage-topline__meta">
-                  <span className="auth-terminal-badge">flow: new handoff</span>
-                </div>
-              )}
-              {!registrationSession && !registrationParam ? (
-                <button
-                  type="button"
-                  className="terminal-link-button"
-                  onClick={() => {
-                    setError(null);
-                    setSelectedPath("choose");
-                  }}
+              return (
+                <li
+                  key={step}
+                  className={state}
+                  aria-current={
+                    currentRegistrationStep === stepNumber ? "step" : undefined
+                  }
                 >
-                  change path
-                </button>
-              ) : null}
-            </div>
+                  <span>step {stepNumber}</span>
+                  {step}
+                </li>
+              );
+            })}
+          </ol>
 
-            <ol className="auth-stage-progress" aria-label="Registration progress">
-              {registrationSteps.map((step, index) => {
-                const stepNumber = index + 1;
-                const state =
-                  currentRegistrationStep > stepNumber
-                    ? "is-done"
-                    : currentRegistrationStep === stepNumber
-                      ? "is-current"
-                      : undefined;
-
-                return (
-                  <li
-                    key={step}
-                    className={state}
-                    aria-current={
-                      currentRegistrationStep === stepNumber ? "step" : undefined
-                    }
-                  >
-                    <span>step {stepNumber}</span>
-                    {step}
-                  </li>
-                );
-              })}
-            </ol>
-
-            <article className="auth-stage-card">
-              {loadingSession && !registrationSession ? (
+          <article className="auth-stage-card">
+            {loadingSession && !registrationSession ? (
+              <div className="auth-stage-card__header">
+                <h2>loading handoff</h2>
+                <p>Pulling the latest registration state now.</p>
+              </div>
+            ) : (
+              <>
                 <div className="auth-stage-card__header">
-                  <h2>loading handoff</h2>
-                  <p>Pulling the latest registration state now.</p>
+                  <h2>{registrationStageCopy.title}</h2>
+                  <p>{registrationStageCopy.description}</p>
                 </div>
-              ) : (
-                <>
-                  <div className="auth-stage-card__header">
-                    <h2>{registrationStageCopy.title}</h2>
-                    <p>{registrationStageCopy.description}</p>
+
+                {registrationStage === "start" ? (
+                  <div className="auth-terminal-form">
+                    <label className="auth-terminal-field">
+                      <span>Account email or handle</span>
+                      <input
+                        value={identifier}
+                        onChange={(event) => setIdentifier(event.target.value)}
+                        placeholder="eric@example.com"
+                        disabled={starting}
+                      />
+                    </label>
+                    <label className="auth-terminal-field">
+                      <span>Display name</span>
+                      <input
+                        value={displayName}
+                        onChange={(event) => setDisplayName(event.target.value)}
+                        placeholder="Eric"
+                        disabled={starting}
+                      />
+                    </label>
+
+                    <p className="auth-terminal-note">
+                      Already started from a CLI? Open the verification link here
+                      and the handoff will resume automatically.
+                    </p>
+
+                    <div className="auth-stage-card__actions">
+                      <button
+                        type="button"
+                        className="terminal-button"
+                        disabled={starting}
+                        onClick={() => void handleStartRegistration()}
+                      >
+                        {starting ? "creating handoff..." : "start handoff"}
+                      </button>
+                    </div>
                   </div>
+                ) : null}
 
-                  {registrationStage === "start" ? (
-                    <form
-                      className="auth-terminal-form"
-                      onSubmit={(event) => {
-                        event.preventDefault();
-                        void handleStartRegistration(
-                          new FormData(event.currentTarget),
-                        );
-                      }}
-                    >
-                      <div className="auth-terminal-field-row">
-                        <label className="auth-terminal-field">
-                          <span>Handle</span>
-                          <input name="handle" placeholder="felix796" />
-                        </label>
-                        <label className="auth-terminal-field">
-                          <span>Display name</span>
-                          <input name="displayName" placeholder="Felix" />
-                        </label>
+                {registrationStage === "passkey" && registrationSession ? (
+                  <>
+                    <dl className="auth-terminal-meta">
+                      <div>
+                        <dt>Account</dt>
+                        <dd>{actorName}</dd>
                       </div>
-
-                      <p className="auth-terminal-note">
-                        Already started from a CLI? Open its verification link
-                        here and the handoff will resume automatically.
-                      </p>
-
-                      <div className="auth-stage-card__actions">
-                        <button
-                          type="submit"
-                          className="terminal-button"
-                          disabled={starting}
-                        >
-                          {starting ? "creating handoff..." : "start handoff"}
-                        </button>
+                      <div>
+                        <dt>Pairing code</dt>
+                        <dd>{registrationSession.pairing.code}</dd>
                       </div>
-                    </form>
-                  ) : null}
+                    </dl>
 
-                  {registrationStage === "passkey" && registrationSession ? (
-                    <>
-                      <dl className="auth-terminal-meta">
-                        <div>
-                          <dt>Account</dt>
-                          <dd>{actorName}</dd>
-                        </div>
-                        <div>
-                          <dt>Pairing code</dt>
-                          <dd>{registrationSession.pairing.code}</dd>
-                        </div>
-                      </dl>
-
-                      {verificationUrl ? (
-                        <div className="auth-terminal-snippet">
-                          <span>Verification link</span>
-                          <code className="auth-terminal-code">
-                            {verificationUrl}
-                          </code>
-                          <div className="auth-stage-card__actions">
-                            <button
-                              type="button"
-                              className="terminal-link-button"
-                              onClick={() =>
-                                void copyValue(
-                                  verificationUrl,
-                                  "verification-url",
-                                )
-                              }
-                            >
-                              {copiedField === "verification-url"
-                                ? "copied"
-                                : "copy link"}
-                            </button>
-                          </div>
-                        </div>
-                      ) : null}
-
-                      <div className="auth-terminal-form">
-                        <label className="auth-terminal-field">
-                          <span>Passkey label</span>
-                          <input
-                            value={passkeyLabel}
-                            onChange={(event) =>
-                              setPasskeyLabel(event.target.value)
-                            }
-                            placeholder="Felix MacBook passkey"
-                          />
-                        </label>
-
-                        <div className="auth-stage-card__actions">
-                          <button
-                            type="button"
-                            className="terminal-button"
-                            disabled={!canCreatePasskey}
-                            onClick={() => void handleCreatePasskey()}
-                          >
-                            {creatingPasskey
-                              ? "saving passkey..."
-                              : "save passkey"}
-                          </button>
-                        </div>
-                      </div>
-                    </>
-                  ) : null}
-
-                  {registrationStage === "waiting" && registrationSession ? (
-                    <>
+                    {verificationUrl ? (
                       <div className="auth-terminal-snippet">
-                        <span>Current state</span>
+                        <span>Verification link</span>
                         <code className="auth-terminal-code">
-                          passkey verified
-                          {"\n"}
-                          pairing unlock pending
-                        </code>
-                      </div>
-
-                      <div className="auth-stage-card__actions">
-                        <button
-                          type="button"
-                          className="terminal-link-button"
-                          onClick={() => void handleRefreshStatus()}
-                        >
-                          refresh status
-                        </button>
-                      </div>
-                    </>
-                  ) : null}
-
-                  {registrationStage === "pair" && registrationSession ? (
-                    <>
-                      <div className="auth-terminal-snippet">
-                        <span>Pairing code</span>
-                        <code className="auth-terminal-code">
-                          {registrationSession.pairing.code}
+                          {verificationUrl}
                         </code>
                         <div className="auth-stage-card__actions">
                           <button
@@ -615,108 +721,267 @@ export function AuthPage({ api, onAuthStateChange }: AuthPageProps) {
                             className="terminal-link-button"
                             onClick={() =>
                               void copyValue(
-                                registrationSession.pairing.code,
-                                "pairing-code",
+                                verificationUrl,
+                                "verification-url",
                               )
                             }
                           >
-                            {copiedField === "pairing-code"
+                            {copiedField === "verification-url"
                               ? "copied"
-                              : "copy code"}
+                              : "copy link"}
                           </button>
                         </div>
                       </div>
+                    ) : null}
 
-                      <form
-                        className="auth-terminal-form"
-                        onSubmit={(event) => {
-                          event.preventDefault();
-                          void handleRedeem(new FormData(event.currentTarget));
-                        }}
-                      >
-                        <label className="auth-terminal-field">
-                          <span>Pairing code</span>
-                          <input
-                            name="pairingCode"
-                            defaultValue={registrationSession.pairing.code}
-                          />
-                        </label>
-                        <label className="auth-terminal-field">
-                          <span>Bot or device label</span>
-                          <input
-                            name="deviceLabel"
-                            placeholder="pixel-cli"
-                            defaultValue={registrationSession.pairing.deviceLabel}
-                          />
-                        </label>
-
-                        <div className="auth-stage-card__actions">
-                          <button
-                            type="submit"
-                            className="terminal-button"
-                            disabled={!canRedeemPairing}
-                          >
-                            {redeeming ? "redeeming..." : "redeem pairing"}
-                          </button>
-                        </div>
-                      </form>
-                    </>
-                  ) : null}
-
-                  {registrationStage === "paired" && registrationSession ? (
-                    <>
-                      {registrationSession.pairing.token ? (
-                        <div className="auth-terminal-snippet">
-                          <span>Issued token</span>
-                          <code className="auth-terminal-code">
-                            {registrationSession.pairing.token}
-                          </code>
-                          <div className="auth-stage-card__actions">
-                            <button
-                              type="button"
-                              className="terminal-link-button"
-                              onClick={() =>
-                                void copyValue(
-                                  registrationSession.pairing.token ?? "",
-                                  "issued-token",
-                                )
-                              }
-                            >
-                              {copiedField === "issued-token"
-                                ? "copied"
-                                : "copy token"}
-                            </button>
-                          </div>
-                        </div>
-                      ) : null}
+                    <div className="auth-terminal-form">
+                      <label className="auth-terminal-field">
+                        <span>Passkey label</span>
+                        <input
+                          value={passkeyLabel}
+                          onChange={(event) => setPasskeyLabel(event.target.value)}
+                          placeholder="Eric laptop passkey"
+                        />
+                      </label>
 
                       <div className="auth-stage-card__actions">
-                        <Link className="terminal-button" to="/">
-                          return to forum
-                        </Link>
+                        <button
+                          type="button"
+                          className="terminal-button"
+                          disabled={!canCreatePasskey}
+                          onClick={() => void handleCreatePasskey()}
+                        >
+                          {creatingPasskey
+                            ? "saving passkey..."
+                            : "save passkey"}
+                        </button>
                       </div>
-                    </>
-                  ) : null}
+                    </div>
+                  </>
+                ) : null}
 
-                  {registrationStage === "expired" ? (
+                {registrationStage === "waiting" && registrationSession ? (
+                  <>
+                    <div className="auth-terminal-snippet">
+                      <span>Current state</span>
+                      <code className="auth-terminal-code">
+                        passkey verified
+                        {"\n"}
+                        pairing unlock pending
+                      </code>
+                    </div>
+
+                    <div className="auth-stage-card__actions">
+                      <button
+                        type="button"
+                        className="terminal-link-button"
+                        onClick={() => void handleRefreshStatus()}
+                      >
+                        refresh status
+                      </button>
+                    </div>
+                  </>
+                ) : null}
+
+                {registrationStage === "pair" && registrationSession ? (
+                  <>
+                    <div className="auth-terminal-snippet">
+                      <span>Pairing code</span>
+                      <code className="auth-terminal-code">
+                        {registrationSession.pairing.code}
+                      </code>
+                      <div className="auth-stage-card__actions">
+                        <button
+                          type="button"
+                          className="terminal-link-button"
+                          onClick={() =>
+                            void copyValue(
+                              registrationSession.pairing.code,
+                              "pairing-code",
+                            )
+                          }
+                        >
+                          {copiedField === "pairing-code"
+                            ? "copied"
+                            : "copy code"}
+                        </button>
+                      </div>
+                    </div>
+
+                    <form
+                      className="auth-terminal-form"
+                      onSubmit={(event) => {
+                        event.preventDefault();
+                        void handleRedeem(new FormData(event.currentTarget));
+                      }}
+                    >
+                      <label className="auth-terminal-field">
+                        <span>Pairing code</span>
+                        <input
+                          name="pairingCode"
+                          defaultValue={registrationSession.pairing.code}
+                        />
+                      </label>
+                      <label className="auth-terminal-field">
+                        <span>Bot or device label</span>
+                        <input
+                          name="deviceLabel"
+                          placeholder="pixel-cli"
+                          defaultValue={registrationSession.pairing.deviceLabel}
+                        />
+                      </label>
+
+                      <div className="auth-stage-card__actions">
+                        <button
+                          type="submit"
+                          className="terminal-button"
+                          disabled={!canRedeemPairing}
+                        >
+                          {redeeming ? "redeeming..." : "redeem pairing"}
+                        </button>
+                      </div>
+                    </form>
+                  </>
+                ) : null}
+
+                {registrationStage === "paired" && registrationSession ? (
+                  <>
+                    {registrationSession.pairing.token ? (
+                      <div className="auth-terminal-snippet">
+                        <span>Issued token</span>
+                        <code className="auth-terminal-code">
+                          {registrationSession.pairing.token}
+                        </code>
+                        <div className="auth-stage-card__actions">
+                          <button
+                            type="button"
+                            className="terminal-link-button"
+                            onClick={() =>
+                              void copyValue(
+                                registrationSession.pairing.token ?? "",
+                                "issued-token",
+                              )
+                            }
+                          >
+                            {copiedField === "issued-token"
+                              ? "copied"
+                              : "copy token"}
+                          </button>
+                        </div>
+                      </div>
+                    ) : null}
+
                     <div className="auth-stage-card__actions">
                       <button
                         type="button"
                         className="terminal-button"
-                        onClick={resetRegistrationFlow}
+                        onClick={() => navigate(returnTo, { replace: true })}
                       >
-                        start a new handoff
+                        return
                       </button>
                     </div>
-                  ) : null}
-                </>
-              )}
-            </article>
-          </section>
-        ) : null}
+                  </>
+                ) : null}
+
+                {registrationStage === "expired" ? (
+                  <div className="auth-stage-card__actions">
+                    <button
+                      type="button"
+                      className="terminal-button"
+                      onClick={resetRegistrationFlow}
+                    >
+                      start a new handoff
+                    </button>
+                  </div>
+                ) : null}
+              </>
+            )}
+          </article>
+        </section>
       </main>
     </div>
   );
+
+  if (presentation === "modal") {
+    return (
+      <ModalFrame
+        onClose={() => navigate(returnTo, { replace: true })}
+        title="Pair an agent"
+      >
+        {content}
+      </ModalFrame>
+    );
+  }
+
+  return content;
+}
+
+function ModalFrame({
+  children,
+  onClose,
+  title,
+}: {
+  children: ReactNode;
+  onClose: () => void;
+  title: string;
+}) {
+  useEffect(() => {
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    function handleKeyDown(event: KeyboardEvent): void {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [onClose]);
+
+  return (
+    <div className="auth-modal" role="presentation">
+      <div className="auth-modal__backdrop" onClick={onClose} />
+      <div
+        className="auth-modal__surface"
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function PageFrame({ children }: { children: ReactNode }) {
+  return (
+    <div className="terminal-page auth-entry-page">
+      <main className="terminal-main">
+        {children}
+      </main>
+    </div>
+  );
+}
+
+function readRequestedMode(value: string | null): AuthMode | null {
+  if (value === "signin" || value === "signup") {
+    return value;
+  }
+
+  return null;
+}
+
+function normalizeIdentifier(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function isValidEmail(value: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
 }
 
 type BrowserCredentialWithAttestation = {
@@ -947,9 +1212,9 @@ function getRegistrationStageCopy(
   switch (stage) {
     case "start":
       return {
-        title: "start a handoff",
+        title: "start a pairing handoff",
         description:
-          "Create the browser handoff first. The passkey and agent pairing happen after that.",
+          "Start from the browser, save a passkey, then redeem a short pairing code for the agent side.",
       };
     case "passkey":
       return {
@@ -982,7 +1247,7 @@ function getRegistrationStageCopy(
       };
     default:
       return {
-        title: "start a handoff",
+        title: "start a pairing handoff",
         description: "Create a browser handoff to begin.",
       };
   }
@@ -1029,27 +1294,4 @@ function toBase64Url(value: Uint8Array): string {
     .replace(/=+$/g, "")
     .replace(/\+/g, "-")
     .replace(/\//g, "_");
-}
-
-function trimOptionalField(
-  value: FormDataEntryValue | null,
-): string | undefined {
-  if (typeof value !== "string") {
-    return undefined;
-  }
-
-  const trimmed = value.trim();
-  return trimmed === "" ? undefined : trimmed;
-}
-
-function readErrorMessage(cause: unknown): string {
-  if (cause instanceof ApiClientError) {
-    return cause.message;
-  }
-
-  if (cause instanceof Error) {
-    return cause.message;
-  }
-
-  return "Something went wrong.";
 }

--- a/apps/web/src/pages/HomePage.tsx
+++ b/apps/web/src/pages/HomePage.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState, type FormEvent } from "react";
 import { Link, useNavigate } from "react-router-dom";
+import { useAuth } from "../auth/AuthContext";
+import { AuthRequiredPanel } from "../components/AuthRequiredPanel";
 import type { ApiClient } from "../lib/api";
 import type { Question, QuestionStatus, ThreadSearchResult } from "../types";
 import { CreateQuestionForm, type CreateQuestionFormValues } from "../components/CreateQuestionForm";
@@ -14,7 +16,7 @@ import {
 } from "../components/HomeSections";
 import { MarkdownContent } from "../components/MarkdownContent";
 import { agentCapabilityItems, buildTopicChips, communitySignals } from "../lib/homeContent";
-import { formatDate, readErrorMessage } from "../lib/ui";
+import { describeActor, formatDate, readErrorMessage } from "../lib/ui";
 
 interface HomePageProps {
   api: ApiClient;
@@ -26,6 +28,7 @@ const INITIAL_VISIBLE_QUESTIONS = 6;
 const LOAD_MORE_STEP = 6;
 
 export function HomePage({ api }: HomePageProps) {
+  const auth = useAuth();
   const navigate = useNavigate();
   const [questions, setQuestions] = useState<Question[]>([]);
   const [statusFilter, setStatusFilter] = useState<QuestionStatusFilter>("all");
@@ -111,18 +114,17 @@ export function HomePage({ api }: HomePageProps) {
   }
 
   async function handleCreateQuestion(values: CreateQuestionFormValues): Promise<void> {
+    if (!auth.session) {
+      return;
+    }
+
     setError(null);
 
     try {
       const createdQuestion = await api.createQuestion({
         title: values.title,
         body: values.body,
-        author: {
-          id: values.handle,
-          kind: "human",
-          handle: values.handle,
-          displayName: values.handle,
-        },
+        author: auth.session.actor,
       });
 
       await refreshQuestions();
@@ -155,7 +157,19 @@ export function HomePage({ api }: HomePageProps) {
           title="Seed the next thread your agent should be able to reuse"
           description="If you want a stronger activation loop, publish the kind of question you would actually want an agent to inherit: specific problem, real constraints, and a title that still makes sense later."
         >
-          <CreateQuestionForm onSubmit={handleCreateQuestion} disabled={loading} />
+          {auth.ready && auth.session ? (
+            <CreateQuestionForm
+              onSubmit={handleCreateQuestion}
+              disabled={loading}
+              authorLabel={describeActor(auth.session.actor)}
+            />
+          ) : (
+            <AuthRequiredPanel
+              title="Sign in to start a thread"
+              description="New threads are locked until you authenticate, so we keep the composer closed for anonymous visitors."
+              loading={!auth.ready}
+            />
+          )}
         </Section>
 
         <Section

--- a/apps/web/src/pages/MyAgentsPage.tsx
+++ b/apps/web/src/pages/MyAgentsPage.tsx
@@ -1,0 +1,129 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { useAuth } from "../auth/AuthContext";
+import { AppShell, Section } from "../components/AppShell";
+import { AuthRequiredPanel } from "../components/AuthRequiredPanel";
+import type { ApiClient } from "../lib/api";
+import { buildPairingAuthPath } from "../lib/auth-routing";
+import { formatDate, readErrorMessage } from "../lib/ui";
+import type { AuthDevice } from "../types";
+
+interface MyAgentsPageProps {
+  api: ApiClient;
+}
+
+export function MyAgentsPage({ api }: MyAgentsPageProps) {
+  const auth = useAuth();
+  const [devices, setDevices] = useState<AuthDevice[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!auth.session) {
+      setDevices([]);
+      return;
+    }
+
+    void refreshDevices();
+  }, [auth.session]);
+
+  async function refreshDevices(): Promise<void> {
+    if (!auth.session) {
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      setDevices(await api.listDevices());
+    } catch (cause) {
+      setError(readErrorMessage(cause));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <AppShell cta={<Link className="button button--ghost" to="/settings">Settings</Link>}>
+      <Section
+        eyebrow="My Agents"
+        title="Paired agents and devices"
+        description="Keep track of the devices and agents that can act on your account with a redeemed pairing token."
+        actions={
+          auth.session ? (
+            <div className="settings-actions">
+              <Link className="button" to={buildPairingAuthPath("/my-agents")}>
+                Pair an agent
+              </Link>
+              <button
+                type="button"
+                className="button button--ghost"
+                onClick={() => void refreshDevices()}
+                disabled={loading}
+              >
+                {loading ? "Refreshing..." : "Refresh"}
+              </button>
+            </div>
+          ) : undefined
+        }
+      >
+        {!auth.ready ? <p className="muted">Checking your session...</p> : null}
+        {error ? <p className="error">{error}</p> : null}
+
+        {auth.ready && !auth.session ? (
+          <AuthRequiredPanel
+            title="Sign in to view your agents"
+            description="Pairing tokens and device history only unlock after you authenticate."
+          />
+        ) : null}
+
+        {auth.session ? (
+          <>
+            {loading && devices.length === 0 ? (
+              <p className="muted">Loading paired agents...</p>
+            ) : null}
+
+            {devices.length === 0 && !loading ? (
+              <div className="card stack settings-empty-state">
+                <h3>No paired agents yet</h3>
+                <p className="muted">
+                  Start a pairing flow to issue a token for a CLI session,
+                  agent runtime, or another device.
+                </p>
+                <div className="row wrap-gap">
+                  <Link className="button" to={buildPairingAuthPath("/my-agents")}>
+                    Pair an agent
+                  </Link>
+                  <Link className="button button--ghost" to="/settings">
+                    Manage passkeys
+                  </Link>
+                </div>
+              </div>
+            ) : null}
+
+            {devices.length > 0 ? (
+              <ul className="settings-list">
+                {devices.map((device) => (
+                  <li key={device.id} className="settings-list__item">
+                    <div>
+                      <strong>{device.deviceLabel}</strong>
+                      <p className="muted settings-list__meta">
+                        Status: {device.status}
+                        {` · paired ${formatDate(device.createdAt)}`}
+                        {device.redeemedAt ? ` · redeemed ${formatDate(device.redeemedAt)}` : ""}
+                      </p>
+                    </div>
+                    <Link className="button button--ghost" to="/settings">
+                      Manage
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            ) : null}
+          </>
+        ) : null}
+      </Section>
+    </AppShell>
+  );
+}

--- a/apps/web/src/pages/ProfilePage.tsx
+++ b/apps/web/src/pages/ProfilePage.tsx
@@ -1,0 +1,77 @@
+import { Link } from "react-router-dom";
+import { useAuth } from "../auth/AuthContext";
+import { AppShell, Section } from "../components/AppShell";
+import { AuthRequiredPanel } from "../components/AuthRequiredPanel";
+import { formatDate } from "../lib/ui";
+
+export function ProfilePage() {
+  const auth = useAuth();
+
+  return (
+    <AppShell cta={<Link className="button button--ghost" to="/my-agents">My Agents</Link>}>
+      <Section
+        eyebrow="Profile"
+        title="Your account profile"
+        description="This page will grow into the public profile surface. For now it shows the account identity currently attached to your session."
+      >
+        {!auth.ready ? <p className="muted">Checking your session...</p> : null}
+
+        {auth.ready && !auth.session ? (
+          <AuthRequiredPanel
+            title="Sign in to view your profile"
+            description="Your profile, settings, and paired agents only unlock after you authenticate."
+          />
+        ) : null}
+
+        {auth.session ? (
+          <div className="settings-grid">
+            <section className="card stack settings-card">
+              <div>
+                <p className="eyebrow">Current identity</p>
+                <h3>{auth.session.actor.displayName ?? auth.session.actor.handle}</h3>
+              </div>
+              <dl className="meta-list settings-meta-list">
+                <div>
+                  <dt>Handle</dt>
+                  <dd>{auth.session.actor.handle}</dd>
+                </div>
+                <div>
+                  <dt>Actor type</dt>
+                  <dd>{auth.session.actor.kind}</dd>
+                </div>
+                <div>
+                  <dt>Signed in</dt>
+                  <dd>{formatDate(auth.session.createdAt)}</dd>
+                </div>
+                <div>
+                  <dt>Session expires</dt>
+                  <dd>{formatDate(auth.session.expiresAt)}</dd>
+                </div>
+              </dl>
+            </section>
+
+            <section className="card stack settings-card">
+              <div>
+                <p className="eyebrow">Next up</p>
+                <h3>Public profile editing lands next</h3>
+              </div>
+              <p className="muted">
+                The public profile page is intentionally small for now. The next
+                pass will add profile metadata and public account links once the
+                auth UX is stable.
+              </p>
+              <div className="row wrap-gap">
+                <Link className="button" to="/settings">
+                  Open settings
+                </Link>
+                <Link className="button button--ghost" to="/my-agents">
+                  Review paired agents
+                </Link>
+              </div>
+            </section>
+          </div>
+        ) : null}
+      </Section>
+    </AppShell>
+  );
+}

--- a/apps/web/src/pages/QuestionPage.tsx
+++ b/apps/web/src/pages/QuestionPage.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useState } from "react";
 import { Link, useParams } from "react-router-dom";
+import { useAuth } from "../auth/AuthContext";
+import { AuthRequiredPanel } from "../components/AuthRequiredPanel";
 import type { ApiClient } from "../lib/api";
 import type { AnswerSkill, QuestionThread } from "../types";
 import { AnswerForm, type AnswerFormValues } from "../components/AnswerForm";
 import { AppShell, Section } from "../components/AppShell";
 import { MarkdownContent } from "../components/MarkdownContent";
-import { formatDate, readErrorMessage } from "../lib/ui";
+import { describeActor, formatDate, readErrorMessage } from "../lib/ui";
 
 function formatSkillType(skill: AnswerSkill): string {
   if (skill.mimeType) {
@@ -24,6 +26,7 @@ interface QuestionPageProps {
 }
 
 export function QuestionPage({ api }: QuestionPageProps) {
+  const auth = useAuth();
   const { questionId } = useParams<{ questionId: string }>();
   const [thread, setThread] = useState<QuestionThread | null>(null);
   const [answerSkills, setAnswerSkills] = useState<Record<string, AnswerSkill[]>>({});
@@ -69,7 +72,7 @@ export function QuestionPage({ api }: QuestionPageProps) {
   }
 
   async function handleCreateAnswer(values: AnswerFormValues): Promise<void> {
-    if (!questionId) {
+    if (!questionId || !auth.session) {
       return;
     }
 
@@ -78,12 +81,7 @@ export function QuestionPage({ api }: QuestionPageProps) {
     try {
       const updatedThread = await api.createAnswer(questionId, {
         body: values.body,
-        author: {
-          id: values.handle,
-          kind: "agent",
-          handle: values.handle,
-          displayName: values.handle,
-        },
+        author: auth.session.actor,
       });
 
       setThread(updatedThread);
@@ -93,7 +91,7 @@ export function QuestionPage({ api }: QuestionPageProps) {
   }
 
   async function handleAcceptAnswer(answerId: string): Promise<void> {
-    if (!questionId) {
+    if (!questionId || !auth.session) {
       return;
     }
 
@@ -208,11 +206,13 @@ export function QuestionPage({ api }: QuestionPageProps) {
                         <button
                           type="button"
                           className={isAccepted ? "button button--secondary" : "button"}
-                          disabled={Boolean(acceptingAnswerId) || isAccepted}
+                          disabled={!auth.session || Boolean(acceptingAnswerId) || isAccepted}
                           onClick={() => void handleAcceptAnswer(answer.id)}
                         >
                           {isAccepted
                             ? "Accepted"
+                            : !auth.session
+                              ? "Sign in to accept"
                             : acceptingAnswerId === answer.id
                               ? "Accepting..."
                               : "Accept answer"}
@@ -229,7 +229,19 @@ export function QuestionPage({ api }: QuestionPageProps) {
             title="Post an answer"
             description="Share a concrete solution with enough detail that the next reader can apply it."
           >
-            <AnswerForm onSubmit={handleCreateAnswer} disabled={loading} />
+            {auth.ready && auth.session ? (
+              <AnswerForm
+                onSubmit={handleCreateAnswer}
+                disabled={loading}
+                authorLabel={describeActor(auth.session.actor)}
+              />
+            ) : (
+              <AuthRequiredPanel
+                title="Sign in to post an answer"
+                description="Replies are locked until you authenticate, so we do not open the form for anonymous visitors."
+                loading={!auth.ready}
+              />
+            )}
           </Section>
         </div>
       ) : null}

--- a/apps/web/src/pages/SettingsPage.test.tsx
+++ b/apps/web/src/pages/SettingsPage.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { describe, expect, it, vi } from "vitest";
+import { AuthProvider } from "../auth/AuthContext";
 import type { ApiClient } from "../lib/api";
 import { SettingsPage } from "./SettingsPage";
 
@@ -11,11 +12,14 @@ describe("SettingsPage", () => {
       getAuthSession: vi.fn().mockResolvedValue(null),
       listPasskeys: vi.fn(),
       listDevices: vi.fn(),
+      signOut: vi.fn(),
     } as unknown as ApiClient;
 
     render(
       <MemoryRouter initialEntries={["/settings"]}>
-        <SettingsPage api={api} />
+        <AuthProvider api={api}>
+          <SettingsPage api={api} />
+        </AuthProvider>
       </MemoryRouter>,
     );
 
@@ -83,7 +87,9 @@ describe("SettingsPage", () => {
 
     render(
       <MemoryRouter initialEntries={["/settings"]}>
-        <SettingsPage api={api} />
+        <AuthProvider api={api}>
+          <SettingsPage api={api} />
+        </AuthProvider>
       </MemoryRouter>,
     );
 

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -1,17 +1,19 @@
 import { useEffect, useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { Link } from "react-router-dom";
+import { useAuth } from "../auth/AuthContext";
 import type { ApiClient } from "../lib/api";
 import { AppShell, Section } from "../components/AppShell";
+import { AuthRequiredPanel } from "../components/AuthRequiredPanel";
+import { buildAuthPath, buildPairingAuthPath } from "../lib/auth-routing";
 import { formatDate, readErrorMessage } from "../lib/ui";
-import type { AuthDevice, AuthPasskey, WebSession } from "../types";
+import type { AuthDevice, AuthPasskey } from "../types";
 
 interface SettingsPageProps {
   api: ApiClient;
 }
 
 export function SettingsPage({ api }: SettingsPageProps) {
-  const navigate = useNavigate();
-  const [session, setSession] = useState<WebSession | null>(null);
+  const auth = useAuth();
   const [passkeys, setPasskeys] = useState<AuthPasskey[]>([]);
   const [devices, setDevices] = useState<AuthDevice[]>([]);
   const [loading, setLoading] = useState(true);
@@ -22,10 +24,21 @@ export function SettingsPage({ api }: SettingsPageProps) {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    void refresh();
-  }, []);
+    if (!auth.ready) {
+      return;
+    }
 
-  async function refresh(options: { quiet?: boolean } = {}): Promise<void> {
+    if (!auth.session) {
+      setPasskeys([]);
+      setDevices([]);
+      setLoading(false);
+      return;
+    }
+
+    void loadAccountData();
+  }, [auth.ready, auth.session?.actor.id]);
+
+  async function loadAccountData(options: { quiet?: boolean } = {}): Promise<void> {
     if (options.quiet) {
       setRefreshing(true);
     } else {
@@ -35,15 +48,6 @@ export function SettingsPage({ api }: SettingsPageProps) {
     setError(null);
 
     try {
-      const nextSession = await api.getAuthSession();
-      setSession(nextSession);
-
-      if (!nextSession) {
-        setPasskeys([]);
-        setDevices([]);
-        return;
-      }
-
       const [nextPasskeys, nextDevices] = await Promise.all([
         api.listPasskeys(),
         api.listDevices(),
@@ -57,6 +61,20 @@ export function SettingsPage({ api }: SettingsPageProps) {
       setLoading(false);
       setRefreshing(false);
     }
+  }
+
+  async function refresh(options: { quiet?: boolean } = {}): Promise<void> {
+    const nextSession = await auth.refreshSession();
+
+    if (!nextSession) {
+      setPasskeys([]);
+      setDevices([]);
+      setLoading(false);
+      setRefreshing(false);
+      return;
+    }
+
+    await loadAccountData(options);
   }
 
   async function handleRemovePasskey(credentialId: string): Promise<void> {
@@ -92,8 +110,9 @@ export function SettingsPage({ api }: SettingsPageProps) {
     setError(null);
 
     try {
-      await api.signOut();
-      navigate("/auth");
+      await auth.signOut();
+      setPasskeys([]);
+      setDevices([]);
     } catch (cause) {
       setError(readErrorMessage(cause));
     } finally {
@@ -102,7 +121,7 @@ export function SettingsPage({ api }: SettingsPageProps) {
   }
 
   return (
-    <AppShell cta={<Link className="button button--ghost" to="/auth">Pair an agent</Link>}>
+    <AppShell cta={<Link className="button button--ghost" to="/my-agents">My Agents</Link>}>
       <div className="settings-layout">
         <Section
           eyebrow="Settings v1"
@@ -113,55 +132,45 @@ export function SettingsPage({ api }: SettingsPageProps) {
               <button className="button button--ghost" type="button" onClick={() => void refresh({ quiet: true })} disabled={loading || refreshing}>
                 {refreshing ? "Refreshing..." : "Refresh"}
               </button>
-              <button type="button" onClick={() => void handleSignOut()} disabled={signingOut || loading}>
-                {signingOut ? "Signing out..." : "Sign out"}
+              <button type="button" onClick={() => void handleSignOut()} disabled={signingOut || loading || !auth.session}>
+                {signingOut ? "Signing out..." : auth.session ? "Sign out" : "Signed out"}
               </button>
             </div>
           }
         >
           {error ? <p className="error">{error}</p> : null}
-          {loading ? <p className="muted">Loading settings...</p> : null}
+          {!auth.ready || loading ? <p className="muted">Loading settings...</p> : null}
 
-          {!loading && !session ? (
-            <div className="card stack settings-empty-state">
-              <h3>Sign in to view your settings</h3>
-              <p className="muted">
-                Once you sign in with a passkey, this page will show your current session, passkeys, and paired agents or devices.
-              </p>
-              <div className="row wrap-gap">
-                <Link className="button" to="/auth">
-                  Sign in with passkey
-                </Link>
-                <Link className="button button--ghost" to="/">
-                  Back to forum
-                </Link>
-              </div>
-            </div>
+          {auth.ready && !loading && !auth.session ? (
+            <AuthRequiredPanel
+              title="Sign in to view your settings"
+              description="Passkeys, account settings, and paired agents only unlock after you authenticate."
+            />
           ) : null}
 
-          {!loading && session ? (
+          {!loading && auth.session ? (
             <div className="settings-grid">
               <section className="card stack settings-card">
                 <div>
                   <p className="eyebrow">Current session</p>
-                  <h3>{session.actor.displayName ?? session.actor.handle}</h3>
+                  <h3>{auth.session.actor.displayName ?? auth.session.actor.handle}</h3>
                 </div>
                 <dl className="meta-list settings-meta-list">
                   <div>
                     <dt>Handle</dt>
-                    <dd>@{session.actor.handle}</dd>
+                    <dd>{auth.session.actor.handle}</dd>
                   </div>
                   <div>
                     <dt>Actor type</dt>
-                    <dd>{session.actor.kind}</dd>
+                    <dd>{auth.session.actor.kind}</dd>
                   </div>
                   <div>
                     <dt>Signed in</dt>
-                    <dd>{formatDate(session.createdAt)}</dd>
+                    <dd>{formatDate(auth.session.createdAt)}</dd>
                   </div>
                   <div>
                     <dt>Session expires</dt>
-                    <dd>{formatDate(session.expiresAt)}</dd>
+                    <dd>{formatDate(auth.session.expiresAt)}</dd>
                   </div>
                 </dl>
               </section>
@@ -172,7 +181,7 @@ export function SettingsPage({ api }: SettingsPageProps) {
                     <p className="eyebrow">Passkeys</p>
                     <h3>Registered passkeys</h3>
                   </div>
-                  <Link className="button button--ghost" to="/auth">
+                  <Link className="button button--ghost" to={buildAuthPath("/settings", { mode: "signup" })}>
                     Add another passkey
                   </Link>
                 </div>
@@ -209,7 +218,7 @@ export function SettingsPage({ api }: SettingsPageProps) {
                     <p className="eyebrow">Agents and devices</p>
                     <h3>Paired agents</h3>
                   </div>
-                  <Link className="button button--ghost" to="/auth">
+                  <Link className="button button--ghost" to={buildPairingAuthPath("/settings")}>
                     Pair new agent
                   </Link>
                 </div>
@@ -247,6 +256,14 @@ export function SettingsPage({ api }: SettingsPageProps) {
                 <p className="muted">
                   This slice is focused on auth and testing visibility first. Preferences can grow later once account, passkey, and agent-state behavior feels solid.
                 </p>
+                <div className="row wrap-gap">
+                  <Link className="button button--ghost" to="/profile">
+                    My Profile
+                  </Link>
+                  <Link className="button button--ghost" to="/my-agents">
+                    My Agents
+                  </Link>
+                </div>
               </section>
             </div>
           ) : null}

--- a/apps/web/src/pages/TerminalGraphPages.test.tsx
+++ b/apps/web/src/pages/TerminalGraphPages.test.tsx
@@ -1,6 +1,7 @@
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
+import { AuthProvider } from "../auth/AuthContext";
 import { ForumPage, LandingPage, PostDetailPage } from "./TerminalGraphPages";
 import type { ApiClient } from "../lib/api";
 import type { Question, QuestionThread } from "../types";
@@ -114,7 +115,7 @@ function buildApi(overrides: Partial<ApiClient> = {}): ApiClient {
     startAuthentication: vi.fn(),
     getPasskeyAuthenticationOptions: vi.fn(),
     authenticatePasskey: vi.fn(),
-    getAuthSession: vi.fn(),
+    getAuthSession: vi.fn().mockResolvedValue(null),
     listPasskeys: vi.fn(),
     removePasskey: vi.fn(),
     listDevices: vi.fn(),
@@ -162,10 +163,11 @@ describe("TerminalGraphPages", () => {
         "/posts/context-protocols",
       );
       expect(screen.getByRole("heading", { name: /context graphs as public memory/i })).toBeInTheDocument();
+      expect(screen.getByRole("heading", { name: /sign in to start a post/i })).toBeInTheDocument();
     });
   });
 
-  it("renders the post detail route with real comments and attached skills", async () => {
+  it("renders locked reply affordances for anonymous readers", async () => {
     const api = buildApi();
 
     render(
@@ -183,6 +185,36 @@ describe("TerminalGraphPages", () => {
       expect(screen.getByText("Eric")).toBeInTheDocument();
       expect(screen.getByText("@lumen_cache")).toBeInTheDocument();
       expect(screen.getByText("extract-claims@0.3")).toBeInTheDocument();
+      expect(screen.getByRole("heading", { name: /sign in to reply/i })).toBeInTheDocument();
     });
+  });
+
+  it("shows the authenticated composer without a handle field", async () => {
+    const api = buildApi({
+      getAuthSession: vi.fn().mockResolvedValue({
+        actor: {
+          id: "acct-1",
+          kind: "human",
+          handle: "eric@example.com",
+          displayName: "Eric",
+        },
+        createdAt: "2026-04-25T00:00:00.000Z",
+        expiresAt: "2026-05-02T00:00:00.000Z",
+      }),
+    });
+
+    render(
+      <MemoryRouter>
+        <AuthProvider api={api}>
+          <ForumPage api={api} />
+        </AuthProvider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Posting as Eric")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByLabelText(/your handle/i)).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/pages/TerminalGraphPages.tsx
+++ b/apps/web/src/pages/TerminalGraphPages.tsx
@@ -1,10 +1,15 @@
 import { useEffect, useMemo, useState, type FormEvent, type ReactNode } from "react";
-import { Link, useParams } from "react-router-dom";
+import { Link, useNavigate, useParams } from "react-router-dom";
+import { useAuth } from "../auth/AuthContext";
+import { AuthControls } from "../components/AuthControls";
+import { AuthRequiredPanel } from "../components/AuthRequiredPanel";
+import { CreateQuestionForm, type CreateQuestionFormValues } from "../components/CreateQuestionForm";
 import type { ApiClient } from "../lib/api";
+import { useAuthNavigation } from "../lib/auth-routing";
 import type { Answer, AnswerSkill, Question, QuestionThread, ThreadSearchResult } from "../types";
 import { AnswerForm, type AnswerFormValues } from "../components/AnswerForm";
 import { MarkdownContent } from "../components/MarkdownContent";
-import { formatDate, readErrorMessage } from "../lib/ui";
+import { describeActor, formatDate, readErrorMessage } from "../lib/ui";
 
 const benefitCards = [
   {
@@ -12,8 +17,8 @@ const benefitCards = [
     body: "One exchange layer for conversation and capability. Read, write, and run.",
   },
   {
-    label: "Handles, not accounts",
-    body: "Agents and humans connect with handles. Interop by design.",
+    label: "Passkeys first",
+    body: "Email gets you to the right account. Passkeys unlock it without password sprawl.",
   },
   {
     label: "Runnable by default",
@@ -52,6 +57,7 @@ function TerminalNav() {
         <span className="terminal-status-dot" />
         <span>network: online</span>
       </div>
+      <AuthControls variant="terminal" />
     </header>
   );
 }
@@ -97,7 +103,7 @@ function excerpt(value: string, maxLength = 150): string {
 }
 
 function displayActor(actor: Question["author"] | Answer["author"]): string {
-  return actor.displayName || actor.handle;
+  return describeActor(actor);
 }
 
 function formatSkillType(skill: AnswerSkill): string {
@@ -339,6 +345,8 @@ function FeedSkeleton() {
 }
 
 export function ForumPage({ api }: TerminalApiProps) {
+  const auth = useAuth();
+  const navigate = useNavigate();
   const [questions, setQuestions] = useState<Question[]>([]);
   const [searchQuery, setSearchQuery] = useState("");
   const [searchResult, setSearchResult] = useState<ThreadSearchResult | null>(null);
@@ -381,6 +389,27 @@ export function ForumPage({ api }: TerminalApiProps) {
       setError(readErrorMessage(cause));
     } finally {
       setSearching(false);
+    }
+  }
+
+  async function handleCreateQuestion(values: CreateQuestionFormValues): Promise<void> {
+    if (!auth.session) {
+      return;
+    }
+
+    setError(null);
+
+    try {
+      const createdQuestion = await api.createQuestion({
+        title: values.title,
+        body: values.body,
+        author: auth.session.actor,
+      });
+
+      await refreshQuestions();
+      navigate(`/posts/${createdQuestion.id}`);
+    } catch (cause) {
+      setError(readErrorMessage(cause));
     }
   }
 
@@ -438,6 +467,29 @@ export function ForumPage({ api }: TerminalApiProps) {
 
         <aside className="terminal-side-stack" aria-label="Forum metadata">
           <section className="terminal-side-card">
+            <h2>new post</h2>
+            {auth.ready && auth.session ? (
+              <div className="terminal-composer-card">
+                <p className="terminal-composer-copy">
+                  Start a new thread without leaving the live stream.
+                </p>
+                <CreateQuestionForm
+                  onSubmit={handleCreateQuestion}
+                  disabled={loading}
+                  authorLabel={displayActor(auth.session.actor)}
+                />
+              </div>
+            ) : (
+              <AuthRequiredPanel
+                surface="terminal"
+                loading={!auth.ready}
+                title="Sign in to start a post"
+                description="Posting is locked until you authenticate, so we do not show a live composer that will fail."
+              />
+            )}
+          </section>
+
+          <section className="terminal-side-card">
             <h2>live handles</h2>
             <ul className="terminal-handle-list">
               {liveHandles.map((handle) => (
@@ -482,6 +534,21 @@ function ThreadGraph({ answerCount, skillCount, status }: { answerCount: number;
   );
 }
 
+function TerminalInlineAuthAction({ label }: { label: string }) {
+  const { openAuth } = useAuthNavigation();
+
+  return (
+    <button
+      type="button"
+      className="terminal-inline-auth-callout"
+      onClick={() => openAuth({ mode: "signin" })}
+    >
+      <span className="terminal-type-badge">lock</span>
+      <span>{label}</span>
+    </button>
+  );
+}
+
 function AnswerSkillPanel({ skills }: { skills: AnswerSkill[] }) {
   if (skills.length === 0) {
     return null;
@@ -512,6 +579,7 @@ function AnswerSkillPanel({ skills }: { skills: AnswerSkill[] }) {
 interface PostDetailPageProps extends TerminalApiProps {}
 
 export function PostDetailPage({ api }: PostDetailPageProps) {
+  const auth = useAuth();
   const { postId, questionId } = useParams<{ postId?: string; questionId?: string }>();
   const resolvedId = postId ?? questionId;
   const [thread, setThread] = useState<QuestionThread | null>(null);
@@ -558,7 +626,7 @@ export function PostDetailPage({ api }: PostDetailPageProps) {
   }
 
   async function handleCreateAnswer(values: AnswerFormValues): Promise<void> {
-    if (!thread) {
+    if (!thread || !auth.session) {
       return;
     }
 
@@ -567,12 +635,7 @@ export function PostDetailPage({ api }: PostDetailPageProps) {
     try {
       const updatedThread = await api.createAnswer(thread.question.id, {
         body: values.body,
-        author: {
-          id: values.handle,
-          kind: "agent",
-          handle: values.handle,
-          displayName: values.handle,
-        },
+        author: auth.session.actor,
       });
       setThread(updatedThread);
     } catch (cause) {
@@ -581,7 +644,7 @@ export function PostDetailPage({ api }: PostDetailPageProps) {
   }
 
   async function handleAcceptAnswer(answerId: string): Promise<void> {
-    if (!thread) {
+    if (!thread || !auth.session) {
       return;
     }
 
@@ -654,14 +717,18 @@ export function PostDetailPage({ api }: PostDetailPageProps) {
                     </div>
                     <MarkdownContent className="markdown-content terminal-markdown" content={answer.body} />
                     <AnswerSkillPanel skills={skills} />
-                    <button
-                      type="button"
-                      className="terminal-mini-button"
-                      disabled={Boolean(acceptingAnswerId) || isAccepted}
-                      onClick={() => void handleAcceptAnswer(answer.id)}
-                    >
-                      {isAccepted ? "accepted" : acceptingAnswerId === answer.id ? "accepting" : "accept answer"}
-                    </button>
+                    {auth.session ? (
+                      <button
+                        type="button"
+                        className="terminal-mini-button"
+                        disabled={Boolean(acceptingAnswerId) || isAccepted}
+                        onClick={() => void handleAcceptAnswer(answer.id)}
+                      >
+                        {isAccepted ? "accepted" : acceptingAnswerId === answer.id ? "accepting" : "accept answer"}
+                      </button>
+                    ) : (
+                      <TerminalInlineAuthAction label="sign in to accept" />
+                    )}
                   </article>
                 );
               })}
@@ -673,7 +740,20 @@ export function PostDetailPage({ api }: PostDetailPageProps) {
                 <span>leave a trace</span>
               </div>
               <h2>Post an answer</h2>
-              <AnswerForm onSubmit={handleCreateAnswer} disabled={loading} />
+              {auth.ready && auth.session ? (
+                <AnswerForm
+                  onSubmit={handleCreateAnswer}
+                  disabled={loading}
+                  authorLabel={displayActor(auth.session.actor)}
+                />
+              ) : (
+                <AuthRequiredPanel
+                  surface="terminal"
+                  loading={!auth.ready}
+                  title="Sign in to reply"
+                  description="Replies are locked until you authenticate, so we keep the composer closed for anonymous visitors."
+                />
+              )}
             </section>
           </article>
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -794,6 +794,230 @@ ul {
   font-size: 0.92rem;
 }
 
+.stack {
+  display: grid;
+  gap: 1rem;
+}
+
+.card {
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-lg);
+  background: var(--surface-soft);
+  box-shadow: var(--shadow-sm);
+  padding: 1.35rem;
+}
+
+.row {
+  display: flex;
+}
+
+.wrap-gap {
+  flex-wrap: wrap;
+  gap: 0.85rem;
+}
+
+.between {
+  justify-content: space-between;
+}
+
+.center {
+  align-items: center;
+}
+
+.meta-list {
+  margin: 0;
+}
+
+.form-author-badge {
+  width: fit-content;
+  padding: 0.38rem 0.8rem;
+  border: 1px solid rgba(15, 118, 110, 0.15);
+  border-radius: 999px;
+  background: rgba(15, 118, 110, 0.08);
+  color: var(--accent-strong);
+  font-size: 0.86rem;
+  font-weight: 800;
+}
+
+.auth-header-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.auth-header-actions .button,
+.auth-header-actions button {
+  min-height: 2.8rem;
+}
+
+.auth-menu {
+  position: relative;
+}
+
+.auth-menu summary {
+  list-style: none;
+}
+
+.auth-menu summary::-webkit-details-marker {
+  display: none;
+}
+
+.auth-menu__trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.35rem;
+  border: 1px solid var(--border-strong);
+  border-radius: 999px;
+  background: var(--surface-elevated);
+  cursor: pointer;
+}
+
+.auth-menu__avatar {
+  display: inline-grid;
+  place-items: center;
+  width: 2.4rem;
+  height: 2.4rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, var(--accent) 0%, #169084 100%);
+  color: #fff;
+  font-size: 0.82rem;
+  font-weight: 800;
+}
+
+.auth-menu__label {
+  display: grid;
+  min-width: 0;
+  gap: 0.1rem;
+}
+
+.auth-menu__label strong,
+.auth-menu__label small {
+  font-family: "Manrope", system-ui, sans-serif;
+  line-height: 1.2;
+}
+
+.auth-menu__label strong {
+  font-size: 0.9rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.auth-menu__label small {
+  color: var(--text-muted);
+  font-size: 0.76rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.auth-menu__panel {
+  position: absolute;
+  top: calc(100% + 0.7rem);
+  right: 0;
+  z-index: 15;
+  min-width: 14rem;
+  display: grid;
+  gap: 0.25rem;
+  padding: 0.55rem;
+  border: 1px solid var(--border-strong);
+  border-radius: 1rem;
+  background: var(--surface-strong);
+  box-shadow: var(--shadow-md);
+  backdrop-filter: blur(18px);
+}
+
+.auth-menu__panel a,
+.auth-menu__panel button {
+  width: 100%;
+  justify-content: flex-start;
+  min-height: 2.6rem;
+  padding: 0.7rem 0.85rem;
+  border-radius: 0.8rem;
+  border: 0;
+  background: transparent;
+  color: var(--text-strong);
+  box-shadow: none;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.auth-menu__panel a:hover,
+.auth-menu__panel button:hover:not(:disabled) {
+  background: rgba(15, 118, 110, 0.08);
+  transform: none;
+}
+
+.auth-menu--terminal .auth-menu__trigger {
+  border-color: rgba(164, 137, 255, 0.2);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.auth-menu--terminal .auth-menu__label strong {
+  color: var(--terminal-text);
+}
+
+.auth-menu--terminal .auth-menu__label small {
+  color: var(--terminal-muted);
+}
+
+.auth-menu--terminal .auth-menu__panel {
+  border-color: rgba(164, 137, 255, 0.22);
+  background: linear-gradient(180deg, rgba(14, 15, 30, 0.98), rgba(7, 8, 17, 0.96));
+}
+
+.auth-menu--terminal .auth-menu__panel a,
+.auth-menu--terminal .auth-menu__panel button {
+  color: var(--terminal-text);
+}
+
+.auth-menu--terminal .auth-menu__panel a:hover,
+.auth-menu--terminal .auth-menu__panel button:hover:not(:disabled) {
+  background: rgba(25, 242, 211, 0.08);
+}
+
+.auth-required-panel {
+  display: grid;
+  gap: 1rem;
+  padding: 1.2rem;
+  border: 1px dashed rgba(19, 34, 56, 0.18);
+  border-radius: 1.2rem;
+  background: rgba(255, 255, 255, 0.58);
+}
+
+.auth-required-panel__icon {
+  display: inline-flex;
+  width: fit-content;
+  padding: 0.35rem 0.7rem;
+  border-radius: 999px;
+  background: rgba(19, 34, 56, 0.08);
+  color: var(--text-soft);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.auth-required-panel__copy {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.auth-required-panel__copy h3 {
+  font-size: clamp(1.05rem, 2vw, 1.35rem);
+}
+
+.auth-required-panel__copy p {
+  color: var(--text-muted);
+}
+
+.auth-required-panel__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+}
+
 .question-list,
 .answer-list,
 .artifact-list {
@@ -1340,8 +1564,25 @@ ul {
   }
 
   .site-nav a,
-  .site-nav .button {
+  .site-nav .button,
+  .site-nav .auth-menu,
+  .site-nav .auth-header-actions {
     width: 100%;
+  }
+
+  .auth-header-actions {
+    display: grid;
+  }
+
+  .auth-header-actions .button,
+  .auth-header-actions button,
+  .auth-menu__trigger {
+    width: 100%;
+  }
+
+  .auth-menu__panel {
+    left: 0;
+    right: 0;
   }
 
   .brand__tagline {
@@ -1537,6 +1778,218 @@ ul {
   .button--ghost {
     background: rgba(22, 34, 50, 0.98);
   }
+
+  .card,
+  .auth-menu__trigger,
+  .auth-menu__panel,
+  .auth-required-panel {
+    background: rgba(16, 26, 39, 0.96);
+    border-color: var(--border-soft);
+  }
+
+  .auth-menu__panel a,
+  .auth-menu__panel button {
+    color: #eef6ff;
+  }
+
+  .auth-required-panel__icon {
+    background: rgba(181, 202, 226, 0.12);
+    color: var(--text-soft);
+  }
+}
+
+.auth-entry-page {
+  min-height: 100vh;
+}
+
+.auth-entry-shell {
+  display: grid;
+  grid-template-columns: minmax(0, 0.95fr) minmax(22rem, 0.85fr);
+  gap: 1.5rem;
+  align-items: start;
+}
+
+.auth-entry-copy,
+.auth-entry-card {
+  border: 1px solid rgba(164, 137, 255, 0.16);
+  border-radius: 1.2rem;
+  background: linear-gradient(180deg, rgba(14, 15, 30, 0.92), rgba(7, 8, 17, 0.88));
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.02), 0 24px 70px rgba(0, 0, 0, 0.3);
+}
+
+.auth-entry-copy {
+  display: grid;
+  gap: 1rem;
+  padding: clamp(1.5rem, 4vw, 2.6rem);
+}
+
+.auth-entry-eyebrow {
+  color: var(--terminal-cyan);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.auth-entry-copy h1,
+.auth-entry-card h2 {
+  font-family: "SFMono-Regular", "JetBrains Mono", "Cascadia Code", "Roboto Mono", ui-monospace, monospace;
+  color: var(--terminal-text);
+  max-width: none;
+  font-size: clamp(2.2rem, 5vw, 4.5rem);
+  line-height: 1.05;
+  letter-spacing: -0.07em;
+  text-transform: lowercase;
+}
+
+.auth-entry-card h2 {
+  font-size: clamp(1.65rem, 3vw, 2.3rem);
+}
+
+.auth-entry-lead,
+.auth-entry-note,
+.auth-entry-state p,
+.auth-entry-status {
+  color: var(--terminal-muted);
+}
+
+.auth-entry-pills,
+.auth-entry-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+}
+
+.auth-entry-pills span {
+  padding: 0.4rem 0.72rem;
+  border: 1px solid rgba(164, 137, 255, 0.18);
+  border-radius: 999px;
+  color: var(--terminal-cyan);
+  font-size: 0.74rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.auth-entry-card {
+  display: grid;
+  gap: 1.1rem;
+  padding: clamp(1.3rem, 3vw, 1.8rem);
+}
+
+.auth-entry-card__topline {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.auth-entry-badge,
+.auth-entry-back,
+.auth-entry-close {
+  color: var(--terminal-cyan);
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.auth-entry-close,
+.auth-entry-back {
+  min-height: auto;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.auth-entry-tabs {
+  display: inline-grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.45rem;
+  padding: 0.3rem;
+  border: 1px solid rgba(164, 137, 255, 0.18);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.auth-entry-tabs button {
+  min-height: 2.45rem;
+  padding: 0.55rem 1rem;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--terminal-muted);
+  box-shadow: none;
+  font-weight: 800;
+  text-transform: none;
+}
+
+.auth-entry-tabs button.is-active {
+  background: linear-gradient(135deg, #6a35ff 0%, #8f66ff 100%);
+  color: #fff;
+}
+
+.auth-entry-form {
+  display: grid;
+  gap: 1rem;
+}
+
+.auth-entry-form .field span {
+  color: var(--terminal-muted);
+}
+
+.auth-entry-form input {
+  border-color: rgba(164, 137, 255, 0.2);
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--terminal-text);
+  box-shadow: none;
+}
+
+.auth-entry-error,
+.auth-entry-status {
+  margin: 0;
+  padding: 0.9rem 1rem;
+  border-radius: 0.9rem;
+}
+
+.auth-entry-error {
+  border: 1px solid rgba(255, 107, 107, 0.24);
+  background: rgba(255, 107, 107, 0.08);
+  color: #ffd3d3;
+}
+
+.auth-entry-status {
+  border: 1px solid rgba(25, 242, 211, 0.18);
+  background: rgba(25, 242, 211, 0.06);
+}
+
+.auth-entry-state {
+  display: grid;
+  gap: 1rem;
+}
+
+.auth-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  display: grid;
+  place-items: center;
+  padding: 1rem;
+}
+
+.auth-modal__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(2, 3, 10, 0.72);
+  backdrop-filter: blur(12px);
+}
+
+.auth-modal__surface {
+  position: relative;
+  z-index: 1;
+  width: min(100%, 68rem);
+  max-height: calc(100vh - 2rem);
+  overflow: auto;
 }
 
 .auth-terminal-page {
@@ -1964,6 +2417,10 @@ ul {
 }
 
 @media (max-width: 980px) {
+  .auth-entry-shell {
+    grid-template-columns: 1fr;
+  }
+
   .auth-terminal-hero,
   .auth-choice-grid {
     grid-template-columns: 1fr;
@@ -1984,6 +2441,17 @@ ul {
 }
 
 @media (max-width: 640px) {
+  .auth-entry-actions,
+  .auth-required-panel__actions {
+    display: grid;
+  }
+
+  .auth-entry-actions .button,
+  .auth-required-panel__actions .button,
+  .auth-required-panel__actions button {
+    width: 100%;
+  }
+
   .auth-terminal-nav,
   .auth-stage-topline,
   .auth-stage-card__actions {
@@ -2059,7 +2527,7 @@ ul {
 
 .terminal-nav {
   display: grid;
-  grid-template-columns: minmax(max-content, 1fr) auto minmax(max-content, 1fr);
+  grid-template-columns: minmax(max-content, 1fr) auto minmax(max-content, 1fr) auto;
   align-items: center;
   gap: 1.5rem;
   min-height: 4.35rem;
@@ -2105,6 +2573,11 @@ ul {
   gap: 0.55rem;
   color: var(--terminal-muted);
   font-size: 0.78rem;
+}
+
+.terminal-nav > .auth-header-actions,
+.terminal-nav > .auth-menu {
+  justify-self: end;
 }
 
 .terminal-status-dot {
@@ -2506,6 +2979,42 @@ ul {
   color: var(--terminal-muted);
 }
 
+.terminal-composer-card {
+  display: grid;
+  gap: 1rem;
+  margin-top: 0.85rem;
+}
+
+.terminal-composer-copy {
+  color: var(--terminal-muted);
+}
+
+.terminal-composer-card .field span,
+.terminal-composer-card .field-hint {
+  color: var(--terminal-muted);
+}
+
+.terminal-composer-card input,
+.terminal-composer-card textarea {
+  border-color: rgba(164, 137, 255, 0.24);
+  background: rgba(3, 4, 11, 0.58);
+  color: var(--terminal-text);
+}
+
+.terminal-composer-card .button {
+  border: 1px solid rgba(164, 137, 255, 0.35);
+  border-radius: 0.65rem;
+  background: linear-gradient(135deg, #6a35ff 0%, #8f66ff 100%);
+  color: #fff;
+  box-shadow: 0 0 28px rgba(124, 77, 255, 0.26);
+}
+
+.terminal-composer-card .form-author-badge {
+  border-color: rgba(25, 242, 211, 0.2);
+  background: rgba(25, 242, 211, 0.08);
+  color: var(--terminal-cyan);
+}
+
 .terminal-feed-card__footer {
   justify-content: space-between;
   margin-top: 1rem;
@@ -2629,6 +3138,11 @@ ul {
     justify-self: start;
   }
 
+  .terminal-nav > .auth-header-actions,
+  .terminal-nav > .auth-menu {
+    justify-self: start;
+  }
+
   .terminal-hero--landing,
   .terminal-layout--feed,
   .terminal-layout--thread {
@@ -2680,6 +3194,18 @@ ul {
   .terminal-command-input {
     grid-template-columns: 1fr;
   }
+
+  .terminal-nav .auth-header-actions {
+    display: grid;
+  }
+
+  .terminal-nav .auth-header-actions,
+  .terminal-nav .auth-header-actions .terminal-button,
+  .terminal-nav .auth-header-actions .terminal-link-button,
+  .terminal-nav .auth-menu,
+  .terminal-nav .auth-menu__trigger {
+    width: 100%;
+  }
 }
 
 .terminal-inline-error {
@@ -2729,6 +3255,47 @@ ul {
   background: linear-gradient(135deg, #6a35ff 0%, #8f66ff 100%);
   color: #fff;
   box-shadow: 0 0 28px rgba(124, 77, 255, 0.26);
+}
+
+.terminal-answer-form .form-author-badge {
+  border-color: rgba(25, 242, 211, 0.2);
+  background: rgba(25, 242, 211, 0.08);
+  color: var(--terminal-cyan);
+}
+
+.auth-required-panel--terminal {
+  border-style: solid;
+  border-color: rgba(164, 137, 255, 0.18);
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.auth-required-panel--terminal .auth-required-panel__icon {
+  background: rgba(164, 137, 255, 0.12);
+  color: var(--terminal-purple-strong);
+}
+
+.auth-required-panel--terminal .auth-required-panel__copy h3 {
+  color: var(--terminal-text);
+  font-family: inherit;
+  letter-spacing: -0.04em;
+}
+
+.auth-required-panel--terminal .auth-required-panel__copy p {
+  color: var(--terminal-muted);
+}
+
+.terminal-inline-auth-callout {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  width: fit-content;
+  min-height: 2.25rem;
+  padding: 0.45rem 0.72rem;
+  border: 1px solid rgba(164, 137, 255, 0.18);
+  border-radius: 0.7rem;
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--terminal-muted);
+  box-shadow: none;
 }
 
 .terminal-markdown {


### PR DESCRIPTION
## Summary
- gate posting, replying, and accepting behind intentional locked auth panels instead of showing forms that later fail
- add a shared auth session context, header sign-in/sign-up controls, and an authenticated profile menu
- rework /auth into email-first sign-in/sign-up with passkey CTAs, modal/return-to routing, and a separate pairing handoff path
- add Profile and My Agents pages plus settings/profile navigation hooks

## Checks
- npm run test --workspace @theagentforum/web -- --run
- npm run typecheck --workspace @theagentforum/web
- npm run build --workspace @theagentforum/web