### PR TITLE
feat: harden live user launch path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,10 @@ CORS_ALLOW_ORIGIN=*
 # Use /api when web and api are deployed together behind the web proxy.
 VITE_API_BASE_URL=/api
 
+# Optional frontend analytics for launch funnel verification.
+VITE_POSTHOG_KEY=
+VITE_POSTHOG_HOST=https://us.i.posthog.com
+
 # Runtime target for web server /api proxy.
 API_PROXY_TARGET=http://api:3001
 

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -12,6 +12,7 @@ import type {
   RedeemPairingInput,
   StartAuthenticationInput,
   StartRegistrationInput,
+  UpdateAccountProfileInput,
 } from "@theagentforum/core";
 import type { AuthStore } from "./auth-store";
 import type { QuestionStore } from "./question-store";
@@ -117,6 +118,68 @@ async function routeRequest(
   }
 
   if (path === "/auth/session") {
+    sendError(res, corsHeaders, 405, "method_not_allowed", "Method not allowed.");
+    return;
+  }
+
+  if (method === "GET" && path === "/profile") {
+    const actor = requireAuthenticatedActor(authenticatedSession);
+    const profile = await authStore.getAccountProfile(actor.id);
+
+    if (!profile) {
+      sendError(res, corsHeaders, 404, "profile_not_found", "Profile not found.");
+      return;
+    }
+
+    sendJson(res, corsHeaders, 200, {
+      ok: true,
+      data: profile,
+    });
+    return;
+  }
+
+  if (method === "PATCH" && path === "/profile") {
+    const actor = requireAuthenticatedActor(authenticatedSession);
+    const payload = await readJsonBody(req);
+    const input = parseUpdateAccountProfileInput(payload);
+    const profile = await authStore.updateAccountProfile(actor.id, input);
+
+    if (!profile) {
+      sendError(res, corsHeaders, 404, "profile_not_found", "Profile not found.");
+      return;
+    }
+
+    sendJson(res, corsHeaders, 200, {
+      ok: true,
+      data: profile,
+    });
+    return;
+  }
+
+  if (path === "/profile") {
+    sendError(res, corsHeaders, 405, "method_not_allowed", "Method not allowed.");
+    return;
+  }
+
+  const publicProfileMatch = matchPath(path, /^\/profiles\/([^/]+)$/);
+
+  if (method === "GET" && publicProfileMatch) {
+    const handle = decodeURIComponent(publicProfileMatch[1]);
+    const profile = await authStore.getPublicProfileByHandle(handle);
+
+    if (!profile) {
+      sendError(res, corsHeaders, 404, "profile_not_found", "Profile not found.");
+      return;
+    }
+
+    sendJson(res, corsHeaders, 200, {
+      ok: true,
+      data: profile,
+    });
+    return;
+  }
+
+  if (publicProfileMatch) {
     sendError(res, corsHeaders, 405, "method_not_allowed", "Method not allowed.");
     return;
   }
@@ -296,7 +359,11 @@ async function routeRequest(
   if (method === "POST" && path === "/questions") {
     const payload = await readJsonBody(req);
     const input = parseCreateQuestionInput(payload);
-    const question = await questionStore.createQuestion(input);
+    const actor = requireAuthenticatedActor(authenticatedSession);
+    const question = await questionStore.createQuestion({
+      ...input,
+      author: actor,
+    });
 
     sendJson(res, corsHeaders, 201, {
       ok: true,
@@ -332,7 +399,11 @@ async function routeRequest(
   if (method === "POST" && answersMatch) {
     const payload = await readJsonBody(req);
     const input = parseCreateAnswerInput(payload);
-    const thread = await questionStore.createAnswer(answersMatch[1], input);
+    const actor = requireAuthenticatedActor(authenticatedSession);
+    const thread = await questionStore.createAnswer(answersMatch[1], {
+      ...input,
+      author: actor,
+    });
 
     if (!thread) {
       sendError(res, corsHeaders, 404, "question_not_found", "Question not found.");
@@ -384,6 +455,7 @@ async function routeRequest(
   }
 
   if (method === "POST" && answerSkillsMatch) {
+    requireAuthenticatedActor(authenticatedSession);
     const questionId = answerSkillsMatch[1];
     const answerId = answerSkillsMatch[2];
     const payload = await readJsonBody(req);
@@ -416,18 +488,41 @@ async function routeRequest(
   }
 
   if (method === "POST" && acceptMatch) {
+    const actor = requireAuthenticatedActor(authenticatedSession);
     const questionId = acceptMatch[1];
     const answerId = acceptMatch[2];
+    const existing = await questionStore.getQuestionThread(questionId);
+
+    if (!existing) {
+      sendError(res, corsHeaders, 404, "question_not_found", "Question not found.");
+      return;
+    }
+
+    if (existing.question.author.id !== actor.id) {
+      sendError(
+        res,
+        corsHeaders,
+        403,
+        "answer_accept_forbidden",
+        "Only the original post author can accept a reply.",
+      );
+      return;
+    }
+
+    if (!existing.answers.some((answer) => answer.id === answerId)) {
+      sendError(
+        res,
+        corsHeaders,
+        404,
+        "answer_not_found",
+        "Answer not found for the specified question.",
+      );
+      return;
+    }
+
     const thread = await questionStore.acceptAnswer(questionId, answerId);
 
     if (!thread) {
-      const questionExists = await questionStore.getQuestionThread(questionId);
-
-      if (!questionExists) {
-        sendError(res, corsHeaders, 404, "question_not_found", "Question not found.");
-        return;
-      }
-
       sendError(
         res,
         corsHeaders,
@@ -532,19 +627,41 @@ async function routeRequest(
   );
 
   if (method === "POST" && acceptCommentMatch) {
-    requireAuthenticatedActor(authenticatedSession);
+    const actor = requireAuthenticatedActor(authenticatedSession);
     const contentId = acceptCommentMatch[1];
     const commentId = acceptCommentMatch[2];
+    const existing = await forumStore.getContentThread(contentId);
+
+    if (!existing) {
+      sendError(res, corsHeaders, 404, "content_not_found", "Content not found.");
+      return;
+    }
+
+    if (existing.content.author.id !== actor.id) {
+      sendError(
+        res,
+        corsHeaders,
+        403,
+        "answer_accept_forbidden",
+        "Only the original post author can accept a reply.",
+      );
+      return;
+    }
+
+    if (!existing.comments.some((comment) => comment.id === commentId)) {
+      sendError(
+        res,
+        corsHeaders,
+        404,
+        "comment_not_found",
+        "Comment not found for the specified content.",
+      );
+      return;
+    }
+
     const thread = await forumStore.acceptComment(contentId, commentId);
 
     if (!thread) {
-      const existing = await forumStore.getContentThread(contentId);
-
-      if (!existing) {
-        sendError(res, corsHeaders, 404, "content_not_found", "Content not found.");
-        return;
-      }
-
       sendError(
         res,
         corsHeaders,
@@ -1010,7 +1127,7 @@ function buildCorsHeaders(
   const allowOrigin = configuredAllowOrigin === "*" && origin ? origin : configuredAllowOrigin;
   const headers: Record<string, string> = {
     "access-control-allow-origin": allowOrigin,
-    "access-control-allow-methods": "GET,POST,OPTIONS",
+    "access-control-allow-methods": "GET,POST,PATCH,DELETE,OPTIONS",
     "access-control-allow-headers": "content-type,authorization",
   };
 
@@ -1208,6 +1325,16 @@ function parseCreateCommentInput(payload: unknown): CreateCommentInput {
   return {
     body: readRequiredString(input.body, "body"),
     author: parseActor(input.author),
+  };
+}
+
+function parseUpdateAccountProfileInput(payload: unknown): UpdateAccountProfileInput {
+  const input = asRecord(payload, "Request body must be an object.");
+
+  return {
+    displayName: readOptionalBoundedString(input.displayName, "displayName", 80),
+    bio: readOptionalBoundedString(input.bio, "bio", 280),
+    avatarUrl: readOptionalHttpUrlString(input.avatarUrl, "avatarUrl", 500),
   };
 }
 
@@ -1525,6 +1652,64 @@ function readOptionalUrlString(value: unknown, fieldName: string): string | unde
     return new URL(parsed).toString();
   } catch {
     throw createHttpError(400, "validation_error", `${fieldName} must be a valid URL.`);
+  }
+}
+
+function readOptionalBoundedString(
+  value: unknown,
+  fieldName: string,
+  maxLength: number,
+): string | undefined {
+  if (value === undefined || value === null || value === "") {
+    return undefined;
+  }
+
+  if (typeof value !== "string") {
+    throw createHttpError(400, "validation_error", `${fieldName} must be a string.`);
+  }
+
+  const normalized = value.trim();
+
+  if (normalized.length === 0) {
+    return undefined;
+  }
+
+  if (normalized.length > maxLength) {
+    throw createHttpError(
+      400,
+      "validation_error",
+      `${fieldName} must be at most ${maxLength} characters.`,
+    );
+  }
+
+  return normalized;
+}
+
+function readOptionalHttpUrlString(
+  value: unknown,
+  fieldName: string,
+  maxLength: number,
+): string | undefined {
+  const parsed = readOptionalBoundedString(value, fieldName, maxLength);
+
+  if (!parsed) {
+    return undefined;
+  }
+
+  try {
+    const normalized = new URL(parsed);
+
+    if (normalized.protocol !== "http:" && normalized.protocol !== "https:") {
+      throw new Error("unsupported_protocol");
+    }
+
+    return normalized.toString();
+  } catch {
+    throw createHttpError(
+      400,
+      "validation_error",
+      `${fieldName} must be a valid http or https URL.`,
+    );
   }
 }
 

--- a/apps/api/src/auth-store.ts
+++ b/apps/api/src/auth-store.ts
@@ -1,4 +1,5 @@
 import type {
+  AccountProfile,
   Actor,
   AuthDevice,
   AuthPasskey,
@@ -6,10 +7,12 @@ import type {
   CompleteRegistrationVerificationInput,
   PasskeyAuthenticationOptions,
   PasskeyRegistrationOptions,
+  PublicProfile,
   RedeemPairingInput,
   RegistrationSession,
   StartAuthenticationInput,
   StartRegistrationInput,
+  UpdateAccountProfileInput,
   WebSession,
 } from "@theagentforum/core";
 
@@ -82,6 +85,12 @@ export interface AuthStore {
   revokeWebSession(token: string): Promise<void>;
   getApiTokenSession(token: string): Promise<ApiTokenSession | null>;
   revokeApiToken(token: string): Promise<void>;
+  getAccountProfile(accountId: string): Promise<AccountProfile | null>;
+  updateAccountProfile(
+    accountId: string,
+    input: UpdateAccountProfileInput,
+  ): Promise<AccountProfile | null>;
+  getPublicProfileByHandle(handle: string): Promise<PublicProfile | null>;
   listAccountPasskeys(accountId: string): Promise<AuthPasskey[]>;
   removeAccountPasskey(accountId: string, credentialId: string): Promise<RemovePasskeyResult>;
   listAccountDevices(accountId: string): Promise<AuthDevice[]>;

--- a/apps/api/src/http.test.ts
+++ b/apps/api/src/http.test.ts
@@ -20,9 +20,37 @@ const agentAuthor = {
 describe("HTTP API", () => {
   it("serves the full question -> answer -> accept flow", async () => {
     const app = createTestApp();
+    const pairing = await requestJson(app, "/auth/registrations/start", {
+      method: "POST",
+      body: {
+        handle: "felix796",
+        displayName: "Felix",
+      },
+    });
+    const registrationId = pairing.body.data.id;
+    const pairingCode = pairing.body.data.pairing.code;
+
+    await requestJson(app, `/auth/registrations/${registrationId}/verify`, {
+      method: "POST",
+      body: {
+        passkeyLabel: "Felix CLI Passkey",
+      },
+    });
+
+    const redeemed = await requestJson(app, "/auth/pairings/redeem", {
+      method: "POST",
+      body: {
+        pairingCode,
+        deviceLabel: "pixel-cli",
+      },
+    });
+    const authHeader = {
+      authorization: `Bearer ${redeemed.body.data.pairing.token}`,
+    };
 
     const createQuestionResponse = await requestJson(app, "/questions", {
       method: "POST",
+      headers: authHeader,
       body: {
         title: "What should the first API support?",
         body: "Questions and accepted answers.",
@@ -36,6 +64,7 @@ describe("HTTP API", () => {
 
     const firstAnswerResponse = await requestJson(app, `/questions/${question.id}/answers`, {
       method: "POST",
+      headers: authHeader,
       body: {
         body: "Ship the smallest possible workflow first.",
         author: agentAuthor,
@@ -47,6 +76,7 @@ describe("HTTP API", () => {
 
     const secondAnswerResponse = await requestJson(app, `/questions/${question.id}/answers`, {
       method: "POST",
+      headers: authHeader,
       body: {
         body: "Add acceptance before reputation.",
         author: humanAuthor,
@@ -60,6 +90,7 @@ describe("HTTP API", () => {
       `/questions/${question.id}/accept/${answerToAccept.id}`,
       {
         method: "POST",
+        headers: authHeader,
       },
     );
 

--- a/apps/api/src/http.webauthn.test.ts
+++ b/apps/api/src/http.webauthn.test.ts
@@ -547,6 +547,69 @@ describe("HTTP API - WebAuthn registration", () => {
     assert.equal(currentSession.body.data.actor.displayName, "Session Felix");
   });
 
+  it("reads and updates the signed-in profile without letting later auth flows overwrite it", async () => {
+    const app = createTestApp();
+
+    const signedIn = await signInWithPasskey(app, {
+      handle: "profile-owner@example.com",
+      displayName: "Profile Owner",
+    });
+
+    const beforeUpdate = await requestJson(app, "/profile", {
+      headers: {
+        cookie: signedIn.cookieHeader,
+      },
+    });
+
+    assert.equal(beforeUpdate.status, 200);
+    assert.equal(beforeUpdate.body.data.handle, "profile-owner@example.com");
+    assert.equal(beforeUpdate.body.data.displayName, "Profile Owner");
+    assert.equal(beforeUpdate.body.data.bio, undefined);
+
+    const updated = await requestJson(app, "/profile", {
+      method: "PATCH",
+      headers: {
+        cookie: signedIn.cookieHeader,
+      },
+      body: {
+        displayName: "Launch Owner",
+        bio: "Ships the launch checklist.",
+        avatarUrl: "https://example.com/avatar.png",
+      },
+    });
+
+    assert.equal(updated.status, 200);
+    assert.equal(updated.body.data.displayName, "Launch Owner");
+    assert.equal(updated.body.data.bio, "Ships the launch checklist.");
+    assert.equal(updated.body.data.avatarUrl, "https://example.com/avatar.png");
+
+    const refreshedSession = await requestJson(app, "/auth/session", {
+      headers: {
+        cookie: signedIn.cookieHeader,
+      },
+    });
+
+    assert.equal(refreshedSession.status, 200);
+    assert.equal(refreshedSession.body.data.actor.displayName, "Launch Owner");
+
+    await requestJson(app, "/auth/registrations/start", {
+      method: "POST",
+      body: {
+        handle: "profile-owner@example.com",
+        displayName: "Stale Derived Name",
+      },
+    });
+
+    const afterRegistrationRestart = await requestJson(app, "/profile", {
+      headers: {
+        cookie: signedIn.cookieHeader,
+      },
+    });
+
+    assert.equal(afterRegistrationRestart.status, 200);
+    assert.equal(afterRegistrationRestart.body.data.displayName, "Launch Owner");
+  });
+
   it("requires a web session for protected v2 writes and attributes writes to the signed-in actor", async () => {
     const app = createTestApp();
 
@@ -649,6 +712,210 @@ describe("HTTP API - WebAuthn registration", () => {
 
     assert.equal(accepted.status, 200);
     assert.equal(accepted.body.data.content.acceptedCommentId, commentId);
+  });
+
+  it("forbids accepting a reply from a different authenticated actor", async () => {
+    const app = createTestApp();
+
+    const owner = await signInWithPasskey(app, {
+      handle: "owner@example.com",
+      displayName: "Owner",
+      fixture: createPasskeyFixture("accept-owner"),
+    });
+    const responder = await signInWithPasskey(app, {
+      handle: "responder@example.com",
+      displayName: "Responder",
+      fixture: createPasskeyFixture("accept-responder"),
+    });
+
+    const created = await requestJson(app, "/v2/contents", {
+      method: "POST",
+      headers: {
+        cookie: owner.cookieHeader,
+      },
+      body: {
+        type: "question",
+        title: "Who can accept this?",
+        body: "Only the original author should be able to.",
+        author: {
+          id: "spoofed-user",
+          kind: "agent",
+          handle: "spoofed",
+        },
+      },
+    });
+
+    const contentId = created.body.data.id as string;
+    const replied = await requestJson(app, `/v2/contents/${contentId}/comments`, {
+      method: "POST",
+      headers: {
+        cookie: responder.cookieHeader,
+      },
+      body: {
+        body: "Responder reply",
+        author: {
+          id: "spoofed-commenter",
+          kind: "agent",
+          handle: "spoofed-commenter",
+        },
+      },
+    });
+
+    const commentId = replied.body.data.comments[0].id as string;
+
+    const forbidden = await requestJson(app, `/v2/contents/${contentId}/accept/${commentId}`, {
+      method: "POST",
+      headers: {
+        cookie: responder.cookieHeader,
+      },
+    });
+
+    assert.equal(forbidden.status, 403);
+    assert.equal(forbidden.body.error.code, "answer_accept_forbidden");
+
+    const accepted = await requestJson(app, `/v2/contents/${contentId}/accept/${commentId}`, {
+      method: "POST",
+      headers: {
+        cookie: owner.cookieHeader,
+      },
+    });
+
+    assert.equal(accepted.status, 200);
+    assert.equal(accepted.body.data.content.acceptedCommentId, commentId);
+  });
+
+  it("covers the end-to-end signup, profile, posting, reply, accept, pairing, and token inspect smoke path", async () => {
+    const app = createTestApp();
+    const fixture = createPasskeyFixture("launch-smoke");
+
+    const started = await requestJson(app, "/auth/registrations/start", {
+      method: "POST",
+      body: {
+        handle: "launch-smoke@example.com",
+        displayName: "Launch Smoke",
+      },
+    });
+
+    const registrationId = started.body.data.id as string;
+    const pairingCode = started.body.data.pairing.code as string;
+    const registrationOptions = await requestJson(app, `/auth/registrations/${registrationId}/passkey/options`, {
+      headers: {
+        origin: "http://localhost:5173",
+      },
+    });
+
+    const registered = await requestJson(app, "/auth/passkeys/register", {
+      method: "POST",
+      headers: {
+        origin: "http://localhost:5173",
+      },
+      body: {
+        registrationSessionId: registrationId,
+        credential: fixture.createRegistrationCredential({
+          challenge: registrationOptions.body.data.challenge,
+          origin: "http://localhost:5173",
+          rpId: "localhost",
+        }),
+        passkeyLabel: "Launch Smoke Passkey",
+      },
+    });
+
+    assert.equal(registered.status, 200);
+    assert.equal(registered.body.data.status, "verified");
+
+    const paired = await requestJson(app, "/auth/pairings/redeem", {
+      method: "POST",
+      body: {
+        pairingCode,
+        deviceLabel: "launch-smoke-cli",
+      },
+    });
+
+    assert.equal(paired.status, 200);
+    assert.equal(paired.body.data.pairing.status, "paired");
+    const apiToken = paired.body.data.pairing.token as string;
+    assert.ok(apiToken);
+
+    const signedIn = await signInWithPasskey(app, {
+      handle: "launch-smoke@example.com",
+      displayName: "Launch Smoke",
+      fixture,
+      passkeyLabel: "Launch Smoke Passkey",
+    });
+
+    const updatedProfile = await requestJson(app, "/profile", {
+      method: "PATCH",
+      headers: {
+        cookie: signedIn.cookieHeader,
+      },
+      body: {
+        displayName: "Launch Smoke",
+        bio: "Exercises the live-user smoke path.",
+        avatarUrl: "https://example.com/launch-smoke.png",
+      },
+    });
+
+    assert.equal(updatedProfile.status, 200);
+    assert.equal(updatedProfile.body.data.bio, "Exercises the live-user smoke path.");
+
+    const created = await requestJson(app, "/v2/contents", {
+      method: "POST",
+      headers: {
+        cookie: signedIn.cookieHeader,
+      },
+      body: {
+        type: "question",
+        title: "Can the launch path post end to end?",
+        body: "Need a full smoke pass across auth, forum, and pairing.",
+        author: {
+          id: "spoofed-user",
+          kind: "agent",
+          handle: "spoofed",
+        },
+      },
+    });
+
+    assert.equal(created.status, 201);
+    const contentId = created.body.data.id as string;
+
+    const replied = await requestJson(app, `/v2/contents/${contentId}/comments`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${apiToken}`,
+      },
+      body: {
+        body: "Yes. Pairing token writes can reply too.",
+        author: {
+          id: "spoofed-commenter",
+          kind: "agent",
+          handle: "spoofed-commenter",
+        },
+      },
+    });
+
+    assert.equal(replied.status, 201);
+    const commentId = replied.body.data.comments[0].id as string;
+    assert.equal(replied.body.data.comments[0].author.handle, "launch-smoke@example.com");
+
+    const accepted = await requestJson(app, `/v2/contents/${contentId}/accept/${commentId}`, {
+      method: "POST",
+      headers: {
+        cookie: signedIn.cookieHeader,
+      },
+    });
+
+    assert.equal(accepted.status, 200);
+    assert.equal(accepted.body.data.content.acceptedCommentId, commentId);
+
+    const tokenSession = await requestJson(app, "/auth/token", {
+      headers: {
+        authorization: `Bearer ${apiToken}`,
+      },
+    });
+
+    assert.equal(tokenSession.status, 200);
+    assert.equal(tokenSession.body.data.actor.handle, "launch-smoke@example.com");
+    assert.equal(tokenSession.body.data.deviceLabel, "launch-smoke-cli");
   });
 
   it("clears the active web session on sign-out", async () => {

--- a/apps/api/src/memory-auth-store.ts
+++ b/apps/api/src/memory-auth-store.ts
@@ -1,5 +1,6 @@
 import { randomBytes } from "node:crypto";
 import type {
+  AccountProfile,
   Actor,
   AuthDevice,
   AuthPasskey,
@@ -8,10 +9,12 @@ import type {
   PairingSession,
   PasskeyAuthenticationOptions,
   PasskeyRegistrationOptions,
+  PublicProfile,
   RedeemPairingInput,
   RegistrationSession,
   StartAuthenticationInput,
   StartRegistrationInput,
+  UpdateAccountProfileInput,
   WebSession,
 } from "@theagentforum/core";
 import type {
@@ -68,6 +71,10 @@ interface StoredAccount {
   id: string;
   handle: string;
   displayName?: string;
+  bio?: string;
+  avatarUrl?: string;
+  createdAt: string;
+  updatedAt: string;
 }
 
 interface StoredWebSession {
@@ -302,7 +309,7 @@ export function createInMemoryAuthStore(): AuthStore {
     const session: StoredAuthenticationSession = {
       id: `aas-${authenticationSequence++}`,
       handle: input.handle,
-      displayName: latestRegistration?.displayName ?? account?.displayName,
+      displayName: account?.displayName ?? latestRegistration?.displayName,
       status: "awaiting_authentication",
       challenge: createChallenge(),
       createdAt,
@@ -437,12 +444,7 @@ export function createInMemoryAuthStore(): AuthStore {
     const token = createWebSessionToken();
     const session: StoredWebSession = {
       token,
-      actor: {
-        id: account.id,
-        kind: "human",
-        handle: account.handle,
-        displayName: account.displayName,
-      },
+      actor: createStoredActor(account),
       createdAt,
       expiresAt,
     };
@@ -450,7 +452,7 @@ export function createInMemoryAuthStore(): AuthStore {
     webSessionsByToken.set(token, session);
     return {
       token,
-      actor: { ...session.actor },
+      actor: createStoredActor(account),
       createdAt,
       expiresAt,
     };
@@ -468,8 +470,10 @@ export function createInMemoryAuthStore(): AuthStore {
       return null;
     }
 
+    const account = accountsByHandle.get(session.actor.handle);
+
     return {
-      actor: { ...session.actor },
+      actor: account ? createStoredActor(account) : { ...session.actor },
       createdAt: session.createdAt,
       expiresAt: session.expiresAt,
     };
@@ -503,12 +507,7 @@ export function createInMemoryAuthStore(): AuthStore {
     const account = ensureAccount(session.handle, session.displayName);
 
     return {
-      actor: {
-        id: account.id,
-        kind: "human",
-        handle: account.handle,
-        displayName: account.displayName,
-      },
+      actor: createStoredActor(account),
       createdAt: session.pairing.createdAt,
       expiresAt: session.pairing.expiresAt,
       deviceLabel: session.pairing.deviceLabel,
@@ -528,6 +527,44 @@ export function createInMemoryAuthStore(): AuthStore {
     if (session.pairing.status === "paired") {
       session.pairing.status = "expired";
     }
+  }
+
+  async function getAccountProfile(accountId: string): Promise<AccountProfile | null> {
+    const account = Array.from(accountsByHandle.values()).find((candidate) => candidate.id === accountId);
+    return account ? cloneAccountProfile(account) : null;
+  }
+
+  async function updateAccountProfile(
+    accountId: string,
+    input: UpdateAccountProfileInput,
+  ): Promise<AccountProfile | null> {
+    const account = Array.from(accountsByHandle.values()).find((candidate) => candidate.id === accountId);
+
+    if (!account) {
+      return null;
+    }
+
+    account.displayName = input.displayName;
+    account.bio = input.bio;
+    account.avatarUrl = input.avatarUrl;
+    account.updatedAt = new Date().toISOString();
+
+    return cloneAccountProfile(account);
+  }
+
+  async function getPublicProfileByHandle(handle: string): Promise<PublicProfile | null> {
+    const account = accountsByHandle.get(handle);
+
+    if (!account) {
+      return null;
+    }
+
+    return {
+      handle: account.handle,
+      displayName: account.displayName,
+      bio: account.bio,
+      avatarUrl: account.avatarUrl,
+    };
   }
 
   async function listAccountPasskeys(accountId: string): Promise<AuthPasskey[]> {
@@ -623,15 +660,19 @@ export function createInMemoryAuthStore(): AuthStore {
     if (existing) {
       if (displayName && !existing.displayName) {
         existing.displayName = displayName;
+        existing.updatedAt = new Date().toISOString();
       }
 
       return existing;
     }
 
+    const createdAt = new Date().toISOString();
     const account: StoredAccount = {
       id: `acct-${accountSequence++}`,
       handle,
       displayName,
+      createdAt,
+      updatedAt: createdAt,
     };
     accountsByHandle.set(handle, account);
     return account;
@@ -655,6 +696,9 @@ export function createInMemoryAuthStore(): AuthStore {
     revokeWebSession,
     getApiTokenSession,
     revokeApiToken,
+    getAccountProfile,
+    updateAccountProfile,
+    getPublicProfileByHandle,
     listAccountPasskeys,
     removeAccountPasskey,
     listAccountDevices,
@@ -702,6 +746,27 @@ function expireAuthenticationSessionIfNeeded(session: StoredAuthenticationSessio
 
 function isAuthenticatablePasskey(credential: StoredCredential): boolean {
   return !credential.credentialId.startsWith("manual-");
+}
+
+function createStoredActor(account: StoredAccount): Actor {
+  return {
+    id: account.id,
+    kind: "human",
+    handle: account.handle,
+    displayName: account.displayName,
+  };
+}
+
+function cloneAccountProfile(account: StoredAccount): AccountProfile {
+  return {
+    id: account.id,
+    handle: account.handle,
+    displayName: account.displayName,
+    bio: account.bio,
+    avatarUrl: account.avatarUrl,
+    createdAt: account.createdAt,
+    updatedAt: account.updatedAt,
+  };
 }
 
 function cloneRegistrationSession(session: StoredRegistrationSession): RegistrationSession {

--- a/apps/api/src/postgres-auth-store.ts
+++ b/apps/api/src/postgres-auth-store.ts
@@ -1,16 +1,18 @@
 import { randomBytes } from "node:crypto";
 import type {
+  AccountProfile,
   AuthenticationSession,
-  Actor,
   AuthDevice,
   AuthPasskey,
   CompleteRegistrationVerificationInput,
   PasskeyAuthenticationOptions,
   PasskeyRegistrationOptions,
+  PublicProfile,
   RedeemPairingInput,
   RegistrationSession,
   StartAuthenticationInput,
   StartRegistrationInput,
+  UpdateAccountProfileInput,
   WebSession,
 } from "@theagentforum/core";
 import { runSql } from "./postgres";
@@ -44,6 +46,9 @@ export function createPostgresAuthStore(): AuthStore {
     revokeWebSession,
     getApiTokenSession,
     revokeApiToken,
+    getAccountProfile,
+    updateAccountProfile,
+    getPublicProfileByHandle,
     listAccountPasskeys,
     removeAccountPasskey,
     listAccountDevices,
@@ -60,7 +65,6 @@ async function startRegistration(input: StartRegistrationInput): Promise<Registr
         values (:'handle', nullif(:'display_name', ''))
         on conflict (handle)
         do update set
-          display_name = coalesce(nullif(excluded.display_name, ''), auth_accounts.display_name),
           updated_at = now()
         returning id, handle, display_name
       ),
@@ -639,6 +643,79 @@ async function revokeApiToken(token: string): Promise<void> {
     `,
     { token },
   );
+}
+
+async function getAccountProfile(accountId: string): Promise<AccountProfile | null> {
+  const output = await runSql(
+    `
+      select json_strip_nulls(json_build_object(
+        'id', id,
+        'handle', handle,
+        'displayName', display_name,
+        'bio', bio,
+        'avatarUrl', avatar_url,
+        'createdAt', to_char(created_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+        'updatedAt', to_char(updated_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+      )) :: text
+      from auth_accounts
+      where id = :'account_id';
+    `,
+    { account_id: accountId },
+  );
+
+  return output ? (JSON.parse(output) as AccountProfile) : null;
+}
+
+async function updateAccountProfile(
+  accountId: string,
+  input: UpdateAccountProfileInput,
+): Promise<AccountProfile | null> {
+  const output = await runSql(
+    `
+      update auth_accounts
+      set
+        display_name = nullif(:'display_name', ''),
+        bio = nullif(:'bio', ''),
+        avatar_url = nullif(:'avatar_url', ''),
+        updated_at = now()
+      where id = :'account_id'
+      returning json_strip_nulls(json_build_object(
+        'id', id,
+        'handle', handle,
+        'displayName', display_name,
+        'bio', bio,
+        'avatarUrl', avatar_url,
+        'createdAt', to_char(created_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+        'updatedAt', to_char(updated_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+      )) :: text;
+    `,
+    {
+      account_id: accountId,
+      display_name: input.displayName ?? "",
+      bio: input.bio ?? "",
+      avatar_url: input.avatarUrl ?? "",
+    },
+  );
+
+  return output ? (JSON.parse(output) as AccountProfile) : null;
+}
+
+async function getPublicProfileByHandle(handle: string): Promise<PublicProfile | null> {
+  const output = await runSql(
+    `
+      select json_strip_nulls(json_build_object(
+        'handle', handle,
+        'displayName', display_name,
+        'bio', bio,
+        'avatarUrl', avatar_url
+      )) :: text
+      from auth_accounts
+      where handle = :'handle';
+    `,
+    { handle },
+  );
+
+  return output ? (JSON.parse(output) as PublicProfile) : null;
 }
 
 async function listAccountPasskeys(accountId: string): Promise<AuthPasskey[]> {

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -13,6 +13,10 @@ COPY docs/skills/theagentforum docs/skills/theagentforum
 
 ARG VITE_API_BASE_URL=/api
 ENV VITE_API_BASE_URL=${VITE_API_BASE_URL}
+ARG VITE_POSTHOG_KEY=
+ENV VITE_POSTHOG_KEY=${VITE_POSTHOG_KEY}
+ARG VITE_POSTHOG_HOST=https://us.i.posthog.com
+ENV VITE_POSTHOG_HOST=${VITE_POSTHOG_HOST}
 
 RUN npm run build --workspace @theagentforum/web
 

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -36,6 +36,11 @@ The refreshed UI keeps the same route and API flow:
 
 Set `VITE_API_BASE_URL` only when you need a different target.
 
+Optional frontend analytics:
+
+- `VITE_POSTHOG_KEY` enables explicit signup/login/profile/posting/pairing funnel events.
+- `VITE_POSTHOG_HOST` overrides the PostHog ingest host and defaults to `https://us.i.posthog.com`.
+
 Example:
 
 ```bash

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -7,6 +7,7 @@ import {
   type Location,
 } from "react-router-dom";
 import { AuthProvider } from "./auth/AuthContext";
+import { PostHogPageViewTracker } from "./components/PostHogPageViewTracker";
 import { createApiClient } from "./lib/api";
 import { AuthPage } from "./pages/AuthPage";
 import { MyAgentsPage } from "./pages/MyAgentsPage";
@@ -23,6 +24,7 @@ function AppRoutes() {
 
   return (
     <>
+      <PostHogPageViewTracker />
       <Routes location={backgroundLocation ?? location}>
         <Route path="/" element={<LandingPage api={api} />} />
         <Route path="/forum" element={<ForumPage api={api} />} />
@@ -30,7 +32,7 @@ function AppRoutes() {
         <Route path="/posts/:postId" element={<PostDetailPage api={api} />} />
         <Route path="/auth" element={<AuthPage api={api} />} />
         <Route path="/settings" element={<SettingsPage api={api} />} />
-        <Route path="/profile" element={<ProfilePage />} />
+        <Route path="/profile" element={<ProfilePage api={api} />} />
         <Route path="/my-agents" element={<MyAgentsPage api={api} />} />
         <Route path="/threads/:questionId" element={<PostDetailPage api={api} />} />
         <Route path="/questions/:questionId" element={<PostDetailPage api={api} />} />

--- a/apps/web/src/auth/AuthContext.tsx
+++ b/apps/web/src/auth/AuthContext.tsx
@@ -8,6 +8,7 @@ import {
   type PropsWithChildren,
 } from "react";
 import type { ApiClient } from "../lib/api";
+import { identifyActor } from "../lib/posthog";
 import { readErrorMessage } from "../lib/ui";
 import type { WebSession } from "../types";
 
@@ -69,6 +70,10 @@ export function AuthProvider({ api, children }: AuthProviderProps) {
   useEffect(() => {
     void refreshSession();
   }, [refreshSession]);
+
+  useEffect(() => {
+    identifyActor(session?.actor ?? null);
+  }, [session?.actor.id, session?.actor.kind]);
 
   const value = useMemo<AuthContextValue>(
     () => ({

--- a/apps/web/src/components/PostHogPageViewTracker.tsx
+++ b/apps/web/src/components/PostHogPageViewTracker.tsx
@@ -1,0 +1,20 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+import { captureClientEvent, isPostHogEnabled } from "../lib/posthog";
+
+export function PostHogPageViewTracker() {
+  const location = useLocation();
+
+  useEffect(() => {
+    if (!isPostHogEnabled()) {
+      return;
+    }
+
+    captureClientEvent("$pageview", {
+      pathname: location.pathname,
+      search: location.search,
+    });
+  }, [location.pathname, location.search]);
+
+  return null;
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,4 +1,5 @@
 import type {
+  AccountProfile,
   Answer,
   AnswerSkill,
   AuthDevice,
@@ -11,6 +12,7 @@ import type {
   FinishRegistrationInput,
   PasskeyAuthenticationOptions,
   PasskeyRegistrationOptions,
+  PublicProfile,
   Question,
   SearchMatchSource,
   QuestionThread,
@@ -19,6 +21,7 @@ import type {
   StartAuthenticationInput,
   StartRegistrationInput,
   ThreadSearchResult,
+  UpdateAccountProfileInput,
   WebSession,
 } from "../types";
 
@@ -267,6 +270,18 @@ export function createApiClient(baseUrl = defaultBaseUrl) {
     return request<WebSession | null>("GET", "/auth/session");
   }
 
+  async function getMyProfile(): Promise<AccountProfile> {
+    return request<AccountProfile>("GET", "/profile");
+  }
+
+  async function updateMyProfile(input: UpdateAccountProfileInput): Promise<AccountProfile> {
+    return request<AccountProfile>("PATCH", "/profile", input);
+  }
+
+  async function getPublicProfile(handle: string): Promise<PublicProfile> {
+    return request<PublicProfile>("GET", `/profiles/${encodeURIComponent(handle)}`);
+  }
+
   async function listPasskeys(): Promise<AuthPasskey[]> {
     return request<AuthPasskey[]>("GET", "/auth/passkeys");
   }
@@ -288,7 +303,7 @@ export function createApiClient(baseUrl = defaultBaseUrl) {
   }
 
   async function request<T>(
-    method: "GET" | "POST" | "DELETE",
+    method: "GET" | "POST" | "PATCH" | "DELETE",
     path: string,
     body?: unknown,
   ): Promise<T> {
@@ -338,6 +353,9 @@ export function createApiClient(baseUrl = defaultBaseUrl) {
     getPasskeyAuthenticationOptions,
     authenticatePasskey,
     getAuthSession,
+    getMyProfile,
+    updateMyProfile,
+    getPublicProfile,
     listPasskeys,
     removePasskey,
     listDevices,

--- a/apps/web/src/lib/posthog.ts
+++ b/apps/web/src/lib/posthog.ts
@@ -1,0 +1,96 @@
+import type { Actor } from "../types";
+
+const DEFAULT_POSTHOG_HOST = "https://us.i.posthog.com";
+const DISTINCT_ID_STORAGE_KEY = "taf.posthog.distinct_id";
+
+const posthogKey = import.meta.env.VITE_POSTHOG_KEY?.trim();
+const posthogHost = (import.meta.env.VITE_POSTHOG_HOST?.trim() || DEFAULT_POSTHOG_HOST).replace(/\/$/, "");
+
+let initialized = false;
+let anonymousDistinctId: string | null = null;
+let actorContext: Pick<Actor, "id" | "kind"> | null = null;
+
+export function initPostHog(): void {
+  if (initialized || !isPostHogEnabled()) {
+    return;
+  }
+
+  anonymousDistinctId = getAnonymousDistinctId();
+  initialized = true;
+}
+
+export function isPostHogEnabled(): boolean {
+  return Boolean(posthogKey) && typeof window !== "undefined";
+}
+
+export function identifyActor(actor: Pick<Actor, "id" | "kind"> | null | undefined): void {
+  actorContext = actor ? { id: actor.id, kind: actor.kind } : null;
+}
+
+export function captureClientEvent(
+  event: string,
+  properties: Record<string, unknown> = {},
+): void {
+  if (!isPostHogEnabled() || !posthogKey) {
+    return;
+  }
+
+  const payload = {
+    api_key: posthogKey,
+    event,
+    distinct_id: actorContext?.id ?? getAnonymousDistinctId(),
+    properties: {
+      source: "theagentforum-web",
+      actor_id: actorContext?.id,
+      actor_kind: actorContext?.kind,
+      pathname: window.location.pathname,
+      search: window.location.search,
+      url: window.location.href,
+      ...properties,
+    },
+  };
+
+  void fetch(`${posthogHost}/capture/`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(payload),
+    keepalive: true,
+  }).catch(() => undefined);
+}
+
+function getAnonymousDistinctId(): string {
+  if (anonymousDistinctId) {
+    return anonymousDistinctId;
+  }
+
+  if (!isPostHogEnabled()) {
+    return "taf-web-disabled";
+  }
+
+  try {
+    const existing = window.localStorage.getItem(DISTINCT_ID_STORAGE_KEY)?.trim();
+
+    if (existing) {
+      anonymousDistinctId = existing;
+      return existing;
+    }
+
+    const created = createDistinctId();
+    window.localStorage.setItem(DISTINCT_ID_STORAGE_KEY, created);
+    anonymousDistinctId = created;
+    return created;
+  } catch {
+    anonymousDistinctId = createDistinctId();
+    return anonymousDistinctId;
+  }
+}
+
+function createDistinctId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+
+  return `taf-web-${Math.random().toString(36).slice(2, 12)}`;
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./App";
+import { initPostHog } from "./lib/posthog";
 import "./styles.css";
 
 const rootElement = document.getElementById("root");
@@ -8,6 +9,8 @@ const rootElement = document.getElementById("root");
 if (!rootElement) {
   throw new Error("Missing #root element.");
 }
+
+initPostHog();
 
 createRoot(rootElement).render(
   <StrictMode>

--- a/apps/web/src/pages/AuthPage.test.tsx
+++ b/apps/web/src/pages/AuthPage.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthProvider } from "../auth/AuthContext";
 import type { ApiClient } from "../lib/api";
 import { AuthPage } from "./AuthPage";
 
@@ -143,6 +144,99 @@ describe("AuthPage", () => {
         authenticatorAttachment: "platform",
         clientExtensionResults: { credProps: { rk: true } },
       },
+    });
+  });
+
+  it("redirects newly signed-in users with incomplete profiles to onboarding", async () => {
+    const user = userEvent.setup();
+    const getCredential = vi.fn().mockResolvedValue(
+      buildAuthenticationCredential({
+        credentialId: Uint8Array.from([1, 2, 3, 4]),
+        clientDataJson: new TextEncoder().encode(
+          JSON.stringify({
+            type: "webauthn.get",
+            challenge: "AQIDBA",
+            origin: window.location.origin,
+          }),
+        ),
+        authenticatorData: Uint8Array.from([9, 8, 7, 6]),
+        signature: Uint8Array.from([4, 3, 2, 1]),
+      }),
+    );
+
+    Object.defineProperty(navigator, "credentials", {
+      configurable: true,
+      value: {
+        get: getCredential,
+      },
+    });
+
+    const api = buildApi({
+      startAuthentication: vi.fn().mockResolvedValue({
+        id: "aas-1",
+        handle: "eric@example.com",
+        displayName: "Eric",
+        status: "awaiting_authentication",
+        challenge: "AQIDBA",
+        createdAt: "2026-03-26T00:00:00.000Z",
+        expiresAt: "2026-03-26T00:15:00.000Z",
+      }),
+      getPasskeyAuthenticationOptions: vi.fn().mockResolvedValue({
+        authenticationSessionId: "aas-1",
+        challenge: "AQIDBA",
+        rpId: "localhost",
+        allowCredentials: [{ id: "AQIDBA", type: "public-key", transports: ["internal"] }],
+        timeout: 60000,
+        userVerification: "required",
+      }),
+      authenticatePasskey: vi.fn().mockResolvedValue({
+        id: "aas-1",
+        handle: "eric@example.com",
+        displayName: "Eric",
+        status: "verified",
+        challenge: "AQIDBA",
+        verificationMethod: "webauthn",
+        passkeyLabel: "Eric passkey",
+        createdAt: "2026-03-26T00:00:00.000Z",
+        expiresAt: "2026-03-26T00:15:00.000Z",
+        verifiedAt: "2026-03-26T00:01:00.000Z",
+      }),
+      getAuthSession: vi.fn().mockResolvedValue({
+        actor: {
+          id: "acct-1",
+          kind: "human",
+          handle: "eric@example.com",
+          displayName: "Eric",
+        },
+        createdAt: "2026-03-26T00:00:00.000Z",
+        expiresAt: "2026-04-02T00:00:00.000Z",
+      }),
+      getMyProfile: vi.fn().mockResolvedValue({
+        id: "acct-1",
+        handle: "eric@example.com",
+        displayName: "Eric",
+        createdAt: "2026-03-26T00:00:00.000Z",
+        updatedAt: "2026-03-26T00:00:00.000Z",
+      }),
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/auth?mode=signin&returnTo=/done"]}>
+        <AuthProvider api={api}>
+          <Routes>
+            <Route path="/auth" element={<AuthPage api={api} />} />
+            <Route path="/profile" element={<p>profile onboarding</p>} />
+            <Route path="/done" element={<p>done</p>} />
+          </Routes>
+        </AuthProvider>
+      </MemoryRouter>,
+    );
+
+    await user.type(screen.getByLabelText("Email"), "Eric@Example.com");
+    await user.click(screen.getByRole("button", { name: /continue with passkey/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("profile onboarding")).toBeInTheDocument();
     });
   });
 
@@ -375,6 +469,16 @@ function buildApi(overrides: Partial<ApiClient> = {}): ApiClient {
     getPasskeyAuthenticationOptions: vi.fn(),
     authenticatePasskey: vi.fn(),
     getAuthSession: vi.fn().mockResolvedValue(null),
+    getMyProfile: vi.fn().mockResolvedValue({
+      id: "acct-1",
+      handle: "eric@example.com",
+      displayName: "Eric",
+      bio: "Complete profile",
+      createdAt: "2026-03-26T00:00:00.000Z",
+      updatedAt: "2026-03-26T00:00:00.000Z",
+    }),
+    updateMyProfile: vi.fn(),
+    getPublicProfile: vi.fn(),
     listPasskeys: vi.fn(),
     removePasskey: vi.fn(),
     listDevices: vi.fn(),

--- a/apps/web/src/pages/AuthPage.tsx
+++ b/apps/web/src/pages/AuthPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import { useAuth } from "../auth/AuthContext";
 import type { ApiClient } from "../lib/api";
+import { captureClientEvent } from "../lib/posthog";
 import {
   buildAuthPath,
   buildPairingAuthPath,
@@ -18,6 +19,7 @@ import type {
   PasskeyAuthenticationOptions,
   PasskeyRegistrationOptions,
   RegistrationSession,
+  WebSession,
 } from "../types";
 
 interface AuthPageProps {
@@ -76,7 +78,7 @@ interface EmailPasskeyAuthPageProps {
   api: ApiClient;
   presentation: "page" | "modal";
   returnTo: string;
-  onAuthStateChange: () => Promise<unknown>;
+  onAuthStateChange: () => Promise<WebSession | null>;
   sessionName: string | null;
   isAuthenticated: boolean;
 }
@@ -110,7 +112,10 @@ function EmailPasskeyAuthPage({
     navigate(returnTo, { replace: true });
   }
 
-  async function finishPasskeySignIn(nextIdentifier: string): Promise<void> {
+  async function finishPasskeySignIn(
+    nextIdentifier: string,
+    flow: "signin" | "signup",
+  ): Promise<void> {
     const authenticationSession = await api.startAuthentication({
       handle: nextIdentifier,
     });
@@ -122,7 +127,25 @@ function EmailPasskeyAuthPage({
       credential,
     });
 
-    await onAuthStateChange();
+    const nextSession = await onAuthStateChange();
+    captureClientEvent(flow === "signup" ? "taf_auth_signup_succeeded" : "taf_auth_signin_succeeded");
+
+    if (!nextSession?.actor.id) {
+      navigate(returnTo, { replace: true });
+      return;
+    }
+
+    try {
+      const profile = await api.getMyProfile();
+
+      if (profileNeedsOnboarding(profile) && !hasSkippedProfileOnboarding(profile.handle)) {
+        navigate(`/profile?onboarding=1&returnTo=${encodeURIComponent(returnTo)}`, { replace: true });
+        return;
+      }
+    } catch {
+      // Do not block sign-in completion if the profile prefetch fails.
+    }
+
     navigate(returnTo, { replace: true });
   }
 
@@ -137,11 +160,16 @@ function EmailPasskeyAuthPage({
     setBusy(true);
     setError(null);
     setStatusMessage(null);
+    captureClientEvent("taf_auth_signin_started");
 
     try {
-      await finishPasskeySignIn(nextIdentifier);
+      await finishPasskeySignIn(nextIdentifier, "signin");
     } catch (cause) {
-      setError(readErrorMessage(cause));
+      const message = readErrorMessage(cause);
+      setError(message);
+      captureClientEvent("taf_auth_signin_failed", {
+        error_message: message,
+      });
     } finally {
       setBusy(false);
     }
@@ -158,6 +186,7 @@ function EmailPasskeyAuthPage({
     setBusy(true);
     setError(null);
     setStatusMessage("Saving your passkey.");
+    captureClientEvent("taf_auth_signup_started");
 
     try {
       const displayName = deriveDisplayNameFromIdentifier(nextIdentifier);
@@ -176,10 +205,14 @@ function EmailPasskeyAuthPage({
       });
 
       setStatusMessage("Passkey saved. Finishing sign in.");
-      await finishPasskeySignIn(nextIdentifier);
+      await finishPasskeySignIn(nextIdentifier, "signup");
     } catch (cause) {
-      setError(readErrorMessage(cause));
+      const message = readErrorMessage(cause);
+      setError(message);
       setStatusMessage(null);
+      captureClientEvent("taf_auth_signup_failed", {
+        error_message: message,
+      });
     } finally {
       setBusy(false);
     }
@@ -440,6 +473,7 @@ function PairingAuthPage({
 
     setStarting(true);
     setError(null);
+    captureClientEvent("taf_pairing_started");
 
     try {
       const session = await api.startRegistration({
@@ -449,7 +483,12 @@ function PairingAuthPage({
       setRegistrationSession(session);
       setPasskeyLabel(`${session.displayName ?? session.handle} device passkey`);
     } catch (cause) {
-      setError(readErrorMessage(cause));
+      const message = readErrorMessage(cause);
+      setError(message);
+      captureClientEvent("taf_pairing_failed", {
+        stage: "start",
+        error_message: message,
+      });
     } finally {
       setStarting(false);
     }
@@ -493,8 +532,14 @@ function PairingAuthPage({
             passkeyLabel.trim() || `${options.user.displayName} passkey`,
         }),
       );
+      captureClientEvent("taf_pairing_passkey_registered");
     } catch (cause) {
-      setError(readErrorMessage(cause));
+      const message = readErrorMessage(cause);
+      setError(message);
+      captureClientEvent("taf_pairing_failed", {
+        stage: "passkey",
+        error_message: message,
+      });
     } finally {
       setCreatingPasskey(false);
     }
@@ -520,8 +565,16 @@ function PairingAuthPage({
           deviceLabel,
         }),
       );
+      captureClientEvent("taf_pairing_token_redeemed", {
+        device_label: deviceLabel,
+      });
     } catch (cause) {
-      setError(readErrorMessage(cause));
+      const message = readErrorMessage(cause);
+      setError(message);
+      captureClientEvent("taf_pairing_failed", {
+        stage: "redeem",
+        error_message: message,
+      });
     } finally {
       setRedeeming(false);
     }
@@ -1258,6 +1311,18 @@ function formatStatus(status: string): string {
     .split("_")
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
     .join(" ");
+}
+
+function profileNeedsOnboarding(profile: { bio?: string; avatarUrl?: string }): boolean {
+  return !profile.bio && !profile.avatarUrl;
+}
+
+function hasSkippedProfileOnboarding(handle: string): boolean {
+  try {
+    return window.localStorage.getItem(`taf.profile.onboarding.skip:${handle}`) === "1";
+  } catch {
+    return false;
+  }
 }
 
 function decodeMaybeBase64Url(value: string): Uint8Array {

--- a/apps/web/src/pages/ProfilePage.test.tsx
+++ b/apps/web/src/pages/ProfilePage.test.tsx
@@ -1,0 +1,108 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+import { AuthProvider } from "../auth/AuthContext";
+import type { ApiClient } from "../lib/api";
+import { ProfilePage } from "./ProfilePage";
+
+describe("ProfilePage", () => {
+  it("shows sign-in guidance when there is no authenticated session", async () => {
+    const api = {
+      getAuthSession: vi.fn().mockResolvedValue(null),
+      signOut: vi.fn(),
+    } as unknown as ApiClient;
+
+    render(
+      <MemoryRouter initialEntries={["/profile"]}>
+        <AuthProvider api={api}>
+          <ProfilePage api={api} />
+        </AuthProvider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: /sign in to edit your profile/i })).toBeInTheDocument();
+    });
+  });
+
+  it("loads the profile editor, saves updates, and exits onboarding", async () => {
+    const user = userEvent.setup();
+    const getAuthSession = vi
+      .fn()
+      .mockResolvedValueOnce({
+        actor: {
+          id: "acct-1",
+          kind: "human",
+          handle: "eric@example.com",
+          displayName: "Eric",
+        },
+        createdAt: "2026-04-24T03:00:00.000Z",
+        expiresAt: "2026-05-01T03:00:00.000Z",
+      })
+      .mockResolvedValueOnce({
+        actor: {
+          id: "acct-1",
+          kind: "human",
+          handle: "eric@example.com",
+          displayName: "Launch Eric",
+        },
+        createdAt: "2026-04-24T03:00:00.000Z",
+        expiresAt: "2026-05-01T03:00:00.000Z",
+      });
+
+    const api = {
+      getAuthSession,
+      getMyProfile: vi.fn().mockResolvedValue({
+        id: "acct-1",
+        handle: "eric@example.com",
+        displayName: "Eric",
+        createdAt: "2026-04-24T03:00:00.000Z",
+        updatedAt: "2026-04-24T03:00:00.000Z",
+      }),
+      updateMyProfile: vi.fn().mockResolvedValue({
+        id: "acct-1",
+        handle: "eric@example.com",
+        displayName: "Launch Eric",
+        bio: "Ships the launch checklist.",
+        createdAt: "2026-04-24T03:00:00.000Z",
+        updatedAt: "2026-04-29T03:00:00.000Z",
+      }),
+      signOut: vi.fn(),
+    } as unknown as ApiClient;
+
+    render(
+      <MemoryRouter initialEntries={["/profile?onboarding=1&returnTo=/forum"]}>
+        <Routes>
+          <Route
+            path="/profile"
+            element={(
+              <AuthProvider api={api}>
+                <ProfilePage api={api} />
+              </AuthProvider>
+            )}
+          />
+          <Route path="/forum" element={<p>forum stream</p>} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: /public profile fields/i })).toBeInTheDocument();
+    });
+
+    await user.clear(screen.getByLabelText("Display name"));
+    await user.type(screen.getByLabelText("Display name"), "Launch Eric");
+    await user.type(screen.getByLabelText("Bio"), "Ships the launch checklist.");
+    await user.click(screen.getByRole("button", { name: /save profile/i }));
+
+    await waitFor(() => {
+      expect(api.updateMyProfile).toHaveBeenCalledWith({
+        displayName: "Launch Eric",
+        bio: "Ships the launch checklist.",
+        avatarUrl: undefined,
+      });
+      expect(screen.getByText("forum stream")).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/pages/ProfilePage.tsx
+++ b/apps/web/src/pages/ProfilePage.tsx
@@ -1,20 +1,170 @@
-import { Link } from "react-router-dom";
+import { useEffect, useMemo, useState } from "react";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import { useAuth } from "../auth/AuthContext";
 import { AuthRequiredPanel } from "../components/AuthRequiredPanel";
 import { TerminalPage } from "../components/TerminalChrome";
-import { describeActor, formatDate } from "../lib/ui";
+import type { ApiClient } from "../lib/api";
+import { captureClientEvent } from "../lib/posthog";
+import { formatDate, readErrorMessage } from "../lib/ui";
+import type { AccountProfile, UpdateAccountProfileInput } from "../types";
 
-export function ProfilePage() {
+interface ProfilePageProps {
+  api: ApiClient;
+}
+
+const ONBOARDING_SKIP_PREFIX = "taf.profile.onboarding.skip";
+
+export function ProfilePage({ api }: ProfilePageProps) {
   const auth = useAuth();
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const onboarding = searchParams.get("onboarding") === "1";
+  const returnTo = readSafeReturnTo(searchParams.get("returnTo"));
+  const [profile, setProfile] = useState<AccountProfile | null>(null);
+  const [draft, setDraft] = useState<UpdateAccountProfileInput>({
+    displayName: "",
+    bio: "",
+    avatarUrl: "",
+  });
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!auth.ready) {
+      return;
+    }
+
+    if (!auth.session) {
+      setProfile(null);
+      setLoading(false);
+      return;
+    }
+
+    void loadProfile();
+  }, [auth.ready, auth.session?.actor.id]);
+
+  useEffect(() => {
+    if (!onboarding || !profile) {
+      return;
+    }
+
+    if (!profileNeedsAttention(profile)) {
+      navigate(returnTo, { replace: true });
+    }
+  }, [navigate, onboarding, profile, returnTo]);
+
+  async function loadProfile(): Promise<void> {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const nextProfile = await api.getMyProfile();
+      setProfile(nextProfile);
+      setDraft({
+        displayName: nextProfile.displayName ?? "",
+        bio: nextProfile.bio ?? "",
+        avatarUrl: nextProfile.avatarUrl ?? "",
+      });
+      captureClientEvent("taf_profile_viewed", {
+        onboarding,
+        profile_complete: !profileNeedsAttention(nextProfile),
+      });
+    } catch (cause) {
+      const message = readErrorMessage(cause);
+      setError(message);
+      captureClientEvent("taf_profile_view_failed", {
+        onboarding,
+        error_message: message,
+      });
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleSave(): Promise<void> {
+    if (!profile) {
+      return;
+    }
+
+    setSaving(true);
+    setError(null);
+    setNotice(null);
+
+    const nextInput: UpdateAccountProfileInput = {
+      displayName: normalizeDraftValue(draft.displayName),
+      bio: normalizeDraftValue(draft.bio),
+      avatarUrl: normalizeDraftValue(draft.avatarUrl),
+    };
+
+    captureClientEvent("taf_profile_update_started", {
+      onboarding,
+    });
+
+    try {
+      const updated = await api.updateMyProfile(nextInput);
+      setProfile(updated);
+      setDraft({
+        displayName: updated.displayName ?? "",
+        bio: updated.bio ?? "",
+        avatarUrl: updated.avatarUrl ?? "",
+      });
+      setNotice(onboarding ? "Profile saved. Returning to your previous route." : "Profile saved.");
+      clearOnboardingSkip(updated.handle);
+      await auth.refreshSession();
+      captureClientEvent("taf_profile_updated", {
+        onboarding,
+        profile_complete: !profileNeedsAttention(updated),
+      });
+
+      if (onboarding && !profileNeedsAttention(updated)) {
+        navigate(returnTo, { replace: true });
+      }
+    } catch (cause) {
+      const message = readErrorMessage(cause);
+      setError(message);
+      captureClientEvent("taf_profile_update_failed", {
+        onboarding,
+        error_message: message,
+      });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function handleSkip(): void {
+    if (!profile) {
+      return;
+    }
+
+    rememberOnboardingSkip(profile.handle);
+    captureClientEvent("taf_profile_onboarding_skipped", {
+      return_to: returnTo,
+    });
+    navigate(returnTo, { replace: true });
+  }
+
+  const isDirty = useMemo(() => {
+    if (!profile) {
+      return false;
+    }
+
+    return (
+      (profile.displayName ?? "") !== draft.displayName
+      || (profile.bio ?? "") !== draft.bio
+      || (profile.avatarUrl ?? "") !== draft.avatarUrl
+    );
+  }, [draft.avatarUrl, draft.bio, draft.displayName, profile]);
 
   return (
     <TerminalPage currentLabel={auth.session ? `profile: ${auth.session.actor.handle}` : "profile: locked"}>
       <section className="terminal-page-heading">
         <p className="terminal-eyebrow">/profile</p>
-        <h1>account profile</h1>
+        <h1>profile + identity</h1>
         <p className="terminal-lead">
-          This page stays intentionally small for MVP. It shows the identity attached to your active session and
-          provides the fastest path to account controls.
+          Your handle is stable for now. Display name, bio, and avatar stay editable so the public account surface
+          can ship without reopening the passkey-first auth flow.
         </p>
         <div className="terminal-actions">
           <Link className="terminal-link-button" to="/settings">
@@ -26,43 +176,151 @@ export function ProfilePage() {
         </div>
       </section>
 
-      {!auth.ready ? (
+      {onboarding ? (
+        <section className="terminal-side-card terminal-profile-banner">
+          <div>
+            <p className="terminal-eyebrow">post-login nudge</p>
+            <h2>Finish the minimum public profile</h2>
+            <p>
+              Add enough context that replies and paired-agent activity are not anonymous blobs. You can skip and come
+              back later.
+            </p>
+          </div>
+          <div className="terminal-actions">
+            <button
+              type="button"
+              className="terminal-mini-button"
+              onClick={handleSkip}
+              disabled={!profile || saving}
+            >
+              Skip for now
+            </button>
+          </div>
+        </section>
+      ) : null}
+
+      {error ? (
+        <p className="terminal-inline-error" role="alert">
+          {error}
+        </p>
+      ) : null}
+
+      {notice ? (
+        <p className="terminal-inline-success" role="status">
+          {notice}
+        </p>
+      ) : null}
+
+      {!auth.ready || loading ? (
         <article className="terminal-feed-card terminal-feed-card--post">
           <div className="terminal-feed-card__meta">
             <span className="terminal-type-badge">sync</span>
-            <span>checking your session</span>
+            <span>loading profile</span>
           </div>
-          <h2>Loading profile…</h2>
-          <p>Reading the current account session before showing profile details.</p>
+          <h2>Reading account profile…</h2>
+          <p>Pulling the live signed-in profile before opening the editor.</p>
         </article>
       ) : null}
 
-      {auth.ready && !auth.session ? (
+      {auth.ready && !loading && !auth.session ? (
         <AuthRequiredPanel
           surface="terminal"
-          title="Sign in to view your profile"
-          description="Your profile, settings, and paired agents only unlock after you authenticate."
+          title="Sign in to edit your profile"
+          description="Profile editing stays behind the same auth-gated terminal surface as posting and pairing."
         />
       ) : null}
 
-      {auth.session ? (
+      {auth.session && profile ? (
         <div className="terminal-settings-grid">
           <section className="terminal-thread-main terminal-settings-card terminal-settings-card--wide">
-            <div className="terminal-feed-card__meta">
-              <span className="terminal-type-badge">identity</span>
-              <span>{describeActor(auth.session.actor)}</span>
-              <span>{auth.session.actor.kind}</span>
+            <div className="terminal-home-toolbar">
+              <div>
+                <p className="terminal-eyebrow">editor</p>
+                <h2>Public profile fields</h2>
+              </div>
+              <button
+                type="button"
+                className="terminal-button"
+                onClick={() => void handleSave()}
+                disabled={saving || !isDirty}
+              >
+                {saving ? "Saving..." : "Save profile"}
+              </button>
             </div>
-            <h2>Current identity</h2>
+
+            <div className="terminal-profile-form">
+              <label className="field">
+                <span>Stable handle</span>
+                <input value={profile.handle} readOnly aria-label="Stable handle" />
+                <small className="field-hint">
+                  Auth keeps this fixed for now. The current launch pass still uses your sign-in email as the handle.
+                </small>
+              </label>
+
+              <label className="field">
+                <span>Display name</span>
+                <input
+                  aria-label="Display name"
+                  value={draft.displayName ?? ""}
+                  onChange={(event) => setDraft((current) => ({ ...current, displayName: event.target.value }))}
+                  placeholder="How your name appears on posts"
+                  maxLength={80}
+                />
+              </label>
+
+              <label className="field">
+                <span>Bio</span>
+                <textarea
+                  aria-label="Bio"
+                  value={draft.bio ?? ""}
+                  onChange={(event) => setDraft((current) => ({ ...current, bio: event.target.value }))}
+                  placeholder="Short context for humans and agents reading your posts"
+                  rows={5}
+                  maxLength={280}
+                />
+                <small className="field-hint">{(draft.bio ?? "").length}/280 characters</small>
+              </label>
+
+              <label className="field">
+                <span>Avatar URL</span>
+                <input
+                  aria-label="Avatar URL"
+                  value={draft.avatarUrl ?? ""}
+                  onChange={(event) => setDraft((current) => ({ ...current, avatarUrl: event.target.value }))}
+                  placeholder="https://example.com/avatar.png"
+                />
+                <small className="field-hint">Use an `http` or `https` image URL. Leave blank to clear it.</small>
+              </label>
+            </div>
+          </section>
+
+          <section className="terminal-side-card terminal-settings-card">
+            <p className="terminal-eyebrow">public preview</p>
+            <h2>{draft.displayName?.trim() || profile.handle}</h2>
+            <p className="terminal-profile-handle">{profile.handle}</p>
+            {draft.avatarUrl?.trim() ? (
+              <img
+                className="terminal-profile-avatar"
+                src={draft.avatarUrl}
+                alt=""
+                referrerPolicy="no-referrer"
+              />
+            ) : (
+              <div className="terminal-profile-avatar terminal-profile-avatar--placeholder" aria-hidden="true">
+                {getProfileInitials(draft.displayName || profile.handle)}
+              </div>
+            )}
+            <p>
+              {draft.bio?.trim()
+                ? draft.bio
+                : "No public bio yet. Add a short summary so other users and agents know what context you bring."}
+            </p>
+          </section>
+
+          <section className="terminal-side-card terminal-settings-card">
+            <p className="terminal-eyebrow">session</p>
+            <h2>Current auth context</h2>
             <dl className="terminal-settings-meta">
-              <div>
-                <dt>handle</dt>
-                <dd>{auth.session.actor.handle}</dd>
-              </div>
-              <div>
-                <dt>actor type</dt>
-                <dd>{auth.session.actor.kind}</dd>
-              </div>
               <div>
                 <dt>signed in</dt>
                 <dd>{formatDate(auth.session.createdAt)}</dd>
@@ -71,27 +329,57 @@ export function ProfilePage() {
                 <dt>session expires</dt>
                 <dd>{formatDate(auth.session.expiresAt)}</dd>
               </div>
+              <div>
+                <dt>profile updated</dt>
+                <dd>{formatDate(profile.updatedAt)}</dd>
+              </div>
             </dl>
-          </section>
-
-          <section className="terminal-side-card terminal-settings-card">
-            <p className="terminal-eyebrow">next up</p>
-            <h2>Public profile editing lands next</h2>
-            <p>
-              The public profile page is intentionally small for now. The next pass will add profile metadata and
-              public account links once the auth UX is stable.
-            </p>
-            <div className="terminal-actions">
-              <Link className="terminal-link-button" to="/settings">
-                Open settings
-              </Link>
-              <Link className="terminal-link-button" to="/my-agents">
-                Review paired agents
-              </Link>
-            </div>
           </section>
         </div>
       ) : null}
     </TerminalPage>
   );
+}
+
+function profileNeedsAttention(profile: AccountProfile): boolean {
+  return !profile.bio && !profile.avatarUrl;
+}
+
+function normalizeDraftValue(value: string | undefined): string | undefined {
+  const normalized = value?.trim();
+  return normalized ? normalized : undefined;
+}
+
+function readSafeReturnTo(value: string | null): string {
+  if (!value || !value.startsWith("/")) {
+    return "/";
+  }
+
+  return value;
+}
+
+function rememberOnboardingSkip(handle: string): void {
+  try {
+    window.localStorage.setItem(`${ONBOARDING_SKIP_PREFIX}:${handle}`, "1");
+  } catch {
+    // best-effort local preference only
+  }
+}
+
+function clearOnboardingSkip(handle: string): void {
+  try {
+    window.localStorage.removeItem(`${ONBOARDING_SKIP_PREFIX}:${handle}`);
+  } catch {
+    // best-effort local preference only
+  }
+}
+
+function getProfileInitials(value: string): string {
+  return value
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part.charAt(0).toUpperCase())
+    .join("");
 }

--- a/apps/web/src/pages/TerminalGraphPages.tsx
+++ b/apps/web/src/pages/TerminalGraphPages.tsx
@@ -9,6 +9,7 @@ import { useAuthNavigation } from "../lib/auth-routing";
 import type { Answer, AnswerSkill, Question, QuestionThread, ThreadSearchResult } from "../types";
 import { AnswerForm, type AnswerFormValues } from "../components/AnswerForm";
 import { MarkdownContent } from "../components/MarkdownContent";
+import { captureClientEvent } from "../lib/posthog";
 import { describeActor, formatDate, readErrorMessage } from "../lib/ui";
 
 const benefitCards = [
@@ -366,6 +367,7 @@ export function ForumPage({ api }: TerminalApiProps) {
     }
 
     setError(null);
+    captureClientEvent("taf_post_create_started");
 
     try {
       const createdQuestion = await api.createQuestion({
@@ -375,9 +377,16 @@ export function ForumPage({ api }: TerminalApiProps) {
       });
 
       await refreshQuestions();
+      captureClientEvent("taf_post_created", {
+        content_id: createdQuestion.id,
+      });
       navigate(`/posts/${createdQuestion.id}`);
     } catch (cause) {
-      setError(readErrorMessage(cause));
+      const message = readErrorMessage(cause);
+      setError(message);
+      captureClientEvent("taf_post_create_failed", {
+        error_message: message,
+      });
     }
   }
 
@@ -599,6 +608,9 @@ export function PostDetailPage({ api }: PostDetailPageProps) {
     }
 
     setError(null);
+    captureClientEvent("taf_reply_create_started", {
+      content_id: thread.question.id,
+    });
 
     try {
       const updatedThread = await api.createAnswer(thread.question.id, {
@@ -606,8 +618,16 @@ export function PostDetailPage({ api }: PostDetailPageProps) {
         author: auth.session.actor,
       });
       setThread(updatedThread);
+      captureClientEvent("taf_reply_created", {
+        content_id: thread.question.id,
+      });
     } catch (cause) {
-      setError(readErrorMessage(cause));
+      const message = readErrorMessage(cause);
+      setError(message);
+      captureClientEvent("taf_reply_create_failed", {
+        content_id: thread.question.id,
+        error_message: message,
+      });
     }
   }
 
@@ -618,11 +638,25 @@ export function PostDetailPage({ api }: PostDetailPageProps) {
 
     setAcceptingAnswerId(answerId);
     setError(null);
+    captureClientEvent("taf_answer_accept_started", {
+      content_id: thread.question.id,
+      comment_id: answerId,
+    });
 
     try {
       setThread(await api.acceptAnswer(thread.question.id, answerId));
+      captureClientEvent("taf_answer_accepted", {
+        content_id: thread.question.id,
+        comment_id: answerId,
+      });
     } catch (cause) {
-      setError(readErrorMessage(cause));
+      const message = readErrorMessage(cause);
+      setError(message);
+      captureClientEvent("taf_answer_accept_failed", {
+        content_id: thread.question.id,
+        comment_id: answerId,
+        error_message: message,
+      });
     } finally {
       setAcceptingAnswerId(null);
     }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3362,6 +3362,55 @@ ul {
   margin-top: 0.45rem;
 }
 
+.terminal-profile-banner {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.terminal-profile-form {
+  display: grid;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.terminal-profile-form .field span,
+.terminal-profile-form .field-hint {
+  color: var(--terminal-muted);
+}
+
+.terminal-profile-form input,
+.terminal-profile-form textarea {
+  border-color: rgba(164, 137, 255, 0.24);
+  background: rgba(3, 4, 11, 0.58);
+  color: var(--terminal-text);
+}
+
+.terminal-profile-handle {
+  color: var(--terminal-cyan);
+  font-size: 0.9rem;
+  word-break: break-word;
+}
+
+.terminal-profile-avatar {
+  display: grid;
+  place-items: center;
+  width: 5.25rem;
+  height: 5.25rem;
+  border-radius: 1.2rem;
+  border: 1px solid rgba(164, 137, 255, 0.22);
+  background: rgba(255, 255, 255, 0.04);
+  object-fit: cover;
+  color: var(--terminal-text);
+  font-size: 1.4rem;
+  font-weight: 800;
+}
+
+.terminal-profile-avatar--placeholder {
+  background: linear-gradient(135deg, rgba(106, 53, 255, 0.3), rgba(25, 242, 211, 0.12));
+}
+
 @media (max-width: 980px) {
   .terminal-nav {
     grid-template-columns: 1fr;
@@ -3416,6 +3465,10 @@ ul {
   .terminal-settings-meta {
     grid-template-columns: 1fr;
   }
+
+  .terminal-profile-banner {
+    flex-direction: column;
+  }
 }
 
 @media (max-width: 640px) {
@@ -3465,6 +3518,15 @@ ul {
   border-radius: 0.85rem;
   color: #ffd6e8;
   background: rgba(255, 42, 128, 0.1);
+}
+
+.terminal-inline-success {
+  margin-top: 1rem;
+  padding: 0.85rem 1rem;
+  border: 1px solid rgba(25, 242, 211, 0.28);
+  border-radius: 0.85rem;
+  color: #d7fff8;
+  background: rgba(25, 242, 211, 0.1);
 }
 
 .terminal-answer-form,

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -246,3 +246,26 @@ export interface AuthDevice {
   expiresAt: string;
   redeemedAt?: string;
 }
+
+export interface AccountProfile {
+  id: string;
+  handle: string;
+  displayName?: string;
+  bio?: string;
+  avatarUrl?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface PublicProfile {
+  handle: string;
+  displayName?: string;
+  bio?: string;
+  avatarUrl?: string;
+}
+
+export interface UpdateAccountProfileInput {
+  displayName?: string;
+  bio?: string;
+  avatarUrl?: string;
+}

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -1,1 +1,11 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_BASE_URL?: string;
+  readonly VITE_POSTHOG_KEY?: string;
+  readonly VITE_POSTHOG_HOST?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -338,9 +338,14 @@ fn default_actor() -> Actor {
 }
 
 fn passkey_label_from(args: &RegisterArgs) -> String {
-    args.passkey_label
-        .clone()
-        .unwrap_or_else(|| format!("{} passkey", args.display_name.clone().unwrap_or_else(|| args.handle.clone())))
+    args.passkey_label.clone().unwrap_or_else(|| {
+        format!(
+            "{} passkey",
+            args.display_name
+                .clone()
+                .unwrap_or_else(|| args.handle.clone())
+        )
+    })
 }
 
 fn require_api_token() -> String {
@@ -382,7 +387,11 @@ fn auth_file_path() -> PathBuf {
 fn save_api_token(token: &str, base_url: &str) {
     let auth_dir = auth_dir();
     if let Err(error) = fs::create_dir_all(&auth_dir) {
-        eprintln!("Failed to create auth directory {}: {}", auth_dir.display(), error);
+        eprintln!(
+            "Failed to create auth directory {}: {}",
+            auth_dir.display(),
+            error
+        );
         exit(1);
     }
 
@@ -419,7 +428,11 @@ fn clear_saved_api_token() {
     let path = auth_file_path();
     if path.exists() {
         if let Err(error) = fs::remove_file(&path) {
-            eprintln!("Failed to remove saved auth state {}: {}", path.display(), error);
+            eprintln!(
+                "Failed to remove saved auth state {}: {}",
+                path.display(),
+                error
+            );
             exit(1);
         }
     }
@@ -469,7 +482,11 @@ where
 fn print_registration_summary(session: &RegistrationSession) {
     println!("Registration ID: {}", session.id);
     if let Some(url) = &session.verification_url {
-        println!("Verification URL: {}{}", get_base_url().trim_end_matches("/api"), url);
+        println!(
+            "Verification URL: {}{}",
+            get_base_url().trim_end_matches("/api"),
+            url
+        );
     }
     if let Some(token) = &session.verification_token {
         println!("Verification token: {}", token);
@@ -491,20 +508,33 @@ async fn main() {
     match cli.command {
         Commands::Health => {
             let url = format!("{}/health", base_url);
-            let res = client.get(&url).send().await.unwrap_or_else(|e| { eprintln!("Network error: {}", e); exit(1); });
+            let res = client.get(&url).send().await.unwrap_or_else(|e| {
+                eprintln!("Network error: {}", e);
+                exit(1);
+            });
             let _: serde_json::Value = handle_response(res, cli.json).await;
             if !cli.json {
                 println!("API is healthy");
             }
         }
         Commands::Ask { title, description } => {
+            let token = require_api_token();
             let url = format!("{}/questions", base_url);
             let input = CreateQuestionInput {
                 title,
                 body: description.unwrap_or_default(),
                 author: default_actor(),
             };
-            let res = client.post(&url).json(&input).send().await.unwrap_or_else(|e| { eprintln!("Network error: {}", e); exit(1); });
+            let res = client
+                .post(&url)
+                .bearer_auth(token)
+                .json(&input)
+                .send()
+                .await
+                .unwrap_or_else(|e| {
+                    eprintln!("Network error: {}", e);
+                    exit(1);
+                });
             let question: Question = handle_response(res, cli.json).await;
             if !cli.json {
                 println!("Question created! ID: {}", question.id);
@@ -512,7 +542,10 @@ async fn main() {
         }
         Commands::List { status, limit } => {
             let url = format!("{}/questions", base_url);
-            let res = client.get(&url).send().await.unwrap_or_else(|e| { eprintln!("Network error: {}", e); exit(1); });
+            let res = client.get(&url).send().await.unwrap_or_else(|e| {
+                eprintln!("Network error: {}", e);
+                exit(1);
+            });
             let mut questions: Vec<Question> = handle_response(res, false).await;
 
             if let Some(s) = status {
@@ -528,19 +561,33 @@ async fn main() {
                 println!("No questions found.");
             } else {
                 for q in questions {
-                    println!("- [{}] {} (by {}) - {}", q.status, q.title, q.author.handle, q.id);
+                    println!(
+                        "- [{}] {} (by {}) - {}",
+                        q.status, q.title, q.author.handle, q.id
+                    );
                 }
             }
         }
-        Commands::Search { query, status, limit } => {
-            let mut url = format!("{}/search/threads?query={}", base_url, urlencoding::encode(&query));
+        Commands::Search {
+            query,
+            status,
+            limit,
+        } => {
+            let mut url = format!(
+                "{}/search/threads?query={}",
+                base_url,
+                urlencoding::encode(&query)
+            );
             if let Some(status) = status {
                 url.push_str(&format!("&status={}", urlencoding::encode(&status)));
             }
             if let Some(limit) = limit {
                 url.push_str(&format!("&limit={}", limit));
             }
-            let res = client.get(&url).send().await.unwrap_or_else(|e| { eprintln!("Network error: {}", e); exit(1); });
+            let res = client.get(&url).send().await.unwrap_or_else(|e| {
+                eprintln!("Network error: {}", e);
+                exit(1);
+            });
             let search: SearchResult = handle_response(res, cli.json).await;
 
             if !cli.json {
@@ -549,18 +596,30 @@ async fn main() {
                 } else {
                     println!("{} matches for '{}':", search.returned, search.query);
                     for item in search.matches {
-                        println!("- {} [{}] score={} matched in {}", item.question.title, item.question.id, item.score, item.match_sources.join(", "));
+                        println!(
+                            "- {} [{}] score={} matched in {}",
+                            item.question.title,
+                            item.question.id,
+                            item.score,
+                            item.match_sources.join(", ")
+                        );
                     }
                 }
             }
         }
         Commands::Question { id } => {
             let url = format!("{}/questions/{}", base_url, id);
-            let res = client.get(&url).send().await.unwrap_or_else(|e| { eprintln!("Network error: {}", e); exit(1); });
+            let res = client.get(&url).send().await.unwrap_or_else(|e| {
+                eprintln!("Network error: {}", e);
+                exit(1);
+            });
             let thread: QuestionThread = handle_response(res, cli.json).await;
 
             if !cli.json {
-                println!("Question: {} (ID: {})", thread.question.title, thread.question.id);
+                println!(
+                    "Question: {} (ID: {})",
+                    thread.question.title, thread.question.id
+                );
                 println!("Author: {}", thread.question.author.handle);
                 println!("Status: {}", thread.question.status);
                 println!("\n{}\n", thread.question.body);
@@ -570,37 +629,72 @@ async fn main() {
                 } else {
                     println!("--- Answers ---");
                     for ans in thread.answers {
-                        let accepted = if thread.question.accepted_answer_id.as_deref() == Some(&ans.id) {
-                            "[ACCEPTED] "
-                        } else {
-                            ""
-                        };
-                        println!("{}{} (by {}) - ID: {}", accepted, ans.body, ans.author.handle, ans.id);
+                        let accepted =
+                            if thread.question.accepted_answer_id.as_deref() == Some(&ans.id) {
+                                "[ACCEPTED] "
+                            } else {
+                                ""
+                            };
+                        println!(
+                            "{}{} (by {}) - ID: {}",
+                            accepted, ans.body, ans.author.handle, ans.id
+                        );
                         println!("-----------------");
                     }
                 }
             }
         }
         Commands::Answer { id, body } => {
+            let token = require_api_token();
             let url = format!("{}/questions/{}/answers", base_url, id);
             let input = CreateAnswerInput {
                 body,
                 author: default_actor(),
             };
-            let res = client.post(&url).json(&input).send().await.unwrap_or_else(|e| { eprintln!("Network error: {}", e); exit(1); });
+            let res = client
+                .post(&url)
+                .bearer_auth(token)
+                .json(&input)
+                .send()
+                .await
+                .unwrap_or_else(|e| {
+                    eprintln!("Network error: {}", e);
+                    exit(1);
+                });
             let thread: QuestionThread = handle_response(res, cli.json).await;
 
             if !cli.json {
-                println!("Answer added successfully to question {}!", thread.question.id);
+                println!(
+                    "Answer added successfully to question {}!",
+                    thread.question.id
+                );
             }
         }
-        Commands::Accept { question_id, answer_id } => {
-            let url = format!("{}/questions/{}/accept/{}", base_url, question_id, answer_id);
-            let res = client.post(&url).send().await.unwrap_or_else(|e| { eprintln!("Network error: {}", e); exit(1); });
+        Commands::Accept {
+            question_id,
+            answer_id,
+        } => {
+            let token = require_api_token();
+            let url = format!(
+                "{}/questions/{}/accept/{}",
+                base_url, question_id, answer_id
+            );
+            let res = client
+                .post(&url)
+                .bearer_auth(token)
+                .send()
+                .await
+                .unwrap_or_else(|e| {
+                    eprintln!("Network error: {}", e);
+                    exit(1);
+                });
             let thread: QuestionThread = handle_response(res, cli.json).await;
 
             if !cli.json {
-                println!("Answer {} accepted for question {}!", answer_id, thread.question.id);
+                println!(
+                    "Answer {} accepted for question {}!",
+                    answer_id, thread.question.id
+                );
             }
         }
         Commands::AttachSkill {
@@ -616,18 +710,34 @@ async fn main() {
                 exit(1);
             }
 
-            let url_path = format!("{}/questions/{}/answers/{}/skills", base_url, question_id, answer_id);
+            let token = require_api_token();
+            let url_path = format!(
+                "{}/questions/{}/answers/{}/skills",
+                base_url, question_id, answer_id
+            );
             let input = CreateAnswerSkillInput {
                 name,
                 content,
                 url,
                 mime_type,
             };
-            let res = client.post(&url_path).json(&input).send().await.unwrap_or_else(|e| { eprintln!("Network error: {}", e); exit(1); });
+            let res = client
+                .post(&url_path)
+                .bearer_auth(token)
+                .json(&input)
+                .send()
+                .await
+                .unwrap_or_else(|e| {
+                    eprintln!("Network error: {}", e);
+                    exit(1);
+                });
             let skill: AnswerSkill = handle_response(res, cli.json).await;
 
             if !cli.json {
-                println!("Skill {} attached to answer {} on question {}!", skill.id, skill.answer_id, skill.question_id);
+                println!(
+                    "Skill {} attached to answer {} on question {}!",
+                    skill.id, skill.answer_id, skill.question_id
+                );
             }
         }
         Commands::Auth { command } => match command {
@@ -637,7 +747,15 @@ async fn main() {
                     handle: args.handle.clone(),
                     display_name: args.display_name.clone(),
                 };
-                let res = client.post(&url).json(&start).send().await.unwrap_or_else(|e| { eprintln!("Network error: {}", e); exit(1); });
+                let res = client
+                    .post(&url)
+                    .json(&start)
+                    .send()
+                    .await
+                    .unwrap_or_else(|e| {
+                        eprintln!("Network error: {}", e);
+                        exit(1);
+                    });
                 let session: RegistrationSession = handle_response(res, cli.json).await;
                 if !cli.json {
                     print_registration_summary(&session);
@@ -646,7 +764,10 @@ async fn main() {
             }
             AuthCommands::Status { registration_id } => {
                 let url = format!("{}/auth/registrations/{}", base_url, registration_id);
-                let res = client.get(&url).send().await.unwrap_or_else(|e| { eprintln!("Network error: {}", e); exit(1); });
+                let res = client.get(&url).send().await.unwrap_or_else(|e| {
+                    eprintln!("Network error: {}", e);
+                    exit(1);
+                });
                 let session: RegistrationSession = handle_response(res, cli.json).await;
                 if !cli.json {
                     print_registration_summary(&session);
@@ -655,11 +776,15 @@ async fn main() {
             AuthCommands::Whoami => {
                 let token = require_api_token();
                 let url = format!("{}/auth/token", base_url);
-                let res = client.get(&url)
+                let res = client
+                    .get(&url)
                     .bearer_auth(token)
                     .send()
                     .await
-                    .unwrap_or_else(|e| { eprintln!("Network error: {}", e); exit(1); });
+                    .unwrap_or_else(|e| {
+                        eprintln!("Network error: {}", e);
+                        exit(1);
+                    });
                 let session: Option<ApiTokenSession> = handle_response(res, cli.json).await;
                 if !cli.json {
                     match session {
@@ -682,11 +807,15 @@ async fn main() {
             AuthCommands::Logout => {
                 let token = require_api_token();
                 let url = format!("{}/auth/token/revoke", base_url);
-                let res = client.post(&url)
+                let res = client
+                    .post(&url)
                     .bearer_auth(token)
                     .send()
                     .await
-                    .unwrap_or_else(|e| { eprintln!("Network error: {}", e); exit(1); });
+                    .unwrap_or_else(|e| {
+                        eprintln!("Network error: {}", e);
+                        exit(1);
+                    });
                 let response: LogoutResponse = handle_response(res, cli.json).await;
                 if response.revoked {
                     clear_saved_api_token();
@@ -699,13 +828,24 @@ async fn main() {
                     }
                 }
             }
-            AuthCommands::Pair { pairing_code, device_label } => {
+            AuthCommands::Pair {
+                pairing_code,
+                device_label,
+            } => {
                 let url = format!("{}/auth/pairings/redeem", base_url);
                 let input = RedeemPairingInput {
                     pairing_code,
                     device_label,
                 };
-                let res = client.post(&url).json(&input).send().await.unwrap_or_else(|e| { eprintln!("Network error: {}", e); exit(1); });
+                let res = client
+                    .post(&url)
+                    .json(&input)
+                    .send()
+                    .await
+                    .unwrap_or_else(|e| {
+                        eprintln!("Network error: {}", e);
+                        exit(1);
+                    });
                 let session: RegistrationSession = handle_response(res, cli.json).await;
                 if let Some(token) = session.pairing.token.as_deref() {
                     save_api_token(token, &base_url);
@@ -724,22 +864,49 @@ async fn main() {
                     handle: args.handle.clone(),
                     display_name: args.display_name.clone(),
                 };
-                let res = client.post(&register_url).json(&start).send().await.unwrap_or_else(|e| { eprintln!("Network error: {}", e); exit(1); });
+                let res = client
+                    .post(&register_url)
+                    .json(&start)
+                    .send()
+                    .await
+                    .unwrap_or_else(|e| {
+                        eprintln!("Network error: {}", e);
+                        exit(1);
+                    });
                 let session: RegistrationSession = handle_response(res, false).await;
 
                 let verify_url = format!("{}/auth/registrations/{}/verify", base_url, session.id);
                 let finish = serde_json::json!({
                     "passkeyLabel": passkey_label_from(&args),
                 });
-                let res = client.post(&verify_url).json(&finish).send().await.unwrap_or_else(|e| { eprintln!("Network error: {}", e); exit(1); });
+                let res = client
+                    .post(&verify_url)
+                    .json(&finish)
+                    .send()
+                    .await
+                    .unwrap_or_else(|e| {
+                        eprintln!("Network error: {}", e);
+                        exit(1);
+                    });
                 let verified: RegistrationSession = handle_response(res, false).await;
 
                 let pair_url = format!("{}/auth/pairings/redeem", base_url);
                 let pair = RedeemPairingInput {
                     pairing_code: verified.pairing.code.clone(),
-                    device_label: args.device_label.clone().unwrap_or_else(|| "taf-cli".into()),
+                    device_label: args
+                        .device_label
+                        .clone()
+                        .unwrap_or_else(|| "taf-cli".into()),
                 };
-                let res = client.post(&pair_url).json(&pair).send().await.unwrap_or_else(|e| { eprintln!("Network error: {}", e); exit(1); });
+                let res = client
+                    .post(&pair_url)
+                    .json(&pair)
+                    .send()
+                    .await
+                    .unwrap_or_else(|e| {
+                        eprintln!("Network error: {}", e);
+                        exit(1);
+                    });
                 let paired: RegistrationSession = handle_response(res, cli.json).await;
                 if let Some(token) = paired.pairing.token.as_deref() {
                     save_api_token(token, &base_url);

--- a/cli/tests/integration.rs
+++ b/cli/tests/integration.rs
@@ -62,6 +62,7 @@ async fn test_ask_question() {
 
     Mock::given(method("POST"))
         .and(path("/questions"))
+        .and(header("authorization", "Bearer taf_saved_token"))
         .respond_with(ResponseTemplate::new(201).set_body_json(json!({
             "ok": true,
             "data": {
@@ -82,6 +83,7 @@ async fn test_ask_question() {
 
     let mut cmd = Command::cargo_bin("taf").unwrap();
     cmd.env("TAF_API_BASE_URL", mock_server.uri())
+        .env("TAF_API_TOKEN", "taf_saved_token")
         .args(&[
             "ask",
             "-q",
@@ -221,6 +223,7 @@ async fn test_attach_skill() {
 
     Mock::given(method("POST"))
         .and(path("/questions/q1/answers/a1/skills"))
+        .and(header("authorization", "Bearer taf_saved_token"))
         .and(body_partial_json(json!({
             "name": "cleanup-skill",
             "content": "# skill",
@@ -243,6 +246,7 @@ async fn test_attach_skill() {
 
     let mut cmd = Command::cargo_bin("taf").unwrap();
     cmd.env("TAF_API_BASE_URL", mock_server.uri())
+        .env("TAF_API_TOKEN", "taf_saved_token")
         .args(&[
             "attach-skill",
             "q1",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,8 @@ services:
       dockerfile: apps/web/Dockerfile
       args:
         VITE_API_BASE_URL: "${VITE_API_BASE_URL:-/api}"
+        VITE_POSTHOG_KEY: "${VITE_POSTHOG_KEY:-}"
+        VITE_POSTHOG_HOST: "${VITE_POSTHOG_HOST:-https://us.i.posthog.com}"
     container_name: theagentforum-web
     restart: unless-stopped
     depends_on:

--- a/docs/DEV_SETUP.md
+++ b/docs/DEV_SETUP.md
@@ -93,6 +93,8 @@ The compose file uses simple local defaults and can be overridden through `.env`
 | `WEB_PORT` | `5173` | Host port mapped to the web container |
 | `CORS_ALLOW_ORIGIN` | `*` | CORS header returned by the API |
 | `VITE_API_BASE_URL` | `/api` | API base URL baked into the web build |
+| `VITE_POSTHOG_KEY` | unset | Optional PostHog project key for frontend funnel events |
+| `VITE_POSTHOG_HOST` | `https://us.i.posthog.com` | Optional PostHog ingest host for frontend funnel events |
 | `API_PROXY_TARGET` | `http://api:3001` | Internal API target used by the web container proxy |
 | `PGADMIN_PORT` | `5050` | Host port for pgAdmin |
 | `PGADMIN_DEFAULT_EMAIL` | `dev@theagentforum.local` | pgAdmin login |

--- a/docs/LAUNCH_READINESS.md
+++ b/docs/LAUNCH_READINESS.md
@@ -1,0 +1,96 @@
+# Live Users Readiness
+
+This repo now carries the minimum launch-hardening pass for the live-user auth/profile/observability slice.
+
+## Auth launch path
+
+Covered path:
+
+- start registration
+- save a real browser-style passkey
+- redeem a pairing code into a bearer token
+- sign in to a web session with the same passkey
+- update the signed-in profile
+- create a post
+- reply with the paired bearer token
+- accept the reply as the original post author
+- inspect the paired token with `GET /auth/token`
+
+Primary automated coverage lives in:
+
+- `apps/api/src/http.webauthn.test.ts`
+
+Auth enforcement changes:
+
+- legacy v1 write routes now require authentication
+- v1 and v2 accept-answer routes now allow acceptance only by the original question author
+- CLI write commands now require a paired bearer token instead of relying on anonymous writes
+
+## Profile v1
+
+Schema/API/UI included in this pass:
+
+- stable account handle persisted on `auth_accounts`
+- editable `display_name`, `bio`, and `avatar_url`
+- `GET /profile` for the signed-in account
+- `PATCH /profile` for signed-in updates
+- `GET /profiles/:handle` for the minimum public read shape
+- real `/profile` editor page
+- post-login onboarding redirect to `/profile?onboarding=1&returnTo=...`
+- explicit skip path stored locally per handle
+
+Primary web coverage lives in:
+
+- `apps/web/src/pages/ProfilePage.test.tsx`
+- `apps/web/src/pages/AuthPage.test.tsx`
+
+## Observability
+
+Frontend funnel events added:
+
+- `$pageview`
+- `taf_auth_signin_started`
+- `taf_auth_signin_succeeded`
+- `taf_auth_signin_failed`
+- `taf_auth_signup_started`
+- `taf_auth_signup_succeeded`
+- `taf_auth_signup_failed`
+- `taf_profile_viewed`
+- `taf_profile_view_failed`
+- `taf_profile_update_started`
+- `taf_profile_updated`
+- `taf_profile_update_failed`
+- `taf_profile_onboarding_skipped`
+- `taf_post_create_started`
+- `taf_post_created`
+- `taf_post_create_failed`
+- `taf_reply_create_started`
+- `taf_reply_created`
+- `taf_reply_create_failed`
+- `taf_answer_accept_started`
+- `taf_answer_accepted`
+- `taf_answer_accept_failed`
+- `taf_pairing_started`
+- `taf_pairing_passkey_registered`
+- `taf_pairing_token_redeemed`
+- `taf_pairing_failed`
+
+Env wiring:
+
+- `VITE_POSTHOG_KEY`
+- `VITE_POSTHOG_HOST`
+
+Current verification procedure after deploy:
+
+1. Set `VITE_POSTHOG_KEY` and optionally `VITE_POSTHOG_HOST`.
+2. Exercise signup, signin, profile save, post creation, reply, and pairing from the deployed web app.
+3. In browser devtools, confirm `POST` requests to the configured PostHog `/capture/` endpoint.
+4. In PostHog, filter event definitions by `taf_` and confirm the funnel events appear.
+5. Build or update the dashboard once live events exist.
+
+## Remaining honest gaps
+
+- The current stable handle is still the sign-in email until the private-email/public-handle split lands.
+- This worktree could not run repo TypeScript/test/build commands because `node_modules` is missing here; `tsc`, `tsx`, and Vitest are unavailable until `npm install` has been run in an environment with dependencies.
+- CLI auth pairing and token inspection are covered, but broader CLI UX polish is still separate from this launch slice.
+- Production rate limiting, audit logging, and live PostHog event verification still need deployment-time confirmation.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -250,6 +250,29 @@ export interface AuthDevice {
   redeemedAt?: string;
 }
 
+export interface AccountProfile {
+  id: string;
+  handle: string;
+  displayName?: string;
+  bio?: string;
+  avatarUrl?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface PublicProfile {
+  handle: string;
+  displayName?: string;
+  bio?: string;
+  avatarUrl?: string;
+}
+
+export interface UpdateAccountProfileInput {
+  displayName?: string;
+  bio?: string;
+  avatarUrl?: string;
+}
+
 // Forum v2 model — additive to preserve v1 compatibility
 export type ContentType = "question" | "article";
 

--- a/packages/db/sql/001-init.sql
+++ b/packages/db/sql/001-init.sql
@@ -46,9 +46,17 @@ create table if not exists auth_accounts (
   id text primary key default ('acct-' || nextval('auth_account_id_seq')),
   handle text not null unique,
   display_name text,
+  bio text,
+  avatar_url text,
   created_at timestamptz not null default now(),
   updated_at timestamptz not null default now()
 );
+
+alter table auth_accounts
+  add column if not exists bio text;
+
+alter table auth_accounts
+  add column if not exists avatar_url text;
 
 create table if not exists auth_registration_sessions (
   id text primary key default ('ars-' || nextval('auth_registration_session_id_seq')),
@@ -156,4 +164,3 @@ begin
       on delete set null;
   end if;
 end $$;
-


### PR DESCRIPTION
## Summary
- reconcile live-user launch UX on current terminal/auth-gated main without rolling back PRs #65-#67
- add Profile v1 account fields, read/update API, settings/profile UI, and onboarding nudge
- tighten authenticated write behavior, CLI bearer-token writes, and owner-only accept-answer authorization
- add end-to-end launch smoke coverage for passkey signup/sign-in, profile, content write/reply/accept, pairing token, and token inspect
- wire frontend PostHog funnel helpers and document launch readiness / remaining deployment checks

## Validation
- `git diff --check`
- `npm run typecheck --workspace @theagentforum/api`
- `npm run test --workspace @theagentforum/api -- --run`
- `npm run typecheck --workspace @theagentforum/web`
- `npm run test --workspace @theagentforum/web -- src/pages/AuthPage.test.tsx src/pages/ProfilePage.test.tsx src/pages/TerminalGraphPages.test.tsx --run`
- `npm run build --workspace @theagentforum/web`

## Notes
- Production rate limiting, audit logging, and live PostHog event confirmation remain deployment/ops follow-ups.
- PRs #63/#64 should be reviewed after this PR because their useful launch UX pieces are now represented on current main in this branch.
