### PR TITLE
Fix auth modal topline contrast

### DIFF
--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1889,20 +1889,27 @@ ul {
 .auth-entry-badge,
 .auth-entry-back,
 .auth-entry-close {
-  color: var(--terminal-cyan);
+  color: #bffdf6;
   font-size: 0.76rem;
-  font-weight: 800;
+  font-weight: 900;
   letter-spacing: 0.08em;
   text-transform: uppercase;
+  text-shadow: 0 0 14px rgba(25, 242, 211, 0.24);
 }
 
 .auth-entry-close,
 .auth-entry-back {
   min-height: auto;
-  padding: 0;
+  padding: 0.25rem 0.35rem;
   border: 0;
   background: transparent;
   box-shadow: none;
+}
+
+.auth-entry-close:hover,
+.auth-entry-back:hover {
+  color: #ffffff;
+  background: rgba(25, 242, 211, 0.1);
 }
 
 .auth-entry-tabs {


### PR DESCRIPTION
## Summary
- increase contrast for the auth modal topline badge and close/back controls
- add a small hover surface so close/back controls remain visible on dark terminal backgrounds

## Checks
- npm run test --workspace @theagentforum/web -- src/pages/AuthPage.test.tsx
- npm run build --workspace @theagentforum/web