### PR TITLE
Polish auth onboarding for first public testers

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -888,7 +888,7 @@ async function routeRequest(
         corsHeaders,
         404,
         "passkey_authentication_not_available",
-        "No registered passkey was found for that handle.",
+        "No registered passkey was found for that email or handle.",
       );
       return;
     }
@@ -1340,10 +1340,26 @@ function parseUpdateAccountProfileInput(payload: unknown): UpdateAccountProfileI
 
 function parseStartRegistrationInput(payload: unknown): StartRegistrationInput {
   const input = asRecord(payload, "Request body must be an object.");
+  const rawHandle = readOptionalString(input.handle, "handle");
+  const rawEmail = readOptionalString(input.email, "email");
+  const inferredEmail = rawEmail ?? (rawHandle && isEmailLike(rawHandle) ? rawHandle : undefined);
+  const email = inferredEmail ? readEmailString(inferredEmail, "email") : undefined;
+  const displayName = readOptionalString(input.displayName, "displayName");
+  const publicHandleSource = rawHandle && rawHandle !== inferredEmail ? rawHandle : email;
+  const handle = publicHandleSource ? buildPublicHandle(publicHandleSource) : undefined;
+
+  if (!handle && !email) {
+    throw createHttpError(
+      400,
+      "validation_error",
+      "Either handle or email must be a non-empty string.",
+    );
+  }
 
   return {
-    handle: readRequiredString(input.handle, "handle"),
-    displayName: readOptionalString(input.displayName, "displayName"),
+    handle,
+    email,
+    displayName,
   };
 }
 
@@ -1351,7 +1367,7 @@ function parseStartAuthenticationInput(payload: unknown): StartAuthenticationInp
   const input = asRecord(payload, "Request body must be an object.");
 
   return {
-    handle: readRequiredString(input.handle, "handle"),
+    handle: readRequiredString(input.handle, "handle").toLowerCase(),
   };
 }
 
@@ -1532,6 +1548,36 @@ function readOptionalString(value: unknown, fieldName: string): string | undefin
   }
 
   return value.trim();
+}
+
+function readEmailString(value: string, fieldName: string): string {
+  const email = value.trim().toLowerCase();
+
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+    throw createHttpError(
+      400,
+      "validation_error",
+      `${fieldName} must be a valid email address.`,
+    );
+  }
+
+  return email;
+}
+
+function isEmailLike(value: string): boolean {
+  return value.includes("@");
+}
+
+function buildPublicHandle(value: string): string | undefined {
+  const source = value.includes("@") ? value.split("@")[0] ?? value : value;
+  const handle = source
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 32);
+
+  return handle || undefined;
 }
 
 function readOptionalInteger(value: unknown, fieldName: string): number | undefined {

--- a/apps/api/src/http.test.ts
+++ b/apps/api/src/http.test.ts
@@ -179,6 +179,92 @@ describe("HTTP API", () => {
     assert.equal(resolved.body.data.id, started.body.data.id);
   });
 
+  it("stores private email separately from the public author handle", async () => {
+    const app = createTestApp();
+
+    const started = await requestJson(app, "/auth/registrations/start", {
+      method: "POST",
+      body: {
+        email: "Eric@Example.com",
+        displayName: "Eric",
+      },
+    });
+
+    assert.equal(started.status, 201);
+    assert.equal(started.body.data.handle, "eric");
+    assert.ok(!started.body.data.handle.includes("@"));
+
+    await requestJson(app, `/auth/registrations/${started.body.data.id}/verify`, {
+      method: "POST",
+      body: {
+        passkeyLabel: "Eric Passkey",
+      },
+    });
+
+    const redeemed = await requestJson(app, "/auth/pairings/redeem", {
+      method: "POST",
+      body: {
+        pairingCode: started.body.data.pairing.code,
+        deviceLabel: "pixel-cli",
+      },
+    });
+    const authHeader = {
+      authorization: `Bearer ${redeemed.body.data.pairing.token}`,
+    };
+
+    const profile = await requestJson(app, "/profile", {
+      headers: authHeader,
+    });
+    assert.equal(profile.status, 200);
+    assert.equal(profile.body.data.email, "eric@example.com");
+    assert.equal(profile.body.data.handle, "eric");
+
+    const created = await requestJson(app, "/questions", {
+      method: "POST",
+      headers: authHeader,
+      body: {
+        title: "Can authors avoid raw emails?",
+        body: "Public posts should show the public handle.",
+        author: {
+          id: "spoof",
+          kind: "agent",
+          handle: "spoofed-email@example.com",
+        },
+      },
+    });
+
+    assert.equal(created.status, 201);
+    assert.equal(created.body.data.author.handle, "eric");
+    assert.equal(created.body.data.author.displayName, "Eric");
+  });
+
+  it("does not merge different private emails that want the same public handle", async () => {
+    const app = createTestApp();
+
+    const first = await requestJson(app, "/auth/registrations/start", {
+      method: "POST",
+      body: {
+        email: "eric@example.com",
+        displayName: "First Eric",
+      },
+    });
+
+    const second = await requestJson(app, "/auth/registrations/start", {
+      method: "POST",
+      body: {
+        email: "eric@example.org",
+        displayName: "Second Eric",
+      },
+    });
+
+    assert.equal(first.status, 201);
+    assert.equal(second.status, 201);
+    assert.equal(first.body.data.handle, "eric");
+    assert.notEqual(second.body.data.handle, first.body.data.handle);
+    assert.match(second.body.data.handle, /^eric-/);
+    assert.equal(second.body.data.displayName, "Second Eric");
+  });
+
   it("inspects and revokes paired API tokens", async () => {
     const app = createTestApp();
 
@@ -252,7 +338,7 @@ describe("HTTP API", () => {
     assert.equal(response.status, 400);
     assert.equal(response.body.ok, false);
     assert.equal(response.body.error.code, "validation_error");
-    assert.match(response.body.error.message, /handle must be a non-empty string/i);
+    assert.match(response.body.error.message, /handle or email/i);
   });
 });
 

--- a/apps/api/src/http.webauthn.test.ts
+++ b/apps/api/src/http.webauthn.test.ts
@@ -250,6 +250,56 @@ describe("HTTP API - WebAuthn registration", () => {
     assert.ok(authenticated.body.data.verifiedAt);
   });
 
+  it("starts passkey authentication from private email and returns the public handle", async () => {
+    const app = createTestApp();
+    const fixture = createPasskeyFixture();
+
+    const started = await requestJson(app, "/auth/registrations/start", {
+      method: "POST",
+      body: {
+        email: "Eric@Example.com",
+        displayName: "Eric",
+      },
+    });
+
+    assert.equal(started.status, 201);
+    assert.equal(started.body.data.handle, "eric");
+
+    const registrationId = started.body.data.id as string;
+    const registrationOptions = await requestJson(app, `/auth/registrations/${registrationId}/passkey/options`, {
+      headers: {
+        origin: "http://localhost:5173",
+      },
+    });
+
+    await requestJson(app, "/auth/passkeys/register", {
+      method: "POST",
+      headers: {
+        origin: "http://localhost:5173",
+      },
+      body: {
+        registrationSessionId: registrationId,
+        credential: fixture.createRegistrationCredential({
+          challenge: registrationOptions.body.data.challenge,
+          origin: "http://localhost:5173",
+          rpId: "localhost",
+        }),
+        passkeyLabel: "Eric MacBook Passkey",
+      },
+    });
+
+    const startedAuthentication = await requestJson(app, "/auth/authentications/start", {
+      method: "POST",
+      body: {
+        handle: "eric@example.com",
+      },
+    });
+
+    assert.equal(startedAuthentication.status, 201);
+    assert.equal(startedAuthentication.body.data.handle, "eric");
+    assert.equal(startedAuthentication.body.data.displayName, "Eric");
+  });
+
   it("rejects a passkey authentication assertion whose challenge does not match", async () => {
     const app = createTestApp();
     const fixture = createPasskeyFixture();
@@ -562,7 +612,8 @@ describe("HTTP API - WebAuthn registration", () => {
     });
 
     assert.equal(beforeUpdate.status, 200);
-    assert.equal(beforeUpdate.body.data.handle, "profile-owner@example.com");
+    assert.equal(beforeUpdate.body.data.handle, "profile-owner");
+    assert.equal(beforeUpdate.body.data.email, "profile-owner@example.com");
     assert.equal(beforeUpdate.body.data.displayName, "Profile Owner");
     assert.equal(beforeUpdate.body.data.bio, undefined);
 
@@ -895,7 +946,7 @@ describe("HTTP API - WebAuthn registration", () => {
 
     assert.equal(replied.status, 201);
     const commentId = replied.body.data.comments[0].id as string;
-    assert.equal(replied.body.data.comments[0].author.handle, "launch-smoke@example.com");
+    assert.equal(replied.body.data.comments[0].author.handle, "launch-smoke");
 
     const accepted = await requestJson(app, `/v2/contents/${contentId}/accept/${commentId}`, {
       method: "POST",
@@ -914,7 +965,7 @@ describe("HTTP API - WebAuthn registration", () => {
     });
 
     assert.equal(tokenSession.status, 200);
-    assert.equal(tokenSession.body.data.actor.handle, "launch-smoke@example.com");
+    assert.equal(tokenSession.body.data.actor.handle, "launch-smoke");
     assert.equal(tokenSession.body.data.deviceLabel, "launch-smoke-cli");
   });
 

--- a/apps/api/src/memory-auth-store.ts
+++ b/apps/api/src/memory-auth-store.ts
@@ -70,6 +70,7 @@ interface StoredAuthenticationSession {
 interface StoredAccount {
   id: string;
   handle: string;
+  email?: string;
   displayName?: string;
   bio?: string;
   avatarUrl?: string;
@@ -90,6 +91,7 @@ export function createInMemoryAuthStore(): AuthStore {
   const authenticationSessions = new Map<string, StoredAuthenticationSession>();
   const credentialsByHandle = new Map<string, StoredCredential[]>();
   const accountsByHandle = new Map<string, StoredAccount>();
+  const accountsByEmail = new Map<string, StoredAccount>();
   const webSessionsByToken = new Map<string, StoredWebSession>();
   let accountSequence = 1;
   let registrationSequence = 1;
@@ -97,7 +99,7 @@ export function createInMemoryAuthStore(): AuthStore {
   let authenticationSequence = 1;
 
   async function startRegistration(input: StartRegistrationInput): Promise<RegistrationSession> {
-    ensureAccount(input.handle, input.displayName);
+    const account = ensureAccount(input);
     const createdAt = new Date().toISOString();
     const expiresAt = new Date(Date.now() + 15 * 60 * 1000).toISOString();
     const pairingExpiresAt = new Date(Date.now() + 30 * 60 * 1000).toISOString();
@@ -106,8 +108,8 @@ export function createInMemoryAuthStore(): AuthStore {
 
     const session: StoredRegistrationSession = {
       id,
-      handle: input.handle,
-      displayName: input.displayName,
+      handle: account.handle,
+      displayName: account.displayName,
       status: "awaiting_verification",
       challenge: createChallenge(),
       verificationToken,
@@ -293,7 +295,13 @@ export function createInMemoryAuthStore(): AuthStore {
   async function startAuthentication(
     input: StartAuthenticationInput,
   ): Promise<AuthenticationSession | null> {
-    const credentials = (credentialsByHandle.get(input.handle) ?? []).filter(isAuthenticatablePasskey);
+    const account = findAccountBySignInIdentifier(input.handle);
+
+    if (!account) {
+      return null;
+    }
+
+    const credentials = (credentialsByHandle.get(account.handle) ?? []).filter(isAuthenticatablePasskey);
 
     if (credentials.length === 0) {
       return null;
@@ -302,13 +310,12 @@ export function createInMemoryAuthStore(): AuthStore {
     const createdAt = new Date().toISOString();
     const expiresAt = new Date(Date.now() + 15 * 60 * 1000).toISOString();
     const latestRegistration = Array.from(registrationSessions.values())
-      .filter((candidate) => candidate.handle === input.handle)
+      .filter((candidate) => candidate.handle === account.handle)
       .sort((left, right) => right.createdAt.localeCompare(left.createdAt))[0];
-    const account = accountsByHandle.get(input.handle);
 
     const session: StoredAuthenticationSession = {
       id: `aas-${authenticationSequence++}`,
-      handle: input.handle,
+      handle: account.handle,
       displayName: account?.displayName ?? latestRegistration?.displayName,
       status: "awaiting_authentication",
       challenge: createChallenge(),
@@ -438,7 +445,10 @@ export function createInMemoryAuthStore(): AuthStore {
       return null;
     }
 
-    const account = ensureAccount(authenticationSession.handle, authenticationSession.displayName);
+    const account = ensureAccount({
+      handle: authenticationSession.handle,
+      displayName: authenticationSession.displayName,
+    });
     const createdAt = new Date().toISOString();
     const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
     const token = createWebSessionToken();
@@ -504,7 +514,10 @@ export function createInMemoryAuthStore(): AuthStore {
       return null;
     }
 
-    const account = ensureAccount(session.handle, session.displayName);
+    const account = ensureAccount({
+      handle: session.handle,
+      displayName: session.displayName,
+    });
 
     return {
       actor: createStoredActor(account),
@@ -654,12 +667,22 @@ export function createInMemoryAuthStore(): AuthStore {
     return "revoked";
   }
 
-  function ensureAccount(handle: string, displayName?: string): StoredAccount {
-    const existing = accountsByHandle.get(handle);
+  function ensureAccount(input: StartRegistrationInput): StoredAccount {
+    const email = normalizeEmail(input.email);
+    const requestedHandle = buildPublicHandle(input.handle ?? email ?? "user");
+    const existing =
+      (email ? accountsByEmail.get(email) : undefined)
+      ?? (email ? accountsByHandle.get(email) : accountsByHandle.get(requestedHandle));
 
     if (existing) {
-      if (displayName && !existing.displayName) {
-        existing.displayName = displayName;
+      if (email && !existing.email) {
+        existing.email = email;
+        accountsByEmail.set(email, existing);
+        existing.updatedAt = new Date().toISOString();
+      }
+
+      if (input.displayName && !existing.displayName) {
+        existing.displayName = input.displayName;
         existing.updatedAt = new Date().toISOString();
       }
 
@@ -669,13 +692,22 @@ export function createInMemoryAuthStore(): AuthStore {
     const createdAt = new Date().toISOString();
     const account: StoredAccount = {
       id: `acct-${accountSequence++}`,
-      handle,
-      displayName,
+      handle: createAvailableHandle(requestedHandle, accountsByHandle),
+      email,
+      displayName: input.displayName,
       createdAt,
       updatedAt: createdAt,
     };
-    accountsByHandle.set(handle, account);
+    accountsByHandle.set(account.handle, account);
+    if (email) {
+      accountsByEmail.set(email, account);
+    }
     return account;
+  }
+
+  function findAccountBySignInIdentifier(identifier: string): StoredAccount | undefined {
+    const normalized = identifier.trim().toLowerCase();
+    return accountsByHandle.get(normalized) ?? accountsByEmail.get(normalized);
   }
 
   return {
@@ -708,6 +740,41 @@ export function createInMemoryAuthStore(): AuthStore {
 
 function createChallenge(): string {
   return randomBytes(18).toString("base64url");
+}
+
+function normalizeEmail(value: string | undefined): string | undefined {
+  const normalized = value?.trim().toLowerCase();
+  return normalized || undefined;
+}
+
+function buildPublicHandle(value: string): string {
+  const source = value.includes("@") ? value.split("@")[0] ?? value : value;
+  const handle = source
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 32);
+
+  return handle || `user-${randomBytes(3).toString("hex")}`;
+}
+
+function createAvailableHandle(
+  requestedHandle: string,
+  accountsByHandle: Map<string, StoredAccount>,
+): string {
+  if (!accountsByHandle.has(requestedHandle)) {
+    return requestedHandle;
+  }
+
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    const candidate = `${requestedHandle}-${randomBytes(3).toString("hex")}`.slice(0, 40);
+    if (!accountsByHandle.has(candidate)) {
+      return candidate;
+    }
+  }
+
+  return `user-${randomBytes(6).toString("hex")}`;
 }
 
 function createPairingCode(): string {
@@ -761,6 +828,7 @@ function cloneAccountProfile(account: StoredAccount): AccountProfile {
   return {
     id: account.id,
     handle: account.handle,
+    email: account.email,
     displayName: account.displayName,
     bio: account.bio,
     avatarUrl: account.avatarUrl,

--- a/apps/api/src/postgres-auth-store.ts
+++ b/apps/api/src/postgres-auth-store.ts
@@ -57,16 +57,84 @@ export function createPostgresAuthStore(): AuthStore {
 }
 
 async function startRegistration(input: StartRegistrationInput): Promise<RegistrationSession> {
+  const registrationFields = buildRegistrationFields(input);
   const verificationToken = randomBytes(6).toString("hex");
   const registrationSession = await queryJson<RegistrationSession>(
     `
-      with ensured_account as (
-        insert into auth_accounts (handle, display_name)
-        values (:'handle', nullif(:'display_name', ''))
-        on conflict (handle)
-        do update set
+      with registration_input as (
+        select
+          :'handle'::text as handle,
+          nullif(:'email', '')::text as email,
+          nullif(:'display_name', '')::text as display_name
+      ),
+      matched_account as (
+        select a.id
+        from auth_accounts a
+        cross join registration_input i
+        where (i.email is null and a.handle = i.handle)
+          or (i.email is not null and lower(a.email) = lower(i.email))
+          or (i.email is not null and lower(a.handle) = lower(i.email))
+        order by
+          case
+            when i.email is not null and lower(a.email) = lower(i.email) then 0
+            when i.email is not null and lower(a.handle) = lower(i.email) then 1
+            else 2
+          end,
+          a.created_at asc
+        limit 1
+      ),
+      updated_existing_account as (
+        update auth_accounts a
+        set
+          email = coalesce(a.email, i.email),
+          display_name = coalesce(a.display_name, i.display_name),
           updated_at = now()
+        from registration_input i, matched_account m
+        where a.id = m.id
+        returning a.id, a.handle, a.display_name
+      ),
+      candidate_handles as (
+        select handle, 0 as priority
+        from registration_input
+        union all
+        select
+          left(
+            concat(
+              (select handle from registration_input),
+              '-',
+              substr(md5(coalesce((select email from registration_input), '') || '-' || attempt::text), 1, 6)
+            ),
+            40
+          ) as handle,
+          attempt as priority
+        from generate_series(1, 20) as candidate_attempts(attempt)
+      ),
+      available_handle as (
+        select candidate_handles.handle
+        from candidate_handles
+        where not exists (
+          select 1
+          from auth_accounts a
+          where a.handle = candidate_handles.handle
+        )
+        order by candidate_handles.priority asc
+        limit 1
+      ),
+      created_account as (
+        insert into auth_accounts (handle, email, display_name)
+        select
+          available_handle.handle,
+          registration_input.email,
+          registration_input.display_name
+        from registration_input
+        cross join available_handle
+        where not exists (select 1 from matched_account)
         returning id, handle, display_name
+      ),
+      ensured_account as (
+        select * from updated_existing_account
+        union all
+        select * from created_account
       ),
       created_registration as (
         insert into auth_registration_sessions (
@@ -97,8 +165,9 @@ async function startRegistration(input: StartRegistrationInput): Promise<Registr
         on created_pairing.registration_session_id = created_registration.id;
     `,
     {
-      handle: input.handle,
-      display_name: input.displayName ?? "",
+      handle: registrationFields.handle,
+      email: registrationFields.email ?? "",
+      display_name: registrationFields.displayName ?? "",
       challenge: createChallenge(),
       verification_url: `/auth?registration=${verificationToken}`,
       pairing_code: createPairingCode(),
@@ -379,18 +448,26 @@ async function redeemPairing(input: RedeemPairingInput): Promise<RegistrationSes
 async function startAuthentication(
   input: StartAuthenticationInput,
 ): Promise<AuthenticationSession | null> {
+  const signInIdentifier = input.handle.trim().toLowerCase();
   const output = await runSql(
     `
       with matched_account as (
         select a.id, a.handle, a.display_name
         from auth_accounts a
-        where a.handle = :'handle'
+        where (
+            lower(a.handle) = :'sign_in_identifier'
+            or lower(a.email) = :'sign_in_identifier'
+          )
           and exists (
             select 1
             from auth_passkey_credentials c
             where c.account_id = a.id
               and c.credential_id not like 'manual-%'
           )
+        order by
+          case when lower(a.email) = :'sign_in_identifier' then 0 else 1 end,
+          a.created_at asc
+        limit 1
       ),
       created_authentication as (
         insert into auth_authentication_sessions (
@@ -411,7 +488,7 @@ async function startAuthentication(
       from created_authentication;
     `,
     {
-      handle: input.handle,
+      sign_in_identifier: signInIdentifier,
       challenge: createChallenge(),
     },
   );
@@ -651,6 +728,7 @@ async function getAccountProfile(accountId: string): Promise<AccountProfile | nu
       select json_strip_nulls(json_build_object(
         'id', id,
         'handle', handle,
+        'email', email,
         'displayName', display_name,
         'bio', bio,
         'avatarUrl', avatar_url,
@@ -682,6 +760,7 @@ async function updateAccountProfile(
       returning json_strip_nulls(json_build_object(
         'id', id,
         'handle', handle,
+        'email', email,
         'displayName', display_name,
         'bio', bio,
         'avatarUrl', avatar_url,
@@ -1043,6 +1122,38 @@ function issuedWebSessionSelect(webSessionAlias: string, accountAlias: string): 
     'createdAt', to_char(${webSessionAlias}.created_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
     'expiresAt', to_char(${webSessionAlias}.expires_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
   )`;
+}
+
+function buildRegistrationFields(input: StartRegistrationInput): {
+  handle: string;
+  email?: string;
+  displayName?: string;
+} {
+  const email = normalizeEmail(input.email);
+  const handle = buildPublicHandle(input.handle ?? email ?? "user");
+
+  return {
+    handle,
+    email,
+    displayName: input.displayName,
+  };
+}
+
+function normalizeEmail(value: string | undefined): string | undefined {
+  const normalized = value?.trim().toLowerCase();
+  return normalized || undefined;
+}
+
+function buildPublicHandle(value: string): string {
+  const source = value.includes("@") ? value.split("@")[0] ?? value : value;
+  const handle = source
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 32);
+
+  return handle || `user-${randomBytes(3).toString("hex")}`;
 }
 
 async function queryJson<T>(sql: string, variables?: Record<string, string>): Promise<T> {

--- a/apps/web/src/lib/ui.ts
+++ b/apps/web/src/lib/ui.ts
@@ -3,6 +3,10 @@ import type { Actor } from "../types";
 
 export function readErrorMessage(cause: unknown): string {
   if (cause instanceof ApiClientError) {
+    if (cause.statusCode === 429) {
+      return "Too many attempts in a short window. Wait a minute, then try again.";
+    }
+
     return cause.message;
   }
 

--- a/apps/web/src/pages/AuthPage.test.tsx
+++ b/apps/web/src/pages/AuthPage.test.tsx
@@ -41,7 +41,7 @@ describe("AuthPage", () => {
     expect(
       screen.getByRole("heading", { name: /sign in with email and a passkey/i }),
     ).toBeInTheDocument();
-    expect(screen.getByLabelText("Email")).toBeInTheDocument();
+    expect(screen.getByLabelText("Email or handle")).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "Sign in" })).toHaveAttribute("aria-selected", "true");
     expect(screen.getByRole("tab", { name: "Sign up" })).toHaveAttribute("aria-selected", "false");
     expect(screen.getByRole("button", { name: /continue with passkey/i })).toBeInTheDocument();
@@ -74,7 +74,7 @@ describe("AuthPage", () => {
     const api = buildApi({
       startAuthentication: vi.fn().mockResolvedValue({
         id: "aas-1",
-        handle: "eric@example.com",
+        handle: "eric",
         displayName: "Eric",
         status: "awaiting_authentication",
         challenge: "AQIDBA",
@@ -112,7 +112,7 @@ describe("AuthPage", () => {
       </MemoryRouter>,
     );
 
-    await user.type(screen.getByLabelText("Email"), "Eric@Example.com");
+    await user.type(screen.getByLabelText("Email or handle"), "Eric@Example.com");
     await user.click(screen.getByRole("button", { name: /continue with passkey/i }));
 
     await waitFor(() => {
@@ -232,7 +232,7 @@ describe("AuthPage", () => {
       </MemoryRouter>,
     );
 
-    await user.type(screen.getByLabelText("Email"), "Eric@Example.com");
+    await user.type(screen.getByLabelText("Email or handle"), "Eric@Example.com");
     await user.click(screen.getByRole("button", { name: /continue with passkey/i }));
 
     await waitFor(() => {
@@ -240,7 +240,7 @@ describe("AuthPage", () => {
     });
   });
 
-  it("creates a passkey account, then signs in and returns to the requested route", async () => {
+  it("creates a passkey account, signs in, and opens profile next steps", async () => {
     const user = userEvent.setup();
     const createCredential = vi.fn().mockResolvedValue(
       buildCredential({
@@ -288,7 +288,7 @@ describe("AuthPage", () => {
         rp: { id: "localhost", name: "TheAgentForum" },
         user: {
           id: "BQYHCA",
-          name: "eric@example.com",
+          name: "eric",
           displayName: "Eric",
         },
         challenge: "AQIDBA",
@@ -326,7 +326,7 @@ describe("AuthPage", () => {
       }),
       authenticatePasskey: vi.fn().mockResolvedValue({
         id: "aas-1",
-        handle: "eric@example.com",
+        handle: "eric",
         displayName: "Eric",
         status: "verified",
         challenge: "AQIDBA",
@@ -336,27 +336,44 @@ describe("AuthPage", () => {
         expiresAt: "2026-03-26T00:15:00.000Z",
         verifiedAt: "2026-03-26T00:01:00.000Z",
       }),
+      getAuthSession: vi
+        .fn()
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({
+          actor: {
+            id: "acct-1",
+            kind: "human",
+            handle: "eric",
+            displayName: "Eric",
+          },
+          createdAt: "2026-03-26T00:00:00.000Z",
+          expiresAt: "2026-04-02T00:00:00.000Z",
+        }),
     });
 
     render(
       <MemoryRouter initialEntries={["/auth?mode=signup&returnTo=/done"]}>
-        <Routes>
-          <Route path="/auth" element={<AuthPage api={api} />} />
-          <Route path="/done" element={<p>done</p>} />
-        </Routes>
+        <AuthProvider api={api}>
+          <Routes>
+            <Route path="/auth" element={<AuthPage api={api} />} />
+            <Route path="/profile" element={<p>profile next step</p>} />
+            <Route path="/done" element={<p>done</p>} />
+          </Routes>
+        </AuthProvider>
       </MemoryRouter>,
     );
 
     await user.click(screen.getByRole("tab", { name: "Sign up" }));
-    await user.type(screen.getByLabelText("Email"), "eric@example.com");
+    await user.type(screen.getByLabelText("Private email"), "eric@example.com");
     await user.click(screen.getByRole("button", { name: /create passkey/i }));
 
     await waitFor(() => {
-      expect(screen.getByText("done")).toBeInTheDocument();
+      expect(screen.getByText("profile next step")).toBeInTheDocument();
     });
 
     expect(api.startRegistration).toHaveBeenCalledWith({
-      handle: "eric@example.com",
+      email: "eric@example.com",
+      handle: "eric",
       displayName: "Eric",
     });
     expect(api.registerPasskey).toHaveBeenCalled();
@@ -408,7 +425,7 @@ describe("AuthPage", () => {
         rp: { id: "localhost", name: "TheAgentForum" },
         user: {
           id: "BQYHCA",
-          name: "eric@example.com",
+          name: "eric",
           displayName: "Eric",
         },
         challenge: "AQIDBA",
@@ -491,7 +508,7 @@ function buildApi(overrides: Partial<ApiClient> = {}): ApiClient {
 function buildRegistrationSession() {
   return {
     id: "ars-1",
-    handle: "eric@example.com",
+    handle: "eric",
     displayName: "Eric",
     status: "pending_webauthn_registration" as const,
     challenge: "AQIDBA",

--- a/apps/web/src/pages/AuthPage.tsx
+++ b/apps/web/src/pages/AuthPage.tsx
@@ -96,6 +96,8 @@ function EmailPasskeyAuthPage({
   const requestedMode = readRequestedMode(searchParams.get("mode"));
   const [mode, setMode] = useState<AuthMode>(requestedMode ?? "signin");
   const [identifier, setIdentifier] = useState("");
+  const [publicHandle, setPublicHandle] = useState("");
+  const [publicHandleEdited, setPublicHandleEdited] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
@@ -105,6 +107,14 @@ function EmailPasskeyAuthPage({
       setMode(requestedMode);
     }
   }, [requestedMode]);
+
+  useEffect(() => {
+    if (mode !== "signup" || publicHandleEdited) {
+      return;
+    }
+
+    setPublicHandle(derivePublicHandleFromIdentifier(identifier));
+  }, [identifier, mode, publicHandleEdited]);
 
   const isSignedInState = isAuthenticated && !requestedMode;
 
@@ -132,6 +142,14 @@ function EmailPasskeyAuthPage({
 
     if (!nextSession?.actor.id) {
       navigate(returnTo, { replace: true });
+      return;
+    }
+
+    if (flow === "signup") {
+      navigate(
+        `/profile?onboarding=1&created=passkey&returnTo=${encodeURIComponent(returnTo)}`,
+        { replace: true },
+      );
       return;
     }
 
@@ -165,7 +183,7 @@ function EmailPasskeyAuthPage({
     try {
       await finishPasskeySignIn(nextIdentifier, "signin");
     } catch (cause) {
-      const message = readErrorMessage(cause);
+      const message = readPasskeyErrorMessage(cause);
       setError(message);
       captureClientEvent("taf_auth_signin_failed", {
         error_message: message,
@@ -177,22 +195,30 @@ function EmailPasskeyAuthPage({
 
   async function handleSignUp(): Promise<void> {
     const nextIdentifier = normalizeIdentifier(identifier);
+    const nextPublicHandle = normalizePublicHandle(
+      publicHandle || derivePublicHandleFromIdentifier(nextIdentifier),
+    );
 
     if (!isValidEmail(nextIdentifier)) {
       setError("Enter a valid email to create an account.");
       return;
     }
 
+    if (!nextPublicHandle) {
+      setError("Choose a public handle for posts and replies.");
+      return;
+    }
+
     setBusy(true);
     setError(null);
-    setStatusMessage("Saving your passkey.");
+    setStatusMessage("Your email stays private. The browser will ask you to save a passkey.");
     captureClientEvent("taf_auth_signup_started");
 
     try {
       const displayName = deriveDisplayNameFromIdentifier(nextIdentifier);
-      // TODO: split private sign-in email from public account handle in the backend contract.
       const registrationSession = await api.startRegistration({
-        handle: nextIdentifier,
+        email: nextIdentifier,
+        handle: nextPublicHandle,
         displayName,
       });
       const options = await api.getPasskeyRegistrationOptions(registrationSession.id);
@@ -204,10 +230,10 @@ function EmailPasskeyAuthPage({
         passkeyLabel: `${displayName} passkey`,
       });
 
-      setStatusMessage("Passkey saved. Finishing sign in.");
+      setStatusMessage("Passkey saved. Signing you in, then profile setup opens.");
       await finishPasskeySignIn(nextIdentifier, "signup");
     } catch (cause) {
-      const message = readErrorMessage(cause);
+      const message = readPasskeyErrorMessage(cause);
       setError(message);
       setStatusMessage(null);
       captureClientEvent("taf_auth_signup_failed", {
@@ -312,7 +338,7 @@ function EmailPasskeyAuthPage({
 
             <div className="auth-entry-form">
               <label className="field" htmlFor="auth-identifier">
-                <span>Email</span>
+                <span>{mode === "signup" ? "Private email" : "Email or handle"}</span>
                 <input
                   id="auth-identifier"
                   type="text"
@@ -326,13 +352,29 @@ function EmailPasskeyAuthPage({
               </label>
 
               {mode === "signup" ? (
-                <p className="auth-entry-note">
-                  Alpha note: this email is also your current account identifier
-                  until profile handles split from sign-in email.
-                </p>
+                <>
+                  <label className="field" htmlFor="auth-public-handle">
+                    <span>Public handle</span>
+                    <input
+                      id="auth-public-handle"
+                      type="text"
+                      autoComplete="nickname"
+                      value={publicHandle}
+                      onChange={(event) => {
+                        setPublicHandleEdited(true);
+                        setPublicHandle(normalizePublicHandle(event.target.value));
+                      }}
+                      placeholder="eric"
+                      disabled={busy}
+                    />
+                  </label>
+                  <p className="auth-entry-note">
+                    Your email is only for sign-in. Posts, replies, and profile links use the public handle.
+                  </p>
+                </>
               ) : (
                 <p className="auth-entry-note">
-                  Legacy passkey accounts can still use their existing handle.
+                  Use the email you signed up with, or a legacy public handle from an earlier account.
                 </p>
               )}
 
@@ -358,6 +400,9 @@ function EmailPasskeyAuthPage({
                   Pair an agent instead
                 </Link>
               </div>
+              <p className="auth-entry-note">
+                If the passkey prompt closes, nothing is saved until this page reports success.
+              </p>
             </div>
           </>
         )}
@@ -476,14 +521,15 @@ function PairingAuthPage({
     captureClientEvent("taf_pairing_started");
 
     try {
+      const displayNameValue = displayName.trim() || deriveDisplayNameFromIdentifier(nextIdentifier);
       const session = await api.startRegistration({
-        handle: nextIdentifier,
-        displayName: displayName.trim() || deriveDisplayNameFromIdentifier(nextIdentifier),
+        ...buildRegistrationIdentity(nextIdentifier),
+        displayName: displayNameValue,
       });
       setRegistrationSession(session);
       setPasskeyLabel(`${session.displayName ?? session.handle} device passkey`);
     } catch (cause) {
-      const message = readErrorMessage(cause);
+      const message = readPasskeyErrorMessage(cause);
       setError(message);
       captureClientEvent("taf_pairing_failed", {
         stage: "start",
@@ -534,7 +580,7 @@ function PairingAuthPage({
       );
       captureClientEvent("taf_pairing_passkey_registered");
     } catch (cause) {
-      const message = readErrorMessage(cause);
+      const message = readPasskeyErrorMessage(cause);
       setError(message);
       captureClientEvent("taf_pairing_failed", {
         stage: "passkey",
@@ -713,7 +759,7 @@ function PairingAuthPage({
                 {registrationStage === "start" ? (
                   <div className="auth-terminal-form">
                     <label className="auth-terminal-field">
-                      <span>Account email or handle</span>
+                      <span>Account email or public handle</span>
                       <input
                         value={identifier}
                         onChange={(event) => setIdentifier(event.target.value)}
@@ -732,8 +778,8 @@ function PairingAuthPage({
                     </label>
 
                     <p className="auth-terminal-note">
-                      Already started from a CLI? Open the verification link here
-                      and the handoff will resume automatically.
+                      If you enter an email, it stays private. The public account handle is derived from it unless
+                      an existing account already matches.
                     </p>
 
                     <div className="auth-stage-card__actions">
@@ -1033,8 +1079,49 @@ function normalizeIdentifier(value: string): string {
   return value.trim().toLowerCase();
 }
 
+function normalizePublicHandle(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 32);
+}
+
+function derivePublicHandleFromIdentifier(value: string): string {
+  const normalized = normalizeIdentifier(value);
+  const source = normalized.includes("@")
+    ? normalized.split("@")[0] ?? normalized
+    : normalized;
+
+  return normalizePublicHandle(source);
+}
+
+function buildRegistrationIdentity(identifier: string): { email?: string; handle?: string } {
+  if (isValidEmail(identifier)) {
+    return {
+      email: identifier,
+      handle: derivePublicHandleFromIdentifier(identifier),
+    };
+  }
+
+  return {
+    handle: normalizePublicHandle(identifier),
+  };
+}
+
 function isValidEmail(value: string): boolean {
   return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+}
+
+function readPasskeyErrorMessage(cause: unknown): string {
+  if (cause instanceof DOMException) {
+    if (cause.name === "NotAllowedError" || cause.name === "AbortError") {
+      return "The passkey prompt was canceled or timed out. Try again when you are ready to approve it.";
+    }
+  }
+
+  return readErrorMessage(cause);
 }
 
 type BrowserCredentialWithAttestation = {

--- a/apps/web/src/pages/ProfilePage.test.tsx
+++ b/apps/web/src/pages/ProfilePage.test.tsx
@@ -34,7 +34,7 @@ describe("ProfilePage", () => {
         actor: {
           id: "acct-1",
           kind: "human",
-          handle: "eric@example.com",
+          handle: "eric",
           displayName: "Eric",
         },
         createdAt: "2026-04-24T03:00:00.000Z",
@@ -44,7 +44,7 @@ describe("ProfilePage", () => {
         actor: {
           id: "acct-1",
           kind: "human",
-          handle: "eric@example.com",
+          handle: "eric",
           displayName: "Launch Eric",
         },
         createdAt: "2026-04-24T03:00:00.000Z",
@@ -55,14 +55,16 @@ describe("ProfilePage", () => {
       getAuthSession,
       getMyProfile: vi.fn().mockResolvedValue({
         id: "acct-1",
-        handle: "eric@example.com",
+        handle: "eric",
+        email: "eric@example.com",
         displayName: "Eric",
         createdAt: "2026-04-24T03:00:00.000Z",
         updatedAt: "2026-04-24T03:00:00.000Z",
       }),
       updateMyProfile: vi.fn().mockResolvedValue({
         id: "acct-1",
-        handle: "eric@example.com",
+        handle: "eric",
+        email: "eric@example.com",
         displayName: "Launch Eric",
         bio: "Ships the launch checklist.",
         createdAt: "2026-04-24T03:00:00.000Z",
@@ -90,6 +92,8 @@ describe("ProfilePage", () => {
     await waitFor(() => {
       expect(screen.getByRole("heading", { name: /public profile fields/i })).toBeInTheDocument();
     });
+
+    expect(screen.getByLabelText("Private sign-in email")).toHaveValue("eric@example.com");
 
     await user.clear(screen.getByLabelText("Display name"));
     await user.type(screen.getByLabelText("Display name"), "Launch Eric");

--- a/apps/web/src/pages/ProfilePage.tsx
+++ b/apps/web/src/pages/ProfilePage.tsx
@@ -19,6 +19,7 @@ export function ProfilePage({ api }: ProfilePageProps) {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const onboarding = searchParams.get("onboarding") === "1";
+  const passkeyCreated = searchParams.get("created") === "passkey";
   const returnTo = readSafeReturnTo(searchParams.get("returnTo"));
   const [profile, setProfile] = useState<AccountProfile | null>(null);
   const [draft, setDraft] = useState<UpdateAccountProfileInput>({
@@ -110,7 +111,7 @@ export function ProfilePage({ api }: ProfilePageProps) {
         bio: updated.bio ?? "",
         avatarUrl: updated.avatarUrl ?? "",
       });
-      setNotice(onboarding ? "Profile saved. Returning to your previous route." : "Profile saved.");
+      setNotice(onboarding ? "Profile saved. Opening the forum next." : "Profile saved.");
       clearOnboardingSkip(updated.handle);
       await auth.refreshSession();
       captureClientEvent("taf_profile_updated", {
@@ -163,8 +164,8 @@ export function ProfilePage({ api }: ProfilePageProps) {
         <p className="terminal-eyebrow">/profile</p>
         <h1>profile + identity</h1>
         <p className="terminal-lead">
-          Your handle is stable for now. Display name, bio, and avatar stay editable so the public account surface
-          can ship without reopening the passkey-first auth flow.
+          Your public handle is what other people and agents see. Your private sign-in email stays separate from
+          public posts, replies, and profile links.
         </p>
         <div className="terminal-actions">
           <Link className="terminal-link-button" to="/settings">
@@ -180,10 +181,10 @@ export function ProfilePage({ api }: ProfilePageProps) {
         <section className="terminal-side-card terminal-profile-banner">
           <div>
             <p className="terminal-eyebrow">post-login nudge</p>
-            <h2>Finish the minimum public profile</h2>
+            <h2>{passkeyCreated ? "Passkey created. Finish your profile." : "Finish the minimum public profile"}</h2>
             <p>
-              Add enough context that replies and paired-agent activity are not anonymous blobs. You can skip and come
-              back later.
+              Add enough context that replies and paired-agent activity are recognizable. Pairing an agent is optional;
+              after this, ask the first public-test question.
             </p>
           </div>
           <div className="terminal-actions">
@@ -250,12 +251,22 @@ export function ProfilePage({ api }: ProfilePageProps) {
 
             <div className="terminal-profile-form">
               <label className="field">
-                <span>Stable handle</span>
-                <input value={profile.handle} readOnly aria-label="Stable handle" />
+                <span>Public handle</span>
+                <input value={profile.handle} readOnly aria-label="Public handle" />
                 <small className="field-hint">
-                  Auth keeps this fixed for now. The current launch pass still uses your sign-in email as the handle.
+                  This appears on posts and profile links. It is separate from your private sign-in email.
                 </small>
               </label>
+
+              {profile.email ? (
+                <label className="field">
+                  <span>Private sign-in email</span>
+                  <input value={profile.email} readOnly aria-label="Private sign-in email" />
+                  <small className="field-hint">
+                    Used for passkey sign-in only. It is not shown as your public author handle.
+                  </small>
+                </label>
+              ) : null}
 
               <label className="field">
                 <span>Display name</span>

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -126,8 +126,8 @@ export function SettingsPage({ api }: SettingsPageProps) {
         <p className="terminal-eyebrow">/settings/auth</p>
         <h1>account + device graph</h1>
         <p className="terminal-lead">
-          Verify which passkeys and paired agents are still trusted, refresh the live auth state from the API, and
-          launch the next pairing flow without leaving the terminal surface.
+          Verify the current browser session, registered passkeys, and paired agents. Public handle visibility stays
+          here; private email is only shown on your profile editor.
         </p>
         <div className="terminal-actions">
           <button
@@ -191,7 +191,7 @@ export function SettingsPage({ api }: SettingsPageProps) {
             <h2>Current session</h2>
             <dl className="terminal-settings-meta">
               <div>
-                <dt>handle</dt>
+                <dt>public handle</dt>
                 <dd>{auth.session.actor.handle}</dd>
               </div>
               <div>
@@ -264,7 +264,10 @@ export function SettingsPage({ api }: SettingsPageProps) {
                   <li key={device.id}>
                     <div>
                       <strong>{device.deviceLabel}</strong>
-                      <p>Status: {device.status} · paired {formatDate(device.createdAt)}</p>
+                      <p>
+                        Status: {device.status} · paired {formatDate(device.createdAt)} · expires{" "}
+                        {formatDate(device.expiresAt)}
+                      </p>
                     </div>
                     <button
                       className="terminal-mini-button"

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -72,7 +72,8 @@ export interface CreateAnswerInput {
 }
 
 export interface StartRegistrationInput {
-  handle: string;
+  handle?: string;
+  email?: string;
   displayName?: string;
 }
 
@@ -250,6 +251,7 @@ export interface AuthDevice {
 export interface AccountProfile {
   id: string;
   handle: string;
+  email?: string;
   displayName?: string;
   bio?: string;
   avatarUrl?: string;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -120,7 +120,8 @@ export interface RegistrationSession {
 }
 
 export interface StartRegistrationInput {
-  handle: string;
+  handle?: string;
+  email?: string;
   displayName?: string;
 }
 
@@ -253,6 +254,7 @@ export interface AuthDevice {
 export interface AccountProfile {
   id: string;
   handle: string;
+  email?: string;
   displayName?: string;
   bio?: string;
   avatarUrl?: string;

--- a/packages/db/sql/001-init.sql
+++ b/packages/db/sql/001-init.sql
@@ -45,6 +45,7 @@ create index if not exists answer_skills_question_answer_idx
 create table if not exists auth_accounts (
   id text primary key default ('acct-' || nextval('auth_account_id_seq')),
   handle text not null unique,
+  email text,
   display_name text,
   bio text,
   avatar_url text,
@@ -53,10 +54,17 @@ create table if not exists auth_accounts (
 );
 
 alter table auth_accounts
+  add column if not exists email text;
+
+alter table auth_accounts
   add column if not exists bio text;
 
 alter table auth_accounts
   add column if not exists avatar_url text;
+
+create unique index if not exists auth_accounts_email_lower_idx
+  on auth_accounts (lower(email))
+  where email is not null;
 
 create table if not exists auth_registration_sessions (
   id text primary key default ('ars-' || nextval('auth_registration_session_id_seq')),


### PR DESCRIPTION
## Summary
- split auth signup/sign-in inputs into private email plus public handle, keeping forum authorship on the public identity
- polish passkey onboarding copy, progress guidance, success/next-step states, and profile/pairing messaging for first public testers
- surface clearer profile/settings identity guidance and improve auth validation coverage for the new private/public identity model

## Validation
- `npm run typecheck --workspace @theagentforum/api`
- `npm run test --workspace @theagentforum/api -- --run`
- `npm run typecheck --workspace @theagentforum/web`
- `npm run test --workspace @theagentforum/web -- src/pages/AuthPage.test.tsx src/pages/ProfilePage.test.tsx --run`
- `npm run build --workspace @theagentforum/web`

## Notes
- Existing users remain compatible; new signup flows can store email privately while presenting the handle publicly.
- Rate-limit enforcement itself is not implemented here; this focuses on UX/identity/onboarding polish.