### PR TITLE
Implement native article content creation

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -15,6 +15,7 @@ import type {
   UpdateAccountProfileInput,
 } from "@theagentforum/core";
 import type { AuthStore } from "./auth-store";
+import type { ArticleStore } from "./article-store";
 import type { QuestionStore } from "./question-store";
 import type { ForumStore } from "./forum-store";
 import { createForumAdapter } from "./forum-adapter";
@@ -27,6 +28,7 @@ import {
 } from "./webauthn";
 
 interface CreateAppOptions {
+  articleStore?: ArticleStore;
   corsAllowOrigin?: string;
 }
 
@@ -38,7 +40,7 @@ export function createApp(
   options: CreateAppOptions = {},
 ) {
   const corsAllowOrigin = options.corsAllowOrigin ?? "*";
-  const forumStore: ForumStore = createForumAdapter(questionStore);
+  const forumStore: ForumStore = createForumAdapter(questionStore, options.articleStore);
 
   return async function app(
     req: IncomingMessage,

--- a/apps/api/src/article-store.ts
+++ b/apps/api/src/article-store.ts
@@ -1,0 +1,13 @@
+import type { ArticleContent, Actor } from "@theagentforum/core";
+
+export interface CreateArticleInput {
+  title: string;
+  body: string;
+  author: Actor;
+}
+
+export interface ArticleStore {
+  listArticles(): Promise<ArticleContent[]>;
+  createArticle(input: CreateArticleInput): Promise<ArticleContent>;
+  getArticle(articleId: string): Promise<ArticleContent | null>;
+}

--- a/apps/api/src/forum-adapter.ts
+++ b/apps/api/src/forum-adapter.ts
@@ -1,42 +1,78 @@
 import type {
   Answer,
-  CreateAnswerInput,
-  Question,
-  ThreadSearchResult,
-} from "@theagentforum/core";
-import type {
-  Comment,
+  ArticleContent,
   Content,
+  ContentSearchMatchSource,
   ContentThread,
+  ContentThreadSearchMatch,
   ContentThreadSearchResult,
+  CreateAnswerInput,
   CreateCommentInput,
   CreateContentInput,
+  Question,
   QuestionContent,
 } from "@theagentforum/core";
+import type { ArticleStore } from "./article-store";
 import type { ForumStore } from "./forum-store";
+import { createInMemoryArticleStore } from "./memory-article-store";
 import type { QuestionStore, QuestionThread } from "./question-store";
 
-export function createForumAdapter(questionStore: QuestionStore): ForumStore {
+export function createForumAdapter(
+  questionStore: QuestionStore,
+  articleStore: ArticleStore = createInMemoryArticleStore(),
+): ForumStore {
   async function listContents(type?: Content["type"]): Promise<Content[]> {
-    if (!type || type === "question") {
+    if (type === "question") {
       const questions = await questionStore.listQuestions();
       return questions.map(mapQuestionToContent);
     }
 
-    // Articles not yet backed by storage in v2 MVP
-    return [];
+    if (type === "article") {
+      return articleStore.listArticles();
+    }
+
+    const [questions, articles] = await Promise.all([
+      questionStore.listQuestions(),
+      articleStore.listArticles(),
+    ]);
+
+    return [...questions.map(mapQuestionToContent), ...articles].sort(compareContentByCreatedAtDesc);
   }
 
   async function searchThreads(
     query: string,
     options: { type?: Content["type"]; status?: Question["status"]; limit?: number } = {},
   ): Promise<ContentThreadSearchResult> {
-    const type = options.type ?? "question";
-
-    if (type !== "question") {
-      return emptySearchResult(query);
+    if (options.type === "question") {
+      return searchQuestionThreads(query, options);
     }
 
+    if (options.type === "article") {
+      return searchArticleThreads(query, options.limit);
+    }
+
+    const [questionResult, articleResult] = await Promise.all([
+      searchQuestionThreads(query, options),
+      searchArticleThreads(query, options.limit),
+    ]);
+
+    const matches = [...questionResult.matches, ...articleResult.matches]
+      .sort((left, right) => right.score - left.score)
+      .slice(0, options.limit ?? Number.POSITIVE_INFINITY);
+
+    return {
+      query,
+      strategy: "keyword_v1",
+      totalMatches: questionResult.totalMatches + articleResult.totalMatches,
+      returned: matches.length,
+      matches,
+    };
+  }
+
+  async function searchQuestionThreads(
+    query: string,
+    options: { status?: Question["status"]; limit?: number } = {},
+  ): Promise<ContentThreadSearchResult> {
     const result = await questionStore.searchThreads(query, {
       status: options.status,
       limit: options.limit,
@@ -49,15 +85,37 @@ export function createForumAdapter(questionStore: QuestionStore): ForumStore {
       returned: result.returned,
       matches: result.matches.map((m) => ({
         score: m.score,
-        matchSources: m.matchSources.map((s) => (s === "answer" ? "comment" : (s as any))),
+        matchSources: m.matchSources.map((s) => (s === "answer" ? "comment" : (s as ContentSearchMatchSource))),
         content: mapQuestionToContent(m.question),
       })),
     };
   }
 
+  async function searchArticleThreads(query: string, limit?: number): Promise<ContentThreadSearchResult> {
+    const normalizedQuery = normalizeSearchText(query);
+    const matches = (await articleStore.listArticles())
+      .map((article) => rankArticle(article, normalizedQuery))
+      .filter((match): match is ContentThreadSearchMatch => Boolean(match))
+      .sort((left, right) => right.score - left.score);
+
+    const returnedMatches = matches.slice(0, limit ?? matches.length);
+
+    return {
+      query,
+      strategy: "keyword_v1",
+      totalMatches: matches.length,
+      returned: returnedMatches.length,
+      matches: returnedMatches,
+    };
+  }
+
   async function createContent(input: CreateContentInput): Promise<Content> {
-    if (input.type !== "question") {
-      throw createNotImplementedError("Only type=question is supported in v2 MVP.");
+    if (input.type === "article") {
+      return articleStore.createArticle({
+        title: input.title,
+        body: input.body,
+        author: input.author,
+      });
     }
 
     const q = await questionStore.createQuestion({
@@ -70,6 +128,11 @@ export function createForumAdapter(questionStore: QuestionStore): ForumStore {
   }
 
   async function getContentThread(contentId: string): Promise<ContentThread | null> {
+    if (isArticleId(contentId)) {
+      const article = await articleStore.getArticle(contentId);
+      return article ? { content: article, comments: [] } : null;
+    }
+
     if (!isQuestionId(contentId)) {
       return null;
     }
@@ -119,6 +182,10 @@ function isQuestionId(id: string): boolean {
   return /^q-/.test(id);
 }
 
+function isArticleId(id: string): boolean {
+  return /^art-/.test(id);
+}
+
 function mapQuestionToContent(q: Question): QuestionContent {
   return {
     id: q.id,
@@ -132,7 +199,7 @@ function mapQuestionToContent(q: Question): QuestionContent {
   };
 }
 
-function mapAnswerToComment(a: Answer): Comment {
+function mapAnswerToComment(a: Answer): ContentThread["comments"][number] {
   return {
     id: a.id,
     contentId: a.questionId,
@@ -154,14 +221,33 @@ function mapCreateCommentToAnswerInput(input: CreateCommentInput): CreateAnswerI
   return { body: input.body, author: input.author };
 }
 
-function emptySearchResult(query: string): ContentThreadSearchResult {
-  return { query, strategy: "keyword_v1", totalMatches: 0, returned: 0, matches: [] };
+function rankArticle(article: ArticleContent, normalizedQuery: string): ContentThreadSearchMatch | null {
+  const title = normalizeSearchText(article.title);
+  const body = normalizeSearchText(article.body);
+  const matchSources: ContentSearchMatchSource[] = [];
+  let score = 0;
+
+  if (title.includes(normalizedQuery)) {
+    matchSources.push("title");
+    score += 5;
+  }
+
+  if (body.includes(normalizedQuery)) {
+    matchSources.push("body");
+    score += 2;
+  }
+
+  if (matchSources.length === 0) {
+    return null;
+  }
+
+  return { score, matchSources, content: article };
 }
 
-function createNotImplementedError(message: string): Error & { statusCode: number; code: string } {
-  const error = new Error(message) as Error & { statusCode: number; code: string };
-  error.statusCode = 501;
-  error.code = "not_implemented";
-  return error;
+function normalizeSearchText(value: string): string {
+  return value.trim().toLowerCase();
 }
 
+function compareContentByCreatedAtDesc(left: Content, right: Content): number {
+  return right.createdAt.localeCompare(left.createdAt);
+}

--- a/apps/api/src/http.v2.test.ts
+++ b/apps/api/src/http.v2.test.ts
@@ -87,6 +87,69 @@ describe("HTTP API v2 forum", () => {
     assert.equal(thread.status, 200);
     assert.equal(thread.body.data.comments[0].id, accepted.body.data.comments[0].id);
   });
+
+  it("creates, lists, fetches, and searches native articles", async () => {
+    const authStore = createInMemoryAuthStore();
+    const app = createApp(createInMemoryQuestionStore(), authStore);
+    const cookieHeader = await createAuthenticatedCookie(authStore, {
+      handle: "article-author",
+      displayName: "Article Author",
+    });
+
+    const question = await requestJson(app, "/v2/contents", {
+      method: "POST",
+      headers: {
+        cookie: cookieHeader,
+      },
+      body: { type: "question", title: "Question title", body: "Question body", author: spoofedHuman },
+    });
+    assert.equal(question.status, 201);
+
+    const article = await requestJson(app, "/v2/contents", {
+      method: "POST",
+      headers: {
+        cookie: cookieHeader,
+      },
+      body: {
+        type: "article",
+        title: "Native Article Title",
+        body: "Durable article body for search",
+        author: spoofedAgent,
+      },
+    });
+
+    assert.equal(article.status, 201);
+    assert.equal(article.body.data.type, "article");
+    assert.match(article.body.data.id, /^art-/);
+    assert.equal(article.body.data.author.handle, "article-author");
+
+    const articles = await requestJson(app, "/v2/contents?type=article");
+    assert.equal(articles.status, 200);
+    assert.deepEqual(
+      articles.body.data.map((item: any) => item.type),
+      ["article"],
+    );
+
+    const allContents = await requestJson(app, "/v2/contents");
+    assert.equal(allContents.status, 200);
+    assert.deepEqual(
+      allContents.body.data.map((item: any) => item.type).sort(),
+      ["article", "question"],
+    );
+
+    const thread = await requestJson(app, `/v2/contents/${article.body.data.id}`);
+    assert.equal(thread.status, 200);
+    assert.equal(thread.body.data.content.id, article.body.data.id);
+    assert.equal(thread.body.data.content.type, "article");
+    assert.deepEqual(thread.body.data.comments, []);
+
+    const search = await requestJson(app, "/v2/search/threads?query=durable&type=article");
+    assert.equal(search.status, 200);
+    assert.equal(search.body.data.totalMatches, 1);
+    assert.equal(search.body.data.matches[0].content.id, article.body.data.id);
+    assert.deepEqual(search.body.data.matches[0].matchSources, ["body"]);
+  });
+
 });
 
 async function createAuthenticatedCookie(

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,5 +1,6 @@
 import { createServer } from "node:http";
 import { createApp } from "./app";
+import { createPostgresArticleStore } from "./postgres-article-store";
 import { createPostgresAuthStore } from "./postgres-auth-store";
 import { createPostgresQuestionStore } from "./postgres-question-store";
 import { runSqlFile } from "./postgres";
@@ -12,7 +13,8 @@ async function main(): Promise<void> {
 
   const questionStore = createPostgresQuestionStore();
   const authStore = createPostgresAuthStore();
-  const app = createApp(questionStore, authStore, { corsAllowOrigin });
+  const articleStore = createPostgresArticleStore();
+  const app = createApp(questionStore, authStore, { articleStore, corsAllowOrigin });
   const server = createServer(app);
 
   server.listen(port, () => {

--- a/apps/api/src/memory-article-store.ts
+++ b/apps/api/src/memory-article-store.ts
@@ -1,0 +1,43 @@
+import type { ArticleContent } from "@theagentforum/core";
+import type { ArticleStore, CreateArticleInput } from "./article-store";
+
+export function createInMemoryArticleStore(): ArticleStore {
+  const articles = new Map<string, ArticleContent>();
+  let articleSequence = 1;
+
+  async function listArticles(): Promise<ArticleContent[]> {
+    return Array.from(articles.values()).sort(compareByCreatedAtDesc).map(cloneArticle);
+  }
+
+  async function createArticle(input: CreateArticleInput): Promise<ArticleContent> {
+    const article: ArticleContent = {
+      id: `art-${articleSequence++}`,
+      type: "article",
+      title: input.title,
+      body: input.body,
+      author: input.author,
+      createdAt: new Date().toISOString(),
+    };
+
+    articles.set(article.id, article);
+    return cloneArticle(article);
+  }
+
+  async function getArticle(articleId: string): Promise<ArticleContent | null> {
+    const article = articles.get(articleId);
+    return article ? cloneArticle(article) : null;
+  }
+
+  return { listArticles, createArticle, getArticle };
+}
+
+function cloneArticle(article: ArticleContent): ArticleContent {
+  return {
+    ...article,
+    author: { ...article.author },
+  };
+}
+
+function compareByCreatedAtDesc(left: ArticleContent, right: ArticleContent): number {
+  return right.createdAt.localeCompare(left.createdAt);
+}

--- a/apps/api/src/postgres-article-store.ts
+++ b/apps/api/src/postgres-article-store.ts
@@ -1,0 +1,78 @@
+import type { ArticleContent } from "@theagentforum/core";
+import type { ArticleStore, CreateArticleInput } from "./article-store";
+import { runSql } from "./postgres";
+
+export function createPostgresArticleStore(): ArticleStore {
+  return { listArticles, createArticle, getArticle };
+}
+
+async function listArticles(): Promise<ArticleContent[]> {
+  return queryJson<ArticleContent[]>(`
+    select coalesce(json_agg(article order by created_at desc), '[]'::json) :: text
+    from (
+      select
+        json_strip_nulls(json_build_object(
+          'id', a.id,
+          'type', 'article',
+          'title', a.title,
+          'body', a.body,
+          'author', a.author,
+          'createdAt', to_char(a.created_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+        )) as article,
+        a.created_at
+      from articles a
+      order by a.created_at desc
+    ) listed;
+  `);
+}
+
+async function createArticle(input: CreateArticleInput): Promise<ArticleContent> {
+  return queryJson<ArticleContent>(
+    `
+      insert into articles (title, body, author)
+      values (:'title', :'body', cast(:'author' as jsonb))
+      returning json_strip_nulls(json_build_object(
+        'id', id,
+        'type', 'article',
+        'title', title,
+        'body', body,
+        'author', author,
+        'createdAt', to_char(created_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+      )) :: text;
+    `,
+    {
+      title: input.title,
+      body: input.body,
+      author: JSON.stringify(input.author),
+    },
+  );
+}
+
+async function getArticle(articleId: string): Promise<ArticleContent | null> {
+  const output = await runSql(
+    `
+      select json_strip_nulls(json_build_object(
+        'id', id,
+        'type', 'article',
+        'title', title,
+        'body', body,
+        'author', author,
+        'createdAt', to_char(created_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+      )) :: text
+      from articles
+      where id = :'article_id';
+    `,
+    { article_id: articleId },
+  );
+
+  if (!output) {
+    return null;
+  }
+
+  return JSON.parse(output) as ArticleContent;
+}
+
+async function queryJson<T>(sql: string, variables?: Record<string, string>): Promise<T> {
+  const output = await runSql(sql, variables);
+  return JSON.parse(output) as T;
+}

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -1,4 +1,6 @@
+export { createPostgresArticleStore } from "./postgres-article-store";
 export { createPostgresQuestionStore, createPostgresQuestionStore as createQuestionStore } from "./postgres-question-store";
+export { createInMemoryArticleStore } from "./memory-article-store";
 export { createInMemoryQuestionStore } from "./memory-question-store";
 export { createPostgresAuthStore } from "./postgres-auth-store";
 export { createInMemoryAuthStore } from "./memory-auth-store";

--- a/packages/db/sql/001-init.sql
+++ b/packages/db/sql/001-init.sql
@@ -1,5 +1,6 @@
 create sequence if not exists question_id_seq;
 create sequence if not exists answer_id_seq;
+create sequence if not exists article_id_seq;
 create sequence if not exists auth_registration_session_id_seq;
 create sequence if not exists auth_pairing_session_id_seq;
 create sequence if not exists auth_account_id_seq;
@@ -41,6 +42,17 @@ create table if not exists answer_skills (
 
 create index if not exists answer_skills_question_answer_idx
   on answer_skills (question_id, answer_id, created_at);
+
+create table if not exists articles (
+  id text primary key default ('art-' || nextval('article_id_seq')),
+  title text not null,
+  body text not null,
+  author jsonb not null,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists articles_created_at_idx
+  on articles (created_at desc);
 
 create table if not exists auth_accounts (
   id text primary key default ('acct-' || nextval('auth_account_id_seq')),


### PR DESCRIPTION
## Summary\n- Add native article storage for v2 contents in memory and Postgres-backed API paths\n- Let POST /v2/contents create type=article instead of returning 501\n- Include articles in list/get/search flows with empty article comment threads\n- Add migration-safe articles table/sequence and v2 API coverage\n\n## Checks\n- npm run test --workspace @theagentforum/api\n- npm run build --workspace @theagentforum/api\n- npm run validate