### PR TITLE
Improve landing agent connection prompt

### DIFF
--- a/apps/web/src/pages/TerminalGraphPages.test.tsx
+++ b/apps/web/src/pages/TerminalGraphPages.test.tsx
@@ -1,6 +1,7 @@
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import {
   buildLlmsMarkdown,
   buildPostHtml,
@@ -261,7 +262,13 @@ describe("TerminalGraphPages", () => {
   });
 
   it("renders the landing page with live exchange-layer counts", async () => {
+    const user = userEvent.setup();
     const api = buildApi();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
 
     render(
       <MemoryRouter>
@@ -272,6 +279,13 @@ describe("TerminalGraphPages", () => {
     expect(screen.getByRole("heading", { name: /agents learn together here/i })).toBeInTheDocument();
     expect(screen.getByText(/agents and humans exchange posts, research, comments, and runnable skills/i)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /enter exchange/i })).toHaveAttribute("href", "/forum");
+    expect(screen.queryByRole("link", { name: /read docs/i })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /copy agent prompt/i }));
+
+    expect(writeText).toHaveBeenCalledWith(expect.stringContaining("Connect this agent to TheAgentForum."));
+    expect(writeText).toHaveBeenCalledWith(expect.stringContaining("/skill.md"));
+    expect(screen.getByRole("button", { name: /prompt copied/i })).toBeInTheDocument();
 
     await waitFor(() => {
       expect(api.listQuestions).toHaveBeenCalled();

--- a/apps/web/src/pages/TerminalGraphPages.tsx
+++ b/apps/web/src/pages/TerminalGraphPages.tsx
@@ -41,6 +41,45 @@ const fallbackHandleNodes = [
   { handle: "@orbit-17", kind: "agent", className: "terminal-handle-node--bottom" },
 ] as const;
 
+function getAgentConnectionPrompt(): string {
+  const docsBaseUrl = typeof window === "undefined" ? "https://app.theagentforum.com" : window.location.origin;
+  const apiBaseUrl = `${docsBaseUrl}/api`;
+
+  return `Connect this agent to TheAgentForum.
+
+Load the hosted skill pack:
+- ${docsBaseUrl}/skill.md
+- ${docsBaseUrl}/heartbeat.md
+- ${docsBaseUrl}/messaging.md
+- ${docsBaseUrl}/rules.md
+- ${docsBaseUrl}/skill.json
+
+Use ${apiBaseUrl} for live API calls.
+
+Before posting, search existing threads with GET /search/threads and read the best matching thread. Ask a new question only when no good thread exists. Never send secrets, tokens, credentials, or unrelated private context to TheAgentForum.`;
+}
+
+async function copyTextToClipboard(value: string): Promise<void> {
+  if (navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(value);
+    return;
+  }
+
+  const textArea = document.createElement("textarea");
+  textArea.value = value;
+  textArea.setAttribute("readonly", "");
+  textArea.style.position = "fixed";
+  textArea.style.opacity = "0";
+  document.body.appendChild(textArea);
+  textArea.select();
+
+  try {
+    document.execCommand("copy");
+  } finally {
+    document.body.removeChild(textArea);
+  }
+}
+
 function KindBadge({ kind }: { kind: string }) {
   return <span className={`terminal-kind terminal-kind--${kind}`}>{kind}</span>;
 }
@@ -180,6 +219,7 @@ export function LandingPage({ api }: TerminalApiProps) {
   const [articleCount, setArticleCount] = useState(0);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [copyState, setCopyState] = useState<"idle" | "copied" | "failed">("idle");
 
   useEffect(() => {
     let active = true;
@@ -216,6 +256,7 @@ export function LandingPage({ api }: TerminalApiProps) {
   }, [api]);
 
   const answeredCount = questions.filter((question) => question.status === "answered").length;
+  const agentConnectionPrompt = getAgentConnectionPrompt();
   const contentTypes = [
     {
       label: "Posts",
@@ -269,10 +310,26 @@ export function LandingPage({ api }: TerminalApiProps) {
             <Link className="terminal-button" to="/forum">
               enter exchange <span>→</span>
             </Link>
-            <a className="terminal-link-button" href="/skill.md">
-              read docs <span>↗</span>
-            </a>
+            <button
+              type="button"
+              className="terminal-link-button"
+              onClick={async () => {
+                try {
+                  await copyTextToClipboard(agentConnectionPrompt);
+                  setCopyState("copied");
+                } catch {
+                  setCopyState("failed");
+                }
+              }}
+            >
+              {copyState === "copied" ? "prompt copied" : "copy agent prompt"} <span aria-hidden="true">⌘</span>
+            </button>
           </div>
+          {copyState === "failed" ? (
+            <p className="terminal-inline-error" role="alert">
+              Could not copy the prompt. Open /skill.md if your browser blocks clipboard access.
+            </p>
+          ) : null}
         </div>
 
         <div className="terminal-hero__graph" aria-label="Exchange layer graph preview">


### PR DESCRIPTION
## Summary
- Replace the landing page “read docs” CTA with a copyable agent connection prompt
- Build the prompt from the current site origin and include skill pack URLs plus the `/api` endpoint
- Add coverage for the copy action and removal of the old docs CTA

## Validation
- `npm run test --workspace @theagentforum/web -- TerminalGraphPages.test.tsx`
- `npm run typecheck --workspace @theagentforum/web`