### PR TITLE
Link thread breadcrumbs to filtered streams

### DIFF
--- a/apps/web/src/pages/TerminalGraphPages.test.tsx
+++ b/apps/web/src/pages/TerminalGraphPages.test.tsx
@@ -1,6 +1,6 @@
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { describe, expect, it, vi } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import { AuthProvider } from "../auth/AuthContext";
 import { ForumPage, LandingPage, PostDetailPage } from "./TerminalGraphPages";
 import type { ApiClient } from "../lib/api";
@@ -233,8 +233,43 @@ describe("TerminalGraphPages", () => {
       expect(screen.getByText(/patterns that survive across sessions/i)).toBeInTheDocument();
       expect(screen.getByText("Eric")).toBeInTheDocument();
       expect(screen.getByText("@lumen_cache")).toBeInTheDocument();
+      const breadcrumb = screen.getByRole("navigation", { name: /breadcrumb/i });
+      expect(breadcrumb).toBeInTheDocument();
+      expect(within(breadcrumb).getByRole("link", { name: "forum" })).toHaveAttribute("href", "/forum");
+      expect(within(breadcrumb).getByRole("link", { name: "posts" })).toHaveAttribute("href", "/forum?type=question");
       expect(screen.getByText("extract-claims@0.3")).toBeInTheDocument();
       expect(screen.getByRole("heading", { name: /sign in to reply/i })).toBeInTheDocument();
+    });
+  });
+
+  it("links article breadcrumbs back to the article stream", async () => {
+    const articleThread: QuestionThread = {
+      question: {
+        id: "art-1",
+        title: "Reusable context report",
+        body: "Long-form article content for durable context.",
+        status: "open",
+        createdAt: "2026-04-25T03:00:00.000Z",
+        author: questions[0].author,
+      },
+      answers: [],
+    };
+    const api = buildApi({ getQuestionThread: vi.fn().mockResolvedValue(articleThread) });
+
+    render(
+      <MemoryRouter initialEntries={["/posts/art-1"]}>
+        <Routes>
+          <Route path="/posts/:postId" element={<PostDetailPage api={api} />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(api.getQuestionThread).toHaveBeenCalledWith("art-1");
+      const breadcrumb = screen.getByRole("navigation", { name: /breadcrumb/i });
+      expect(within(breadcrumb).getByRole("link", { name: "forum" })).toHaveAttribute("href", "/forum");
+      expect(within(breadcrumb).getByRole("link", { name: "articles" })).toHaveAttribute("href", "/forum?type=article");
+      expect(within(breadcrumb).getByText("art-1")).toHaveAttribute("aria-current", "page");
     });
   });
 

--- a/apps/web/src/pages/TerminalGraphPages.tsx
+++ b/apps/web/src/pages/TerminalGraphPages.tsx
@@ -721,16 +721,19 @@ export function PostDetailPage({ api }: PostDetailPageProps) {
     () => Object.values(answerSkills).reduce((total, skills) => total + skills.length, 0),
     [answerSkills],
   );
+  const isArticle = resolvedId?.startsWith("art-") ?? false;
+  const contentListPath = isArticle ? "/forum?type=article" : "/forum?type=question";
+  const contentListLabel = isArticle ? "articles" : "posts";
 
   return (
     <TerminalPage>
-      <div className="terminal-breadcrumb">
+      <nav className="terminal-breadcrumb" aria-label="Breadcrumb">
         <Link to="/forum">forum</Link>
-        <span>/</span>
-        <span>posts</span>
-        <span>/</span>
-        <span>{resolvedId ?? "missing"}</span>
-      </div>
+        <span aria-hidden="true">/</span>
+        <Link to={contentListPath}>{contentListLabel}</Link>
+        <span aria-hidden="true">/</span>
+        <span aria-current="page">{resolvedId ?? "missing"}</span>
+      </nav>
 
       {error ? <p className="terminal-inline-error" role="alert">{error}</p> : null}
       {loading ? <p className="terminal-feed-card">Loading live post from the forum API…</p> : null}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3239,6 +3239,13 @@ ul {
 
 .terminal-breadcrumb a {
   color: var(--terminal-cyan);
+  text-decoration: none;
+}
+
+.terminal-breadcrumb a:hover,
+.terminal-breadcrumb a:focus-visible {
+  text-decoration: underline;
+  text-underline-offset: 0.18em;
 }
 
 .terminal-thread-main {


### PR DESCRIPTION
## Summary\n- Turn the thread breadcrumb into a real nav element\n- Link forum back to /forum\n- Link posts/articles crumb back to the matching filtered stream\n- Keep the current content id marked as aria-current\n\n## Checks\n- npm run test --workspace @theagentforum/web -- TerminalGraphPages\n- npm run build --workspace @theagentforum/web\n- npm run validate