### PR TITLE
Add launch rate limits

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -20,6 +20,14 @@ import type { QuestionStore } from "./question-store";
 import type { ForumStore } from "./forum-store";
 import { createForumAdapter } from "./forum-adapter";
 import {
+  createNoopRateLimitService,
+  launchCompanionIpPolicies,
+  launchRateLimitPolicies,
+  type RateLimitRule,
+  type RateLimitService,
+  type RateLimitSubject,
+} from "./rate-limit";
+import {
   deriveRequestOrigin,
   deriveRpId,
   verifyPasskeyAuthentication,
@@ -30,6 +38,7 @@ import {
 interface CreateAppOptions {
   articleStore?: ArticleStore;
   corsAllowOrigin?: string;
+  rateLimiter?: RateLimitService;
 }
 
 const SESSION_COOKIE_NAME = "taf_session";
@@ -41,6 +50,7 @@ export function createApp(
 ) {
   const corsAllowOrigin = options.corsAllowOrigin ?? "*";
   const forumStore: ForumStore = createForumAdapter(questionStore, options.articleStore);
+  const rateLimiter = options.rateLimiter ?? createNoopRateLimitService();
 
   return async function app(
     req: IncomingMessage,
@@ -49,10 +59,21 @@ export function createApp(
     const corsHeaders = buildCorsHeaders(corsAllowOrigin, req.headers.origin);
 
     try {
-      await routeRequest(questionStore, authStore, forumStore, req, res, corsHeaders);
+      await routeRequest(questionStore, authStore, forumStore, rateLimiter, req, res, corsHeaders);
     } catch (error) {
       if (isHttpError(error)) {
-        sendError(res, corsHeaders, error.statusCode, error.code, error.message);
+        sendError(
+          res,
+          {
+            ...corsHeaders,
+            ...(error.headers ?? {}),
+          },
+          error.statusCode,
+          error.code,
+          error.message,
+          error.details,
+          error.retryAfterSeconds,
+        );
         return;
       }
 
@@ -77,6 +98,7 @@ async function routeRequest(
   questionStore: QuestionStore,
   authStore: AuthStore,
   forumStore: ForumStore,
+  rateLimiter: RateLimitService,
   req: IncomingMessage,
   res: ServerResponse,
   corsHeaders: Record<string, string>,
@@ -89,6 +111,7 @@ async function routeRequest(
   const apiToken = readBearerToken(req.headers.authorization);
   const apiTokenSession = apiToken ? await authStore.getApiTokenSession(apiToken) : null;
   const authenticatedSession = webSession ?? apiTokenSession;
+  const requestIp = readRequestIp(req);
 
   if (method === "OPTIONS") {
     sendNoContent(res, corsHeaders);
@@ -142,6 +165,15 @@ async function routeRequest(
 
   if (method === "PATCH" && path === "/profile") {
     const actor = requireAuthenticatedActor(authenticatedSession);
+    await enforceRateLimit(rateLimiter, {
+      action: "profile_update",
+      checks: buildAuthenticatedRateLimitChecks(
+        actor,
+        requestIp,
+        launchRateLimitPolicies.profileUpdate,
+        launchCompanionIpPolicies.profileUpdate,
+      ),
+    });
     const payload = await readJsonBody(req);
     const input = parseUpdateAccountProfileInput(payload);
     const profile = await authStore.updateAccountProfile(actor.id, input);
@@ -226,6 +258,18 @@ async function routeRequest(
   }
 
   if (method === "POST" && path === "/auth/token/revoke") {
+    if (authenticatedSession) {
+      await enforceRateLimit(rateLimiter, {
+        action: "api_token_lifecycle",
+        checks: buildAuthenticatedRateLimitChecks(
+          authenticatedSession.actor,
+          requestIp,
+          launchRateLimitPolicies.apiTokenLifecycle,
+          launchCompanionIpPolicies.apiTokenLifecycle,
+        ),
+      });
+    }
+
     if (apiToken) {
       await authStore.revokeApiToken(apiToken);
     }
@@ -306,6 +350,15 @@ async function routeRequest(
 
   if (method === "DELETE" && deviceManagementMatch) {
     const actor = requireAuthenticatedActor(authenticatedSession);
+    await enforceRateLimit(rateLimiter, {
+      action: "api_token_lifecycle",
+      checks: buildAuthenticatedRateLimitChecks(
+        actor,
+        requestIp,
+        launchRateLimitPolicies.apiTokenLifecycle,
+        launchCompanionIpPolicies.apiTokenLifecycle,
+      ),
+    });
     const deviceId = decodeURIComponent(deviceManagementMatch[1]);
     const result = await authStore.revokeAccountDevice(actor.id, deviceId);
 
@@ -362,6 +415,15 @@ async function routeRequest(
     const payload = await readJsonBody(req);
     const input = parseCreateQuestionInput(payload);
     const actor = requireAuthenticatedActor(authenticatedSession);
+    await enforceRateLimit(rateLimiter, {
+      action: "create_post",
+      checks: buildAuthenticatedRateLimitChecks(
+        actor,
+        requestIp,
+        launchRateLimitPolicies.createPost,
+        launchCompanionIpPolicies.createPost,
+      ),
+    });
     const question = await questionStore.createQuestion({
       ...input,
       author: actor,
@@ -402,6 +464,15 @@ async function routeRequest(
     const payload = await readJsonBody(req);
     const input = parseCreateAnswerInput(payload);
     const actor = requireAuthenticatedActor(authenticatedSession);
+    await enforceRateLimit(rateLimiter, {
+      action: "create_reply",
+      checks: buildAuthenticatedRateLimitChecks(
+        actor,
+        requestIp,
+        launchRateLimitPolicies.createReply,
+        launchCompanionIpPolicies.createReply,
+      ),
+    });
     const thread = await questionStore.createAnswer(answersMatch[1], {
       ...input,
       author: actor,
@@ -491,6 +562,15 @@ async function routeRequest(
 
   if (method === "POST" && acceptMatch) {
     const actor = requireAuthenticatedActor(authenticatedSession);
+    await enforceRateLimit(rateLimiter, {
+      action: "accept_answer",
+      checks: buildAuthenticatedRateLimitChecks(
+        actor,
+        requestIp,
+        launchRateLimitPolicies.acceptAnswer,
+        launchCompanionIpPolicies.acceptAnswer,
+      ),
+    });
     const questionId = acceptMatch[1];
     const answerId = acceptMatch[2];
     const existing = await questionStore.getQuestionThread(questionId);
@@ -565,6 +645,15 @@ async function routeRequest(
     const payload = await readJsonBody(req);
     const input = parseCreateContentInput(payload);
     const actor = requireAuthenticatedActor(authenticatedSession);
+    await enforceRateLimit(rateLimiter, {
+      action: "create_post",
+      checks: buildAuthenticatedRateLimitChecks(
+        actor,
+        requestIp,
+        launchRateLimitPolicies.createPost,
+        launchCompanionIpPolicies.createPost,
+      ),
+    });
     const content = await forumStore.createContent({
       ...input,
       author: actor,
@@ -609,6 +698,15 @@ async function routeRequest(
     const payload = await readJsonBody(req);
     const input = parseCreateCommentInput(payload);
     const actor = requireAuthenticatedActor(authenticatedSession);
+    await enforceRateLimit(rateLimiter, {
+      action: "create_reply",
+      checks: buildAuthenticatedRateLimitChecks(
+        actor,
+        requestIp,
+        launchRateLimitPolicies.createReply,
+        launchCompanionIpPolicies.createReply,
+      ),
+    });
     const thread = await forumStore.createComment(commentsMatch[1], {
       ...input,
       author: actor,
@@ -630,6 +728,15 @@ async function routeRequest(
 
   if (method === "POST" && acceptCommentMatch) {
     const actor = requireAuthenticatedActor(authenticatedSession);
+    await enforceRateLimit(rateLimiter, {
+      action: "accept_answer",
+      checks: buildAuthenticatedRateLimitChecks(
+        actor,
+        requestIp,
+        launchRateLimitPolicies.acceptAnswer,
+        launchCompanionIpPolicies.acceptAnswer,
+      ),
+    });
     const contentId = acceptCommentMatch[1];
     const commentId = acceptCommentMatch[2];
     const existing = await forumStore.getContentThread(contentId);
@@ -679,6 +786,15 @@ async function routeRequest(
   }
 
   if (method === "POST" && path === "/auth/registrations/start") {
+    await enforceRateLimit(rateLimiter, {
+      action: "signup_start",
+      checks: [
+        {
+          rules: launchRateLimitPolicies.signupStart,
+          subjects: [{ scopeType: "ip", scopeValue: requestIp }],
+        },
+      ],
+    });
     const payload = await readJsonBody(req);
     const input = parseStartRegistrationInput(payload);
 
@@ -848,6 +964,15 @@ async function routeRequest(
   }
 
   if (method === "POST" && path === "/auth/pairings/redeem") {
+    await enforceRateLimit(rateLimiter, {
+      action: "pairing_redeem",
+      checks: [
+        {
+          rules: launchRateLimitPolicies.pairingRedeem,
+          subjects: [{ scopeType: "ip", scopeValue: requestIp }],
+        },
+      ],
+    });
     const payload = await readJsonBody(req);
     const input = parseRedeemPairingInput(payload);
     const session = await authStore.redeemPairing(input);
@@ -882,6 +1007,18 @@ async function routeRequest(
   if (method === "POST" && path === "/auth/authentications/start") {
     const payload = await readJsonBody(req);
     const input = parseStartAuthenticationInput(payload);
+    await enforceRateLimit(rateLimiter, {
+      action: "passkey_login_attempt",
+      checks: [
+        {
+          rules: launchRateLimitPolicies.passkeyLoginAttempt,
+          subjects: [
+            { scopeType: "user", scopeValue: input.handle.toLowerCase() },
+            { scopeType: "ip", scopeValue: requestIp },
+          ],
+        },
+      ],
+    });
     const session = await authStore.startAuthentication(input);
 
     if (!session) {
@@ -1110,13 +1247,15 @@ function sendError(
   code: string,
   message: string,
   details?: unknown,
+  retryAfterSeconds?: number,
 ): void {
   sendJson(res, corsHeaders, statusCode, {
     ok: false,
     error: {
       code,
       message,
-      details,
+      ...(retryAfterSeconds === undefined ? {} : { retryAfterSeconds }),
+      ...(details === undefined ? {} : { details }),
     },
   });
 }
@@ -1150,6 +1289,72 @@ function requireAuthenticatedActor(webSession: { actor: Actor } | null): Actor {
   }
 
   return webSession.actor;
+}
+
+async function enforceRateLimit(
+  rateLimiter: RateLimitService,
+  config: {
+    action: string;
+    checks: Array<{
+      rules: readonly RateLimitRule[];
+      subjects: readonly RateLimitSubject[];
+    }>;
+  },
+): Promise<void> {
+  for (const check of config.checks) {
+    const decision = await rateLimiter.consume({
+      action: config.action,
+      rules: check.rules,
+      subjects: check.subjects,
+    });
+
+    if (decision.allowed) {
+      continue;
+    }
+
+    throw createHttpError(429, decision.exceeded.code, decision.exceeded.message, {
+      details: {
+        action: decision.exceeded.action,
+        scopeType: decision.exceeded.scopeType,
+        ruleId: decision.exceeded.ruleId,
+        limit: decision.exceeded.limit,
+        windowSeconds: decision.exceeded.windowSeconds,
+      },
+      retryAfterSeconds: decision.exceeded.retryAfterSeconds,
+      headers: {
+        "retry-after": String(decision.exceeded.retryAfterSeconds),
+      },
+    });
+  }
+}
+
+function buildAuthenticatedRateLimitChecks(
+  actor: Actor,
+  requestIp: string,
+  userRules: readonly RateLimitRule[],
+  ipRules: readonly RateLimitRule[],
+): Array<{
+  rules: readonly RateLimitRule[];
+  subjects: readonly RateLimitSubject[];
+}> {
+  const checks: Array<{
+    rules: readonly RateLimitRule[];
+    subjects: readonly RateLimitSubject[];
+  }> = [
+    {
+      rules: userRules,
+      subjects: [{ scopeType: "user", scopeValue: actor.id }],
+    },
+  ];
+
+  if (requestIp !== "unknown") {
+    checks.push({
+      rules: ipRules,
+      subjects: [{ scopeType: "ip", scopeValue: requestIp }],
+    });
+  }
+
+  return checks;
 }
 
 function readBearerToken(header: string | string[] | undefined): string | undefined {
@@ -1239,6 +1444,27 @@ function readFirstHeaderValue(value: string | string[] | undefined): string | un
   const [first] = value.split(",", 1);
   const normalized = first?.trim();
   return normalized ? normalized : undefined;
+}
+
+function readRequestIp(req: IncomingMessage): string {
+  const forwardedFor = readFirstHeaderValue(req.headers["x-forwarded-for"]);
+  const realIp = readFirstHeaderValue(req.headers["x-real-ip"]);
+  const candidate = forwardedFor ?? realIp ?? req.socket?.remoteAddress ?? "unknown";
+  return normalizeIp(candidate);
+}
+
+function normalizeIp(value: string): string {
+  const normalized = value.trim();
+
+  if (!normalized) {
+    return "unknown";
+  }
+
+  if (normalized.startsWith("::ffff:")) {
+    return normalized.slice("::ffff:".length);
+  }
+
+  return normalized;
 }
 
 async function readJsonBody(req: IncomingMessage): Promise<unknown> {
@@ -1727,16 +1953,42 @@ function createHttpError(
   statusCode: number,
   code: string,
   message: string,
-): Error & { statusCode: number; code: string } {
-  const error = new Error(message) as Error & { statusCode: number; code: string };
+  options: {
+    details?: unknown;
+    retryAfterSeconds?: number;
+    headers?: Record<string, string>;
+  } = {},
+): Error & {
+  statusCode: number;
+  code: string;
+  details?: unknown;
+  retryAfterSeconds?: number;
+  headers?: Record<string, string>;
+} {
+  const error = new Error(message) as Error & {
+    statusCode: number;
+    code: string;
+    details?: unknown;
+    retryAfterSeconds?: number;
+    headers?: Record<string, string>;
+  };
   error.statusCode = statusCode;
   error.code = code;
+  error.details = options.details;
+  error.retryAfterSeconds = options.retryAfterSeconds;
+  error.headers = options.headers;
   return error;
 }
 
 function isHttpError(
   error: unknown,
-): error is Error & { statusCode: number; code: string } {
+): error is Error & {
+  statusCode: number;
+  code: string;
+  details?: unknown;
+  retryAfterSeconds?: number;
+  headers?: Record<string, string>;
+} {
   return (
     error instanceof Error &&
     typeof (error as { statusCode?: unknown }).statusCode === "number" &&

--- a/apps/api/src/http.rate-limit.test.ts
+++ b/apps/api/src/http.rate-limit.test.ts
@@ -1,0 +1,260 @@
+import assert from "node:assert/strict";
+import { Readable } from "node:stream";
+import { describe, it } from "node:test";
+import { createApp } from "./app";
+import type { AuthStore } from "./auth-store";
+import { createInMemoryAuthStore } from "./memory-auth-store";
+import { createInMemoryQuestionStore } from "./memory-question-store";
+import {
+  createInMemoryRateLimitStore,
+  createRateLimitService,
+  type RateLimitExceededEvent,
+} from "./rate-limit";
+
+const fixedNow = "2026-04-30T00:00:00.000Z";
+
+const spoofedHuman = {
+  id: "user-1",
+  kind: "human" as const,
+  handle: "spoofed-human",
+};
+
+describe("HTTP API rate limits", () => {
+  it("limits signup starts per IP and returns the launch 429 shape", async () => {
+    const { app, events } = createRateLimitedTestApp();
+
+    for (let index = 0; index < 5; index += 1) {
+      const response = await requestJson(app, "/auth/registrations/start", {
+        method: "POST",
+        headers: {
+          "x-forwarded-for": "203.0.113.10",
+        },
+        body: {
+          handle: `signup-user-${index}`,
+          displayName: `Signup User ${index}`,
+        },
+      });
+
+      assert.equal(response.status, 201);
+      assert.equal(response.body.ok, true);
+    }
+
+    const limited = await requestJson(app, "/auth/registrations/start", {
+      method: "POST",
+      headers: {
+        "x-forwarded-for": "203.0.113.10",
+      },
+      body: {
+        handle: "signup-user-6",
+        displayName: "Signup User 6",
+      },
+    });
+
+    assert.equal(limited.status, 429);
+    assert.equal(limited.headers["retry-after"], "3600");
+    assert.equal(limited.body.ok, false);
+    assert.equal(limited.body.error.code, "rate_limit_exceeded");
+    assert.equal(limited.body.error.message, "Too many requests for this action. Try again later.");
+    assert.equal(limited.body.error.retryAfterSeconds, 3600);
+    assert.deepEqual(limited.body.error.details, {
+      action: "signup_start",
+      scopeType: "ip",
+      ruleId: "signup_start_hour",
+      limit: 5,
+      windowSeconds: 3600,
+    });
+
+    assert.equal(events.length, 1);
+    assert.deepEqual(events[0], {
+      event: "taf_rate_limit_exceeded",
+      action: "signup_start",
+      scopeType: "ip",
+      ruleId: "signup_start_hour",
+      limit: 5,
+      windowSeconds: 3600,
+      retryAfterSeconds: 3600,
+    });
+  });
+
+  it("limits authenticated post creation per user", async () => {
+    const { app, authStore } = createRateLimitedTestApp();
+    const cookieHeader = await createAuthenticatedCookie(authStore, {
+      handle: "felix-posts",
+      displayName: "Felix Posts",
+    });
+
+    for (let index = 0; index < 5; index += 1) {
+      const response = await requestJson(app, "/questions", {
+        method: "POST",
+        headers: {
+          cookie: cookieHeader,
+          "x-forwarded-for": "198.51.100.15",
+        },
+        body: {
+          title: `Question ${index}`,
+          body: `Body ${index}`,
+          author: spoofedHuman,
+        },
+      });
+
+      assert.equal(response.status, 201);
+      assert.equal(response.body.data.author.handle, "felix-posts");
+    }
+
+    const limited = await requestJson(app, "/questions", {
+      method: "POST",
+      headers: {
+        cookie: cookieHeader,
+        "x-forwarded-for": "198.51.100.15",
+      },
+      body: {
+        title: "Question 6",
+        body: "Body 6",
+        author: spoofedHuman,
+      },
+    });
+
+    assert.equal(limited.status, 429);
+    assert.equal(limited.body.error.code, "rate_limit_exceeded");
+    assert.equal(limited.body.error.details.action, "create_post");
+    assert.equal(limited.body.error.details.scopeType, "user");
+  });
+
+  it("limits profile updates per authenticated user", async () => {
+    const { app, authStore } = createRateLimitedTestApp();
+    const cookieHeader = await createAuthenticatedCookie(authStore, {
+      handle: "felix-profile",
+      displayName: "Felix Profile",
+    });
+
+    for (let index = 0; index < 10; index += 1) {
+      const response = await requestJson(app, "/profile", {
+        method: "PATCH",
+        headers: {
+          cookie: cookieHeader,
+          "x-forwarded-for": "198.51.100.20",
+        },
+        body: {
+          displayName: `Felix Profile ${index}`,
+        },
+      });
+
+      assert.equal(response.status, 200);
+      assert.equal(response.body.data.displayName, `Felix Profile ${index}`);
+    }
+
+    const limited = await requestJson(app, "/profile", {
+      method: "PATCH",
+      headers: {
+        cookie: cookieHeader,
+        "x-forwarded-for": "198.51.100.20",
+      },
+      body: {
+        displayName: "Felix Profile 11",
+      },
+    });
+
+    assert.equal(limited.status, 429);
+    assert.equal(limited.body.error.code, "rate_limit_exceeded");
+    assert.equal(limited.body.error.details.action, "profile_update");
+    assert.equal(limited.body.error.details.scopeType, "user");
+  });
+});
+
+function createRateLimitedTestApp(): {
+  app: ReturnType<typeof createApp>;
+  authStore: AuthStore;
+  events: RateLimitExceededEvent[];
+} {
+  const authStore = createInMemoryAuthStore();
+  const events: RateLimitExceededEvent[] = [];
+  const rateLimiter = createRateLimitService(createInMemoryRateLimitStore(), {
+    clock: {
+      now: () => new Date(fixedNow),
+    },
+    eventSink: {
+      emit(event) {
+        events.push(event);
+      },
+    },
+  });
+
+  return {
+    app: createApp(createInMemoryQuestionStore(), authStore, { rateLimiter }),
+    authStore,
+    events,
+  };
+}
+
+async function createAuthenticatedCookie(
+  authStore: AuthStore,
+  input: { handle: string; displayName: string },
+): Promise<string> {
+  const registration = await authStore.startRegistration(input);
+  const credentialId = `cred-${input.handle}`;
+
+  await authStore.finishPasskeyRegistration({
+    registrationSessionId: registration.id,
+    credentialId,
+    publicKey: "public-key",
+    verificationMethod: "webauthn",
+    passkeyLabel: `${input.displayName} Passkey`,
+    transports: ["internal"],
+  });
+
+  const authenticationSession = await authStore.startAuthentication({ handle: input.handle });
+  assert.ok(authenticationSession);
+
+  await authStore.finishPasskeyAuthentication({
+    authenticationSessionId: authenticationSession.id,
+    credentialId,
+    verificationMethod: "webauthn",
+    signCount: 1,
+    passkeyLabel: `${input.displayName} Passkey`,
+  });
+
+  const webSession = await authStore.createWebSession(authenticationSession.id);
+  assert.ok(webSession);
+  return `taf_session=${webSession.token}`;
+}
+
+async function requestJson(
+  app: ReturnType<typeof createApp>,
+  path: string,
+  init?: { method?: string; body?: unknown; headers?: Record<string, string> },
+): Promise<{ status: number; headers: Record<string, string>; body: any }> {
+  const request = Readable.from(init?.body ? [JSON.stringify(init.body)] : []) as any;
+  request.method = init?.method ?? "GET";
+  request.url = path;
+  request.headers = {
+    host: "localhost",
+    ...(init?.body ? { "content-type": "application/json" } : {}),
+    ...(init?.headers ?? {}),
+  };
+
+  const response = createMockResponse();
+  await app(request, response);
+
+  return {
+    status: response.statusCode,
+    headers: response.headers,
+    body: JSON.parse(response.body),
+  };
+}
+
+function createMockResponse() {
+  return {
+    statusCode: 200,
+    headers: {} as Record<string, string>,
+    body: "",
+    writeHead(statusCode: number, headers?: Record<string, string>) {
+      this.statusCode = statusCode;
+      this.headers = headers ?? {};
+      return this;
+    },
+    end(chunk?: string | Buffer) {
+      this.body = chunk ? chunk.toString() : "";
+      return this;
+    },
+  };
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -2,8 +2,10 @@ import { createServer } from "node:http";
 import { createApp } from "./app";
 import { createPostgresArticleStore } from "./postgres-article-store";
 import { createPostgresAuthStore } from "./postgres-auth-store";
+import { createPostgresRateLimitStore } from "./postgres-rate-limit-store";
 import { createPostgresQuestionStore } from "./postgres-question-store";
 import { runSqlFile } from "./postgres";
+import { createConsoleServerEventSink, createRateLimitService } from "./rate-limit";
 
 const port = Number(process.env.PORT ?? 3001);
 const corsAllowOrigin = process.env.CORS_ALLOW_ORIGIN ?? "*";
@@ -14,7 +16,14 @@ async function main(): Promise<void> {
   const questionStore = createPostgresQuestionStore();
   const authStore = createPostgresAuthStore();
   const articleStore = createPostgresArticleStore();
-  const app = createApp(questionStore, authStore, { articleStore, corsAllowOrigin });
+  const rateLimiter = createRateLimitService(createPostgresRateLimitStore(), {
+    eventSink: createConsoleServerEventSink(),
+  });
+  const app = createApp(questionStore, authStore, {
+    articleStore,
+    corsAllowOrigin,
+    rateLimiter,
+  });
   const server = createServer(app);
 
   server.listen(port, () => {

--- a/apps/api/src/postgres-rate-limit-store.ts
+++ b/apps/api/src/postgres-rate-limit-store.ts
@@ -1,0 +1,59 @@
+import { runSql } from "./postgres";
+import type {
+  RateLimitCounterInput,
+  RateLimitCounterRecord,
+  RateLimitStore,
+} from "./rate-limit";
+
+export function createPostgresRateLimitStore(): RateLimitStore {
+  return {
+    incrementCounter,
+  };
+}
+
+async function incrementCounter(
+  input: RateLimitCounterInput,
+): Promise<RateLimitCounterRecord> {
+  const output = await runSql(
+    `
+      insert into rate_limit_counters (
+        action,
+        scope_type,
+        scope_key_hash,
+        window_seconds,
+        window_started_at,
+        request_count
+      )
+      values (
+        :'action',
+        :'scope_type',
+        :'scope_key_hash',
+        cast(:'window_seconds' as integer),
+        cast(:'window_started_at' as timestamptz),
+        1
+      )
+      on conflict (action, scope_type, scope_key_hash, window_seconds, window_started_at)
+      do update
+      set
+        request_count = rate_limit_counters.request_count + 1,
+        updated_at = now()
+      returning json_build_object(
+        'count',
+        request_count
+      ) :: text;
+    `,
+    {
+      action: input.action,
+      scope_type: input.scopeType,
+      scope_key_hash: input.scopeKeyHash,
+      window_seconds: String(input.windowSeconds),
+      window_started_at: input.windowStartedAt,
+    },
+  );
+
+  if (!output) {
+    throw new Error("Failed to increment rate limit counter.");
+  }
+
+  return JSON.parse(output) as RateLimitCounterRecord;
+}

--- a/apps/api/src/rate-limit.test.ts
+++ b/apps/api/src/rate-limit.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  NEW_ACCOUNT_WINDOW_SECONDS,
+  isAccountWithinAgeWindow,
+} from "./rate-limit";
+
+describe("rate-limit helpers", () => {
+  it("detects accounts created within the first 24 hours", () => {
+    const now = new Date("2026-04-30T12:00:00.000Z");
+
+    assert.equal(
+      isAccountWithinAgeWindow("2026-04-29T12:00:01.000Z", NEW_ACCOUNT_WINDOW_SECONDS, now),
+      true,
+    );
+    assert.equal(
+      isAccountWithinAgeWindow("2026-04-29T12:00:00.000Z", NEW_ACCOUNT_WINDOW_SECONDS, now),
+      false,
+    );
+  });
+
+  it("treats invalid timestamps as not eligible for new-account limits", () => {
+    const now = new Date("2026-04-30T12:00:00.000Z");
+
+    assert.equal(
+      isAccountWithinAgeWindow("not-a-date", NEW_ACCOUNT_WINDOW_SECONDS, now),
+      false,
+    );
+  });
+});

--- a/apps/api/src/rate-limit.ts
+++ b/apps/api/src/rate-limit.ts
@@ -1,0 +1,316 @@
+import { createHash } from "node:crypto";
+
+export type RateLimitScopeType = "user" | "ip";
+
+export interface RateLimitRule {
+  id: string;
+  limit: number;
+  windowSeconds: number;
+}
+
+export interface RateLimitSubject {
+  scopeType: RateLimitScopeType;
+  scopeValue: string;
+}
+
+export interface RateLimitCounterInput {
+  action: string;
+  scopeType: RateLimitScopeType;
+  scopeKeyHash: string;
+  windowSeconds: number;
+  windowStartedAt: string;
+}
+
+export interface RateLimitCounterRecord {
+  count: number;
+}
+
+export interface RateLimitStore {
+  incrementCounter(input: RateLimitCounterInput): Promise<RateLimitCounterRecord>;
+}
+
+export interface RateLimitExceededEvent {
+  event: "taf_rate_limit_exceeded";
+  action: string;
+  scopeType: RateLimitScopeType;
+  ruleId: string;
+  limit: number;
+  windowSeconds: number;
+  retryAfterSeconds: number;
+}
+
+export interface ServerEventSink {
+  emit(event: RateLimitExceededEvent): Promise<void> | void;
+}
+
+export interface RateLimitCheckInput {
+  action: string;
+  rules: readonly RateLimitRule[];
+  subjects: readonly RateLimitSubject[];
+}
+
+export interface RateLimitExceededResult {
+  code: "rate_limit_exceeded";
+  message: string;
+  action: string;
+  scopeType: RateLimitScopeType;
+  ruleId: string;
+  limit: number;
+  windowSeconds: number;
+  retryAfterSeconds: number;
+}
+
+export type RateLimitDecision =
+  | { allowed: true }
+  | { allowed: false; exceeded: RateLimitExceededResult };
+
+export interface RateLimitService {
+  consume(input: RateLimitCheckInput): Promise<RateLimitDecision>;
+}
+
+export interface Clock {
+  now(): Date;
+}
+
+const FIFTEEN_MINUTES_SECONDS = 15 * 60;
+const ONE_HOUR_SECONDS = 60 * 60;
+const ONE_DAY_SECONDS = 24 * 60 * 60;
+
+export const NEW_ACCOUNT_WINDOW_SECONDS = ONE_DAY_SECONDS;
+export const AUTHENTICATED_WRITE_IP_LIMIT_MULTIPLIER = 3;
+
+export const launchRateLimitPolicies = {
+  signupStart: [
+    { id: "signup_start_hour", limit: 5, windowSeconds: ONE_HOUR_SECONDS },
+  ],
+  passkeyLoginAttempt: [
+    { id: "passkey_login_attempt_15m", limit: 10, windowSeconds: FIFTEEN_MINUTES_SECONDS },
+  ],
+  pairingRedeem: [
+    { id: "pairing_redeem_15m", limit: 10, windowSeconds: FIFTEEN_MINUTES_SECONDS },
+  ],
+  createPost: [
+    { id: "create_post_hour", limit: 5, windowSeconds: ONE_HOUR_SECONDS },
+    { id: "create_post_day", limit: 20, windowSeconds: ONE_DAY_SECONDS },
+  ],
+  createReply: [
+    { id: "create_reply_hour", limit: 20, windowSeconds: ONE_HOUR_SECONDS },
+    { id: "create_reply_day", limit: 100, windowSeconds: ONE_DAY_SECONDS },
+  ],
+  acceptAnswer: [
+    { id: "accept_answer_day", limit: 30, windowSeconds: ONE_DAY_SECONDS },
+  ],
+  profileUpdate: [
+    { id: "profile_update_hour", limit: 10, windowSeconds: ONE_HOUR_SECONDS },
+  ],
+  apiTokenLifecycle: [
+    { id: "api_token_lifecycle_day", limit: 5, windowSeconds: ONE_DAY_SECONDS },
+  ],
+} satisfies Record<string, readonly RateLimitRule[]>;
+
+export const launchCompanionIpPolicies = {
+  createPost: scaleRateLimitRules(
+    launchRateLimitPolicies.createPost,
+    AUTHENTICATED_WRITE_IP_LIMIT_MULTIPLIER,
+    "ip",
+  ),
+  createReply: scaleRateLimitRules(
+    launchRateLimitPolicies.createReply,
+    AUTHENTICATED_WRITE_IP_LIMIT_MULTIPLIER,
+    "ip",
+  ),
+  acceptAnswer: scaleRateLimitRules(
+    launchRateLimitPolicies.acceptAnswer,
+    AUTHENTICATED_WRITE_IP_LIMIT_MULTIPLIER,
+    "ip",
+  ),
+  profileUpdate: scaleRateLimitRules(
+    launchRateLimitPolicies.profileUpdate,
+    AUTHENTICATED_WRITE_IP_LIMIT_MULTIPLIER,
+    "ip",
+  ),
+  apiTokenLifecycle: scaleRateLimitRules(
+    launchRateLimitPolicies.apiTokenLifecycle,
+    AUTHENTICATED_WRITE_IP_LIMIT_MULTIPLIER,
+    "ip",
+  ),
+} satisfies Record<string, RateLimitRule[]>;
+
+const defaultClock: Clock = {
+  now: () => new Date(),
+};
+
+export function createRateLimitService(
+  store: RateLimitStore,
+  options: {
+    clock?: Clock;
+    eventSink?: ServerEventSink;
+  } = {},
+): RateLimitService {
+  const clock = options.clock ?? defaultClock;
+  const eventSink = options.eventSink;
+
+  return {
+    async consume(input: RateLimitCheckInput): Promise<RateLimitDecision> {
+      const subjects = dedupeSubjects(input.subjects);
+
+      if (subjects.length === 0 || input.rules.length === 0) {
+        return { allowed: true };
+      }
+
+      const now = clock.now();
+
+      for (const subject of subjects) {
+        for (const rule of input.rules) {
+          const windowStartedAt = getWindowStartedAt(now, rule.windowSeconds);
+          const record = await store.incrementCounter({
+            action: input.action,
+            scopeType: subject.scopeType,
+            scopeKeyHash: hashScopeValue(subject.scopeValue),
+            windowSeconds: rule.windowSeconds,
+            windowStartedAt: windowStartedAt.toISOString(),
+          });
+
+          if (record.count <= rule.limit) {
+            continue;
+          }
+
+          const retryAfterSeconds = getRetryAfterSeconds(now, windowStartedAt, rule.windowSeconds);
+          const exceeded: RateLimitExceededResult = {
+            code: "rate_limit_exceeded",
+            message: "Too many requests for this action. Try again later.",
+            action: input.action,
+            scopeType: subject.scopeType,
+            ruleId: rule.id,
+            limit: rule.limit,
+            windowSeconds: rule.windowSeconds,
+            retryAfterSeconds,
+          };
+
+          await eventSink?.emit({
+            event: "taf_rate_limit_exceeded",
+            action: exceeded.action,
+            scopeType: exceeded.scopeType,
+            ruleId: exceeded.ruleId,
+            limit: exceeded.limit,
+            windowSeconds: exceeded.windowSeconds,
+            retryAfterSeconds: exceeded.retryAfterSeconds,
+          });
+
+          return {
+            allowed: false,
+            exceeded,
+          };
+        }
+      }
+
+      return { allowed: true };
+    },
+  };
+}
+
+export function createNoopRateLimitService(): RateLimitService {
+  return {
+    async consume(): Promise<RateLimitDecision> {
+      return { allowed: true };
+    },
+  };
+}
+
+export function createInMemoryRateLimitStore(): RateLimitStore {
+  const counters = new Map<string, number>();
+
+  return {
+    async incrementCounter(input: RateLimitCounterInput): Promise<RateLimitCounterRecord> {
+      const key = [
+        input.action,
+        input.scopeType,
+        input.scopeKeyHash,
+        String(input.windowSeconds),
+        input.windowStartedAt,
+      ].join(":");
+      const count = (counters.get(key) ?? 0) + 1;
+      counters.set(key, count);
+      return { count };
+    },
+  };
+}
+
+export function createConsoleServerEventSink(
+  logger: Pick<Console, "warn"> = console,
+): ServerEventSink {
+  return {
+    emit(event: RateLimitExceededEvent): void {
+      logger.warn(JSON.stringify(event));
+    },
+  };
+}
+
+export function scaleRateLimitRules(
+  rules: readonly RateLimitRule[],
+  multiplier: number,
+  suffix: string,
+): RateLimitRule[] {
+  return rules.map((rule) => ({
+    id: `${rule.id}_${suffix}`,
+    limit: Math.max(1, Math.ceil(rule.limit * multiplier)),
+    windowSeconds: rule.windowSeconds,
+  }));
+}
+
+export function isAccountWithinAgeWindow(
+  createdAt: string,
+  maxAgeSeconds: number,
+  now: Date = new Date(),
+): boolean {
+  const createdAtMs = Date.parse(createdAt);
+
+  if (!Number.isFinite(createdAtMs)) {
+    return false;
+  }
+
+  const ageMs = now.getTime() - createdAtMs;
+  return ageMs >= 0 && ageMs < maxAgeSeconds * 1000;
+}
+
+function dedupeSubjects(subjects: readonly RateLimitSubject[]): RateLimitSubject[] {
+  const seen = new Set<string>();
+  const deduped: RateLimitSubject[] = [];
+
+  for (const subject of subjects) {
+    const scopeValue = subject.scopeValue.trim();
+
+    if (!scopeValue) {
+      continue;
+    }
+
+    const key = `${subject.scopeType}:${scopeValue}`;
+
+    if (seen.has(key)) {
+      continue;
+    }
+
+    seen.add(key);
+    deduped.push({
+      scopeType: subject.scopeType,
+      scopeValue,
+    });
+  }
+
+  return deduped;
+}
+
+function hashScopeValue(scopeValue: string): string {
+  return createHash("sha256").update(scopeValue).digest("hex");
+}
+
+function getWindowStartedAt(now: Date, windowSeconds: number): Date {
+  const windowMs = windowSeconds * 1000;
+  const startedAtMs = Math.floor(now.getTime() / windowMs) * windowMs;
+  return new Date(startedAtMs);
+}
+
+function getRetryAfterSeconds(now: Date, windowStartedAt: Date, windowSeconds: number): number {
+  const retryAfterMs = windowStartedAt.getTime() + windowSeconds * 1000 - now.getTime();
+  return Math.max(1, Math.ceil(retryAfterMs / 1000));
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -57,6 +57,26 @@ Error responses use:
 }
 ```
 
+Rate-limited responses use the same error envelope with `HTTP 429`, a `Retry-After` header, and `error.retryAfterSeconds`:
+
+```json
+{
+  "ok": false,
+  "error": {
+    "code": "rate_limit_exceeded",
+    "message": "Too many requests for this action. Try again later.",
+    "retryAfterSeconds": 3600,
+    "details": {
+      "action": "signup_start",
+      "scopeType": "ip",
+      "ruleId": "signup_start_hour",
+      "limit": 5,
+      "windowSeconds": 3600
+    }
+  }
+}
+```
+
 ## Endpoints
 
 ### `GET /health`

--- a/docs/LAUNCH_READINESS.md
+++ b/docs/LAUNCH_READINESS.md
@@ -88,9 +88,26 @@ Current verification procedure after deploy:
 4. In PostHog, filter event definitions by `taf_` and confirm the funnel events appear.
 5. Build or update the dashboard once live events exist.
 
+## Rate limits
+
+Launch-safe API rate limits now cover the main auth-sensitive and write-heavy routes:
+
+- signup start by IP
+- passkey login start by normalized handle or IP
+- pairing redemption by IP
+- authenticated post creation by user and companion IP bucket
+- authenticated reply creation by user and companion IP bucket
+- answer acceptance by user and companion IP bucket
+- profile updates by user and companion IP bucket
+- token/device revocation lifecycle by user and companion IP bucket
+
+Primary docs live in:
+
+- `docs/RATE_LIMITS.md`
+
 ## Remaining honest gaps
 
 - The current stable handle is still the sign-in email until the private-email/public-handle split lands.
-- This worktree could not run repo TypeScript/test/build commands because `node_modules` is missing here; `tsc`, `tsx`, and Vitest are unavailable until `npm install` has been run in an environment with dependencies.
 - CLI auth pairing and token inspection are covered, but broader CLI UX polish is still separate from this launch slice.
-- Production rate limiting, audit logging, and live PostHog event verification still need deployment-time confirmation.
+- Server-side audit logging beyond the rate-limit exceeded event is still separate from this launch slice.
+- Live PostHog event verification still needs deployment-time confirmation.

--- a/docs/RATE_LIMITS.md
+++ b/docs/RATE_LIMITS.md
@@ -1,0 +1,83 @@
+# Rate Limits
+
+The launch API now enforces fixed-window Postgres-backed rate limits for the highest-risk write and auth-sensitive routes.
+
+Implementation notes:
+
+- Counters live in `rate_limit_counters`.
+- Subject keys are stored as SHA-256 hashes, not raw user IDs, handles, or IP addresses.
+- Exceeded requests emit a server event named `taf_rate_limit_exceeded`.
+- Exceeded responses return `HTTP 429`, a `Retry-After` header, and `error.retryAfterSeconds`.
+
+## Default limits
+
+Authenticated write routes use both:
+
+- a per-user bucket keyed by action + authenticated account id
+- a companion per-IP bucket keyed by action + client IP
+
+Launch companion IP buckets are set to `3x` the user bucket to catch hot-IP abuse without making shared-network collisions as aggressive as a same-value mirror.
+
+| Action | Routes | User limit | Companion IP limit |
+| --- | --- | --- | --- |
+| `create_post` | `POST /questions`, `POST /v2/contents` | `5/hour`, `20/day` | `15/hour`, `60/day` |
+| `create_reply` | `POST /questions/:id/answers`, `POST /v2/contents/:id/comments` | `20/hour`, `100/day` | `60/hour`, `300/day` |
+| `accept_answer` | `POST /questions/:id/accept/:answerId`, `POST /v2/contents/:id/accept/:commentId` | `30/day` | `90/day` |
+| `profile_update` | `PATCH /profile` | `10/hour` | `30/hour` |
+| `api_token_lifecycle` | `POST /auth/token/revoke`, `DELETE /auth/devices/:id` | `5/day` | `15/day` |
+
+Unauthenticated or pre-auth flows use these buckets:
+
+| Action | Routes | Limit |
+| --- | --- | --- |
+| `signup_start` | `POST /auth/registrations/start` | `5/hour/IP` |
+| `passkey_login_attempt` | `POST /auth/authentications/start` | `10/15min` per normalized handle or IP |
+| `pairing_redeem` | `POST /auth/pairings/redeem` | `10/15min/IP` |
+
+## 429 shape
+
+Example:
+
+```json
+{
+  "ok": false,
+  "error": {
+    "code": "rate_limit_exceeded",
+    "message": "Too many requests for this action. Try again later.",
+    "retryAfterSeconds": 3600,
+    "details": {
+      "action": "signup_start",
+      "scopeType": "ip",
+      "ruleId": "signup_start_hour",
+      "limit": 5,
+      "windowSeconds": 3600
+    }
+  }
+}
+```
+
+## Telemetry
+
+Exceeded requests emit:
+
+```json
+{
+  "event": "taf_rate_limit_exceeded",
+  "action": "create_post",
+  "scopeType": "user",
+  "ruleId": "create_post_hour",
+  "limit": 5,
+  "windowSeconds": 3600,
+  "retryAfterSeconds": 3600
+}
+```
+
+The event intentionally omits raw IPs, handles, account ids, tokens, and other request secrets.
+
+## Deferred or manual follow-up
+
+- Read/search routes are not rate-limited yet. `GET /search/threads` and `GET /v2/search/threads` stay open for launch to avoid degrading normal UX before real traffic data exists.
+- First-24-hour new-account throttles are only scaffolded as a helper/test today. The repo now has an account-age helper, but tighter launch values still need product tuning before enforcement is turned on for content writes.
+- There is no separate authenticated pairing-code creation route in the current MVP. The only pairing-code creation path is registration start, so that path is covered by `signup_start`.
+- `rate_limit_counters` is append-only by window. Operators should add a periodic cleanup job after launch, for example deleting rows whose `window_started_at` is older than the longest retained operational horizon.
+- There is no admin bypass or manual unblock endpoint yet. Operational overrides still require direct database access or a deploy-time code change.

--- a/packages/db/sql/001-init.sql
+++ b/packages/db/sql/001-init.sql
@@ -162,6 +162,25 @@ create index if not exists auth_web_sessions_account_id_idx
 create index if not exists auth_web_sessions_token_idx
   on auth_web_sessions (token);
 
+create table if not exists rate_limit_counters (
+  action text not null,
+  scope_type text not null,
+  scope_key_hash text not null,
+  window_seconds integer not null,
+  window_started_at timestamptz not null,
+  request_count integer not null default 0,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint rate_limit_counters_scope_type_check
+    check (scope_type in ('user', 'ip')),
+  constraint rate_limit_counters_window_seconds_check
+    check (window_seconds > 0),
+  primary key (action, scope_type, scope_key_hash, window_seconds, window_started_at)
+);
+
+create index if not exists rate_limit_counters_updated_at_idx
+  on rate_limit_counters (updated_at);
+
 do $$
 begin
   if not exists (

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -46,6 +46,10 @@ export const plannedTables: TableNote[] = [
     name: "auth_web_sessions",
     purpose: "Stores issued browser session cookies for authenticated web usage.",
   },
+  {
+    name: "rate_limit_counters",
+    purpose: "Stores fixed-window API rate limit counters using hashed scope keys.",
+  },
 ];
 
 export function readDatabaseConfig(env: NodeJS.ProcessEnv = process.env): DatabaseConfig {


### PR DESCRIPTION
## Summary
- add fixed-window rate limiting for signup, login, pairing redeem, profile, token/device lifecycle, and authenticated write routes
- persist counters in Postgres with hashed subject keys and emit sanitized rate-limit telemetry
- document launch limits and 429 response shape

## Checks
- npm run test --workspace @theagentforum/api
- npm run typecheck --workspace @theagentforum/api
- git diff --check