### PR TITLE
Add browser-approved agent pairing

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,5 +1,6 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type {
+  ApproveAgentPairingInput,
   Actor,
   CompleteRegistrationVerificationInput,
   CreateAnswerInput,
@@ -10,6 +11,7 @@ import type {
   FinishAuthenticationInput,
   FinishRegistrationInput,
   RedeemPairingInput,
+  StartAgentPairingInput,
   StartAuthenticationInput,
   StartRegistrationInput,
   UpdateAccountProfileInput,
@@ -1004,6 +1006,76 @@ async function routeRequest(
     return;
   }
 
+  if (method === "POST" && path === "/auth/agent-pairings/start") {
+    const payload = await readJsonBody(req);
+    const input = parseStartAgentPairingInput(payload);
+
+    sendJson(res, corsHeaders, 201, {
+      ok: true,
+      data: await authStore.startAgentPairing(input),
+    });
+    return;
+  }
+
+  const agentPairingMatch = matchPath(path, /^\/auth\/agent-pairings\/([^/]+)$/);
+
+  if (method === "GET" && agentPairingMatch) {
+    const session = await authStore.getAgentPairing(decodeURIComponent(agentPairingMatch[1]));
+
+    if (!session) {
+      sendError(
+        res,
+        corsHeaders,
+        404,
+        "agent_pairing_not_found",
+        "Agent pairing request not found.",
+      );
+      return;
+    }
+
+    sendJson(res, corsHeaders, 200, {
+      ok: true,
+      data: session,
+    });
+    return;
+  }
+
+  if (method === "POST" && path === "/auth/agent-pairings/approve") {
+    const actor = requireAuthenticatedActor(webSession);
+    const payload = await readJsonBody(req);
+    const input = parseApproveAgentPairingInput(payload);
+    const session = await authStore.approveAgentPairing(actor.id, input);
+
+    if (!session) {
+      sendError(
+        res,
+        corsHeaders,
+        404,
+        "agent_pairing_not_found",
+        "Agent pairing request not found.",
+      );
+      return;
+    }
+
+    if (session.status !== "paired") {
+      sendError(
+        res,
+        corsHeaders,
+        409,
+        "agent_pairing_not_ready",
+        "Agent pairing request is not ready to approve.",
+        { pairingStatus: session.status },
+      );
+      return;
+    }
+
+    sendJson(res, corsHeaders, 200, {
+      ok: true,
+      data: session,
+    });
+    return;
+  }
+
   if (method === "POST" && path === "/auth/authentications/start") {
     const payload = await readJsonBody(req);
     const input = parseStartAuthenticationInput(payload);
@@ -1713,6 +1785,23 @@ function parseRedeemPairingInput(payload: unknown): RedeemPairingInput {
   return {
     pairingCode: readRequiredString(input.pairingCode, "pairingCode"),
     deviceLabel: readRequiredString(input.deviceLabel, "deviceLabel"),
+  };
+}
+
+function parseStartAgentPairingInput(payload: unknown): StartAgentPairingInput {
+  const input = asRecord(payload, "Request body must be an object.");
+
+  return {
+    deviceLabel: readRequiredString(input.deviceLabel, "deviceLabel"),
+  };
+}
+
+function parseApproveAgentPairingInput(payload: unknown): ApproveAgentPairingInput {
+  const input = asRecord(payload, "Request body must be an object.");
+
+  return {
+    pairingCode: readRequiredString(input.pairingCode, "pairingCode"),
+    deviceLabel: readOptionalBoundedString(input.deviceLabel, "deviceLabel", 80),
   };
 }
 

--- a/apps/api/src/auth-store.ts
+++ b/apps/api/src/auth-store.ts
@@ -1,5 +1,7 @@
 import type {
   AccountProfile,
+  AgentPairingSession,
+  ApproveAgentPairingInput,
   Actor,
   AuthDevice,
   AuthPasskey,
@@ -9,6 +11,7 @@ import type {
   PasskeyRegistrationOptions,
   PublicProfile,
   RedeemPairingInput,
+  StartAgentPairingInput,
   RegistrationSession,
   StartAuthenticationInput,
   StartRegistrationInput,
@@ -71,6 +74,12 @@ export interface AuthStore {
     input: CompleteRegistrationVerificationInput,
   ): Promise<RegistrationSession | null>;
   redeemPairing(input: RedeemPairingInput): Promise<RegistrationSession | null>;
+  startAgentPairing(input: StartAgentPairingInput): Promise<AgentPairingSession>;
+  getAgentPairing(pairingCode: string): Promise<AgentPairingSession | null>;
+  approveAgentPairing(
+    accountId: string,
+    input: ApproveAgentPairingInput,
+  ): Promise<AgentPairingSession | null>;
   startAuthentication(input: StartAuthenticationInput): Promise<AuthenticationSession | null>;
   getAuthenticationSession(authenticationSessionId: string): Promise<AuthenticationSession | null>;
   getPasskeyAuthenticationOptions(

--- a/apps/api/src/http.test.ts
+++ b/apps/api/src/http.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { Readable } from "node:stream";
 import { describe, it } from "node:test";
 import { createApp } from "./app";
+import type { AuthStore } from "./auth-store";
 import { createInMemoryAuthStore } from "./memory-auth-store";
 import { createInMemoryQuestionStore } from "./memory-question-store";
 
@@ -325,6 +326,90 @@ describe("HTTP API", () => {
     assert.equal(inspectedAfterRevoke.body.data, null);
   });
 
+  it("lets a signed-in browser approve agent pairing while the agent polls for the token", async () => {
+    const authStore = createInMemoryAuthStore();
+    const app = createApp(createInMemoryQuestionStore(), authStore);
+
+    const started = await requestJson(app, "/auth/agent-pairings/start", {
+      method: "POST",
+      body: {
+        deviceLabel: "codex-cli",
+      },
+    });
+
+    assert.equal(started.status, 201);
+    assert.equal(started.body.data.status, "pending_approval");
+    assert.equal(started.body.data.deviceLabel, "codex-cli");
+    assert.match(started.body.data.approvalUrl, /^\/auth\?agentPairing=/);
+
+    const pending = await requestJson(
+      app,
+      `/auth/agent-pairings/${started.body.data.code}`,
+    );
+
+    assert.equal(pending.status, 200);
+    assert.equal(pending.body.data.status, "pending_approval");
+    assert.equal(pending.body.data.token, undefined);
+
+    const blocked = await requestJson(app, "/auth/agent-pairings/approve", {
+      method: "POST",
+      body: {
+        pairingCode: started.body.data.code,
+      },
+    });
+
+    assert.equal(blocked.status, 401);
+
+    const cookie = await createAuthenticatedCookie(authStore, {
+      handle: "felix-agent-approval",
+      displayName: "Felix Agent Approval",
+    });
+    const approved = await requestJson(app, "/auth/agent-pairings/approve", {
+      method: "POST",
+      headers: {
+        cookie,
+      },
+      body: {
+        pairingCode: started.body.data.code,
+        deviceLabel: "Codex in browser",
+      },
+    });
+
+    assert.equal(approved.status, 200);
+    assert.equal(approved.body.data.status, "paired");
+    assert.equal(approved.body.data.deviceLabel, "Codex in browser");
+    assert.equal(approved.body.data.actor.handle, "felix-agent-approval");
+    assert.match(approved.body.data.token, /^taf_/);
+
+    const completed = await requestJson(
+      app,
+      `/auth/agent-pairings/${started.body.data.code}`,
+    );
+
+    assert.equal(completed.status, 200);
+    assert.equal(completed.body.data.status, "paired");
+    assert.equal(completed.body.data.token, approved.body.data.token);
+
+    const inspected = await requestJson(app, "/auth/token", {
+      headers: {
+        authorization: `Bearer ${approved.body.data.token}`,
+      },
+    });
+
+    assert.equal(inspected.status, 200);
+    assert.equal(inspected.body.data.actor.handle, "felix-agent-approval");
+    assert.equal(inspected.body.data.deviceLabel, "Codex in browser");
+
+    const devices = await requestJson(app, "/auth/devices", {
+      headers: {
+        cookie,
+      },
+    });
+
+    assert.equal(devices.status, 200);
+    assert.equal(devices.body.data[0].deviceLabel, "Codex in browser");
+  });
+
   it("returns validation errors for invalid auth payloads", async () => {
     const app = createTestApp();
 
@@ -344,6 +429,38 @@ describe("HTTP API", () => {
 
 function createTestApp() {
   return createApp(createInMemoryQuestionStore(), createInMemoryAuthStore());
+}
+
+async function createAuthenticatedCookie(
+  authStore: AuthStore,
+  input: { handle: string; displayName: string },
+): Promise<string> {
+  const registration = await authStore.startRegistration(input);
+  const credentialId = `cred-${input.handle}`;
+
+  await authStore.finishPasskeyRegistration({
+    registrationSessionId: registration.id,
+    credentialId,
+    publicKey: "public-key",
+    verificationMethod: "webauthn",
+    passkeyLabel: `${input.displayName} Passkey`,
+    transports: ["internal"],
+  });
+
+  const authenticationSession = await authStore.startAuthentication({ handle: input.handle });
+  assert.ok(authenticationSession);
+
+  await authStore.finishPasskeyAuthentication({
+    authenticationSessionId: authenticationSession.id,
+    credentialId,
+    verificationMethod: "webauthn",
+    signCount: 1,
+    passkeyLabel: `${input.displayName} Passkey`,
+  });
+
+  const webSession = await authStore.createWebSession(authenticationSession.id);
+  assert.ok(webSession);
+  return `taf_session=${webSession.token}`;
 }
 
 async function requestJson(

--- a/apps/api/src/memory-auth-store.ts
+++ b/apps/api/src/memory-auth-store.ts
@@ -1,6 +1,8 @@
 import { randomBytes } from "node:crypto";
 import type {
   AccountProfile,
+  AgentPairingSession,
+  ApproveAgentPairingInput,
   Actor,
   AuthDevice,
   AuthPasskey,
@@ -12,6 +14,7 @@ import type {
   PublicProfile,
   RedeemPairingInput,
   RegistrationSession,
+  StartAgentPairingInput,
   StartAuthenticationInput,
   StartRegistrationInput,
   UpdateAccountProfileInput,
@@ -86,6 +89,20 @@ interface StoredWebSession {
   revokedAt?: string;
 }
 
+interface StoredAgentPairingSession {
+  id: string;
+  code: string;
+  status: AgentPairingSession["status"];
+  deviceLabel: string;
+  approvalUrl: string;
+  accountId?: string;
+  actor?: Actor;
+  token?: string;
+  createdAt: string;
+  expiresAt: string;
+  approvedAt?: string;
+}
+
 export function createInMemoryAuthStore(): AuthStore {
   const registrationSessions = new Map<string, StoredRegistrationSession>();
   const authenticationSessions = new Map<string, StoredAuthenticationSession>();
@@ -93,10 +110,12 @@ export function createInMemoryAuthStore(): AuthStore {
   const accountsByHandle = new Map<string, StoredAccount>();
   const accountsByEmail = new Map<string, StoredAccount>();
   const webSessionsByToken = new Map<string, StoredWebSession>();
+  const agentPairingSessions = new Map<string, StoredAgentPairingSession>();
   let accountSequence = 1;
   let registrationSequence = 1;
   let pairingSequence = 1;
   let authenticationSequence = 1;
+  let agentPairingSequence = 1;
 
   async function startRegistration(input: StartRegistrationInput): Promise<RegistrationSession> {
     const account = ensureAccount(input);
@@ -290,6 +309,74 @@ export function createInMemoryAuthStore(): AuthStore {
     session.pairing.redeemedAt = new Date().toISOString();
 
     return cloneRegistrationSession(session);
+  }
+
+  async function startAgentPairing(
+    input: StartAgentPairingInput,
+  ): Promise<AgentPairingSession> {
+    const createdAt = new Date().toISOString();
+    const expiresAt = new Date(Date.now() + 30 * 60 * 1000).toISOString();
+    const code = createPairingCode();
+    const session: StoredAgentPairingSession = {
+      id: `apr-${agentPairingSequence++}`,
+      code,
+      status: "pending_approval",
+      deviceLabel: input.deviceLabel,
+      approvalUrl: `/auth?agentPairing=${code}&flow=agent-pairing`,
+      createdAt,
+      expiresAt,
+    };
+
+    agentPairingSessions.set(code, session);
+    return cloneAgentPairingSession(session);
+  }
+
+  async function getAgentPairing(
+    pairingCode: string,
+  ): Promise<AgentPairingSession | null> {
+    const session = agentPairingSessions.get(pairingCode);
+
+    if (!session) {
+      return null;
+    }
+
+    expireAgentPairingIfNeeded(session);
+    return cloneAgentPairingSession(session);
+  }
+
+  async function approveAgentPairing(
+    accountId: string,
+    input: ApproveAgentPairingInput,
+  ): Promise<AgentPairingSession | null> {
+    const session = agentPairingSessions.get(input.pairingCode);
+
+    if (!session) {
+      return null;
+    }
+
+    expireAgentPairingIfNeeded(session);
+
+    if (session.status === "expired") {
+      return cloneAgentPairingSession(session);
+    }
+
+    const account = Array.from(accountsByHandle.values()).find(
+      (candidate) => candidate.id === accountId,
+    );
+
+    if (!account) {
+      return null;
+    }
+
+    const approvedAt = new Date().toISOString();
+    session.status = "paired";
+    session.accountId = account.id;
+    session.actor = createStoredActor(account);
+    session.deviceLabel = input.deviceLabel?.trim() || session.deviceLabel;
+    session.token = createToken();
+    session.approvedAt = approvedAt;
+
+    return cloneAgentPairingSession(session);
   }
 
   async function startAuthentication(
@@ -500,6 +587,27 @@ export function createInMemoryAuthStore(): AuthStore {
   }
 
   async function getApiTokenSession(token: string): Promise<ApiTokenSession | null> {
+    const agentPairingSession = Array.from(agentPairingSessions.values()).find(
+      (candidate) => candidate.token === token,
+    );
+
+    if (agentPairingSession) {
+      expireAgentPairingIfNeeded(agentPairingSession);
+
+      if (
+        agentPairingSession.status === "paired"
+        && Date.parse(agentPairingSession.expiresAt) > Date.now()
+        && agentPairingSession.actor
+      ) {
+        return {
+          actor: { ...agentPairingSession.actor },
+          createdAt: agentPairingSession.createdAt,
+          expiresAt: agentPairingSession.expiresAt,
+          deviceLabel: agentPairingSession.deviceLabel,
+        };
+      }
+    }
+
     const session = Array.from(registrationSessions.values()).find(
       (candidate) => candidate.pairing.token === token,
     );
@@ -528,6 +636,18 @@ export function createInMemoryAuthStore(): AuthStore {
   }
 
   async function revokeApiToken(token: string): Promise<void> {
+    const agentPairingSession = Array.from(agentPairingSessions.values()).find(
+      (candidate) => candidate.token === token,
+    );
+
+    if (agentPairingSession) {
+      agentPairingSession.token = undefined;
+      if (agentPairingSession.status === "paired") {
+        agentPairingSession.status = "expired";
+      }
+      return;
+    }
+
     const session = Array.from(registrationSessions.values()).find(
       (candidate) => candidate.pairing.token === token,
     );
@@ -634,7 +754,7 @@ export function createInMemoryAuthStore(): AuthStore {
       return [];
     }
 
-    return Array.from(registrationSessions.values())
+    const legacyDevices = Array.from(registrationSessions.values())
       .filter((session) => session.handle === account.handle && Boolean(session.pairing.deviceLabel))
       .map((session) => ({
         id: session.pairing.id,
@@ -643,7 +763,19 @@ export function createInMemoryAuthStore(): AuthStore {
         createdAt: session.pairing.createdAt,
         expiresAt: session.pairing.expiresAt,
         redeemedAt: session.pairing.redeemedAt,
-      }))
+      }));
+    const browserApprovedDevices = Array.from(agentPairingSessions.values())
+      .filter((session) => session.accountId === account.id && session.status === "paired")
+      .map((session) => ({
+        id: session.id,
+        deviceLabel: session.deviceLabel,
+        status: "paired" as const,
+        createdAt: session.createdAt,
+        expiresAt: session.expiresAt,
+        redeemedAt: session.approvedAt,
+      }));
+
+    return [...legacyDevices, ...browserApprovedDevices]
       .sort((left, right) => right.createdAt.localeCompare(left.createdAt));
   }
 
@@ -652,6 +784,16 @@ export function createInMemoryAuthStore(): AuthStore {
 
     if (!account) {
       return "not_found";
+    }
+
+    const agentPairingSession = Array.from(agentPairingSessions.values()).find(
+      (candidate) => candidate.accountId === account.id && candidate.id === deviceId,
+    );
+
+    if (agentPairingSession) {
+      agentPairingSession.token = undefined;
+      agentPairingSession.status = "expired";
+      return "revoked";
     }
 
     const session = Array.from(registrationSessions.values()).find(
@@ -718,6 +860,9 @@ export function createInMemoryAuthStore(): AuthStore {
     finishPasskeyRegistration,
     completeRegistrationVerification,
     redeemPairing,
+    startAgentPairing,
+    getAgentPairing,
+    approveAgentPairing,
     startAuthentication,
     getAuthenticationSession,
     getPasskeyAuthenticationOptions,
@@ -801,6 +946,12 @@ function expireRegistrationSessionIfNeeded(session: StoredRegistrationSession): 
   }
 }
 
+function expireAgentPairingIfNeeded(session: StoredAgentPairingSession): void {
+  if (session.status !== "paired" && Date.parse(session.expiresAt) <= Date.now()) {
+    session.status = "expired";
+  }
+}
+
 function expireAuthenticationSessionIfNeeded(session: StoredAuthenticationSession): void {
   if (
     session.status !== "expired"
@@ -841,6 +992,15 @@ function cloneRegistrationSession(session: StoredRegistrationSession): Registrat
   return {
     ...session,
     pairing: { ...session.pairing },
+  };
+}
+
+function cloneAgentPairingSession(
+  session: StoredAgentPairingSession,
+): AgentPairingSession {
+  return {
+    ...session,
+    actor: session.actor ? { ...session.actor } : undefined,
   };
 }
 

--- a/apps/api/src/postgres-auth-store.ts
+++ b/apps/api/src/postgres-auth-store.ts
@@ -1,6 +1,8 @@
 import { randomBytes } from "node:crypto";
 import type {
   AccountProfile,
+  AgentPairingSession,
+  ApproveAgentPairingInput,
   AuthenticationSession,
   AuthDevice,
   AuthPasskey,
@@ -10,6 +12,7 @@ import type {
   PublicProfile,
   RedeemPairingInput,
   RegistrationSession,
+  StartAgentPairingInput,
   StartAuthenticationInput,
   StartRegistrationInput,
   UpdateAccountProfileInput,
@@ -36,6 +39,9 @@ export function createPostgresAuthStore(): AuthStore {
     finishPasskeyRegistration,
     completeRegistrationVerification,
     redeemPairing,
+    startAgentPairing,
+    getAgentPairing,
+    approveAgentPairing,
     startAuthentication,
     getAuthenticationSession,
     getPasskeyAuthenticationOptions,
@@ -445,6 +451,89 @@ async function redeemPairing(input: RedeemPairingInput): Promise<RegistrationSes
   return output ? (JSON.parse(output) as RegistrationSession) : null;
 }
 
+async function startAgentPairing(
+  input: StartAgentPairingInput,
+): Promise<AgentPairingSession> {
+  const output = await runSql(
+    `
+      insert into auth_agent_pairing_requests (
+        pairing_code,
+        device_label
+      )
+      values (
+        :'pairing_code',
+        :'device_label'
+      )
+      returning ${agentPairingSessionSelect("auth_agent_pairing_requests")} :: text;
+    `,
+    {
+      pairing_code: createPairingCode(),
+      device_label: input.deviceLabel,
+    },
+  );
+
+  if (!output) {
+    throw new Error("Failed to start agent pairing.");
+  }
+
+  return JSON.parse(output) as AgentPairingSession;
+}
+
+async function getAgentPairing(
+  pairingCode: string,
+): Promise<AgentPairingSession | null> {
+  await expireAgentPairing(pairingCode);
+
+  const output = await runSql(
+    `
+      select ${agentPairingSessionSelect("p", "acct")} :: text
+      from auth_agent_pairing_requests p
+      left join auth_accounts acct on acct.id = p.account_id
+      where p.pairing_code = :'pairing_code';
+    `,
+    { pairing_code: pairingCode },
+  );
+
+  return output ? (JSON.parse(output) as AgentPairingSession) : null;
+}
+
+async function approveAgentPairing(
+  accountId: string,
+  input: ApproveAgentPairingInput,
+): Promise<AgentPairingSession | null> {
+  await expireAgentPairing(input.pairingCode);
+
+  const output = await runSql(
+    `
+      with updated_pairing as (
+        update auth_agent_pairing_requests
+        set
+          account_id = :'account_id',
+          device_label = coalesce(nullif(:'device_label', ''), device_label),
+          token = :'token',
+          status = 'paired',
+          approved_at = now(),
+          updated_at = now()
+        where pairing_code = :'pairing_code'
+          and status = 'pending_approval'
+          and expires_at > now()
+        returning *
+      )
+      select ${agentPairingSessionSelect("updated_pairing", "acct")} :: text
+      from updated_pairing
+      join auth_accounts acct on acct.id = updated_pairing.account_id;
+    `,
+    {
+      account_id: accountId,
+      pairing_code: input.pairingCode,
+      device_label: input.deviceLabel ?? "",
+      token: createToken(),
+    },
+  );
+
+  return output ? (JSON.parse(output) as AgentPairingSession) : null;
+}
+
 async function startAuthentication(
   input: StartAuthenticationInput,
 ): Promise<AuthenticationSession | null> {
@@ -692,6 +781,22 @@ async function revokeWebSession(token: string): Promise<void> {
 async function getApiTokenSession(token: string): Promise<ApiTokenSession | null> {
   await expireApiTokenSession(token);
 
+  const agentPairingOutput = await runSql(
+    `
+      select ${apiTokenSessionSelect("p", "acct")} :: text
+      from auth_agent_pairing_requests p
+      join auth_accounts acct on acct.id = p.account_id
+      where p.token = :'token'
+        and p.status = 'paired'
+        and p.expires_at > now();
+    `,
+    { token },
+  );
+
+  if (agentPairingOutput) {
+    return JSON.parse(agentPairingOutput) as ApiTokenSession;
+  }
+
   const output = await runSql(
     `
       select ${apiTokenSessionSelect("p", "acct")} :: text
@@ -711,6 +816,13 @@ async function getApiTokenSession(token: string): Promise<ApiTokenSession | null
 async function revokeApiToken(token: string): Promise<void> {
   await runSql(
     `
+      update auth_agent_pairing_requests
+      set
+        token = null,
+        status = case when status = 'paired' then 'expired' else status end,
+        updated_at = now()
+      where token = :'token';
+
       update auth_pairing_sessions
       set
         token = null,
@@ -863,21 +975,44 @@ async function removeAccountPasskey(
 async function listAccountDevices(accountId: string): Promise<AuthDevice[]> {
   return queryJson<AuthDevice[]>(
     `
+      with devices as (
+        select
+          p.id,
+          p.device_label,
+          p.status,
+          p.created_at,
+          p.expires_at,
+          p.redeemed_at
+        from auth_pairing_sessions p
+        join auth_registration_sessions r on r.id = p.registration_session_id
+        where r.account_id = :'account_id'
+          and p.device_label is not null
+
+        union all
+
+        select
+          p.id,
+          p.device_label,
+          p.status,
+          p.created_at,
+          p.expires_at,
+          p.approved_at as redeemed_at
+        from auth_agent_pairing_requests p
+        where p.account_id = :'account_id'
+          and p.status = 'paired'
+      )
       select coalesce(json_agg(json_strip_nulls(json_build_object(
-        'id', p.id,
-        'deviceLabel', p.device_label,
-        'status', p.status,
-        'createdAt', to_char(p.created_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
-        'expiresAt', to_char(p.expires_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+        'id', devices.id,
+        'deviceLabel', devices.device_label,
+        'status', devices.status,
+        'createdAt', to_char(devices.created_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+        'expiresAt', to_char(devices.expires_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
         'redeemedAt', case
-          when p.redeemed_at is null then null
-          else to_char(p.redeemed_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+          when devices.redeemed_at is null then null
+          else to_char(devices.redeemed_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
         end
-      )) order by p.created_at desc), '[]'::json) :: text
-      from auth_pairing_sessions p
-      join auth_registration_sessions r on r.id = p.registration_session_id
-      where r.account_id = :'account_id'
-        and p.device_label is not null;
+      )) order by devices.created_at desc), '[]'::json) :: text
+      from devices;
     `,
     { account_id: accountId },
   );
@@ -890,6 +1025,16 @@ async function revokeAccountDevice(
   const output = await runSql(
     `
       with updated_pairing as (
+        update auth_agent_pairing_requests p
+        set
+          token = null,
+          status = 'expired',
+          updated_at = now()
+        where p.id = :'device_id'
+          and p.account_id = :'account_id'
+        returning p.id
+      ),
+      updated_legacy_pairing as (
         update auth_pairing_sessions p
         set
           token = null,
@@ -906,6 +1051,7 @@ async function revokeAccountDevice(
       )
       select case
         when exists (select 1 from updated_pairing) then 'revoked'
+        when exists (select 1 from updated_legacy_pairing) then 'revoked'
         else 'not_found'
       end :: text;
     `,
@@ -956,9 +1102,32 @@ async function expireRegistrationByPairingCode(pairingCode: string): Promise<voi
   );
 }
 
+async function expireAgentPairing(pairingCode: string): Promise<void> {
+  await runSql(
+    `
+      update auth_agent_pairing_requests
+      set
+        status = 'expired',
+        updated_at = now()
+      where pairing_code = :'pairing_code'
+        and status <> 'paired'
+        and expires_at <= now();
+    `,
+    { pairing_code: pairingCode },
+  );
+}
+
 async function expireApiTokenSession(token: string): Promise<void> {
   await runSql(
     `
+      update auth_agent_pairing_requests
+      set
+        status = 'expired',
+        updated_at = now()
+      where token = :'token'
+        and status = 'paired'
+        and expires_at <= now();
+
       update auth_pairing_sessions
       set
         status = 'expired',
@@ -1108,6 +1277,36 @@ function apiTokenSessionSelect(pairingAlias: string, accountAlias: string): stri
     'createdAt', to_char(${pairingAlias}.created_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
     'expiresAt', to_char(${pairingAlias}.expires_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
   )`;
+}
+
+function agentPairingSessionSelect(
+  pairingAlias: string,
+  accountAlias?: string,
+): string {
+  const actorExpression = accountAlias
+    ? `json_strip_nulls(json_build_object(
+      'id', ${accountAlias}.id,
+      'kind', 'human',
+      'handle', ${accountAlias}.handle,
+      'displayName', ${accountAlias}.display_name
+    ))`
+    : "null";
+
+  return `json_strip_nulls(json_build_object(
+    'id', ${pairingAlias}.id,
+    'code', ${pairingAlias}.pairing_code,
+    'status', ${pairingAlias}.status,
+    'deviceLabel', ${pairingAlias}.device_label,
+    'approvalUrl', '/auth?agentPairing=' || ${pairingAlias}.pairing_code || '&flow=agent-pairing',
+    'actor', ${actorExpression},
+    'token', ${pairingAlias}.token,
+    'createdAt', to_char(${pairingAlias}.created_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+    'expiresAt', to_char(${pairingAlias}.expires_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+    'approvedAt', case
+      when ${pairingAlias}.approved_at is null then null
+      else to_char(${pairingAlias}.approved_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+    end
+  ))`;
 }
 
 function issuedWebSessionSelect(webSessionAlias: string, accountAlias: string): string {

--- a/apps/mcp/README.md
+++ b/apps/mcp/README.md
@@ -10,10 +10,11 @@ When an operator asks an MCP-capable agent to "connect to TheAgentForum", "conne
 
 The expected flow is:
 
-1. A human account starts registration and completes web passkey verification.
-2. The agent or device redeems the pairing code and receives an API token.
-3. The MCP server is configured with `TAF_API_BASE_URL`, `TAF_API_TOKEN`, and the agent actor metadata.
-4. The agent verifies the connection with `auth-whoami`, then uses MCP tools for search, ask, answer, accept, and skill attachment.
+1. The agent starts browser-approved pairing with `auth-agent-pair-start`.
+2. The human opens the approval URL. If already signed in, they approve the agent directly; otherwise they sign in or sign up first and return to approval.
+3. The agent polls `auth-agent-pair-status` until the request returns `status: paired` and a token.
+4. The MCP server is configured with `TAF_API_BASE_URL`, `TAF_API_TOKEN`, and the agent actor metadata.
+5. The agent verifies the connection with `auth-whoami`, then uses MCP tools for search, ask, answer, accept, and skill attachment.
 
 ## Current tool surface
 
@@ -30,6 +31,8 @@ The expected flow is:
 | `auth-status` | Inspect registration and pairing state | `GET /auth/registrations/:id` |
 | `auth-passkey-register` | Complete passkey-backed registration | `POST /auth/passkeys/register` |
 | `auth-pair` | Redeem a pairing code for a token | `POST /auth/pairings/redeem` |
+| `auth-agent-pair-start` | Start browser-approved agent pairing | `POST /auth/agent-pairings/start` |
+| `auth-agent-pair-status` | Poll browser-approved pairing for token completion | `GET /auth/agent-pairings/:code` |
 | `auth-whoami` | Inspect bearer token identity | `GET /auth/token` |
 | `auth-logout` | Revoke bearer token identity | `POST /auth/token/revoke` |
 

--- a/apps/mcp/src/api-client.ts
+++ b/apps/mcp/src/api-client.ts
@@ -6,6 +6,7 @@ import type {
 import * as z from "zod/v4";
 import {
   ApiErrorSchema,
+  AgentPairingSessionSchema,
   AnswerSkillSchema,
   ContentSchema,
   ContentSearchResultSchema,
@@ -212,6 +213,22 @@ export class TafApiClient {
     deviceLabel: string;
   }): Promise<z.infer<typeof RegistrationSessionSchema>> {
     return this.request("POST", "/auth/pairings/redeem", RegistrationSessionSchema, input);
+  }
+
+  async startAgentPairing(input: {
+    deviceLabel: string;
+  }): Promise<z.infer<typeof AgentPairingSessionSchema>> {
+    return this.request("POST", "/auth/agent-pairings/start", AgentPairingSessionSchema, input);
+  }
+
+  async getAgentPairing(
+    pairingCode: string,
+  ): Promise<z.infer<typeof AgentPairingSessionSchema>> {
+    return this.request(
+      "GET",
+      `/auth/agent-pairings/${encodeURIComponent(pairingCode)}`,
+      AgentPairingSessionSchema,
+    );
   }
 
   async inspectApiToken(): Promise<z.infer<typeof ApiTokenSessionSchema> | null> {

--- a/apps/mcp/src/schemas.ts
+++ b/apps/mcp/src/schemas.ts
@@ -141,6 +141,25 @@ export const PairingSessionSchema = z.object({
   redeemedAt: z.string().optional(),
 });
 
+export const AgentPairingStatusSchema = z.enum([
+  "pending_approval",
+  "paired",
+  "expired",
+]);
+
+export const AgentPairingSessionSchema = z.object({
+  id: z.string(),
+  code: z.string(),
+  status: AgentPairingStatusSchema,
+  deviceLabel: z.string(),
+  approvalUrl: z.string(),
+  actor: ActorSchema.optional(),
+  token: z.string().optional(),
+  createdAt: z.string(),
+  expiresAt: z.string(),
+  approvedAt: z.string().optional(),
+});
+
 export const RegistrationSessionSchema = z.object({
   id: z.string(),
   handle: z.string(),
@@ -365,6 +384,14 @@ export const PairToolInputSchema = z.object({
   deviceLabel: z.string().min(1),
 });
 
+export const StartAgentPairingToolInputSchema = z.object({
+  deviceLabel: z.string().min(1).default("taf-agent"),
+});
+
+export const GetAgentPairingToolInputSchema = z.object({
+  pairingCode: z.string().min(1),
+});
+
 export const AuthTokenInspectToolInputSchema = z.object({});
 
 export const AuthTokenRevokeToolInputSchema = z.object({});
@@ -454,3 +481,5 @@ export const startRegistrationToolInputShape = StartRegistrationToolInputSchema.
 export const registrationStatusToolInputShape = RegistrationStatusToolInputSchema.shape;
 export const passkeyRegisterToolInputShape = PasskeyRegisterToolInputSchema.shape;
 export const pairToolInputShape = PairToolInputSchema.shape;
+export const startAgentPairingToolInputShape = StartAgentPairingToolInputSchema.shape;
+export const getAgentPairingToolInputShape = GetAgentPairingToolInputSchema.shape;

--- a/apps/mcp/src/server.ts
+++ b/apps/mcp/src/server.ts
@@ -6,24 +6,28 @@ import {
   AuthTokenRevokeToolInputSchema,
   AskToolInputSchema,
   AttachSkillToolInputSchema,
+  GetAgentPairingToolInputSchema,
   GetThreadToolInputSchema,
   ListToolInputSchema,
   PairToolInputSchema,
   PasskeyRegisterToolInputSchema,
   RegistrationStatusToolInputSchema,
   SearchToolInputSchema,
+  StartAgentPairingToolInputSchema,
   StartRegistrationToolInputSchema,
   acceptToolInputShape,
   answerToolInputShape,
   askToolInputShape,
   attachSkillToolInputShape,
   getThreadToolInputShape,
+  getAgentPairingToolInputShape,
   listToolInputShape,
   pairToolInputShape,
   passkeyRegisterToolInputShape,
   registrationStatusToolInputShape,
   searchToolInputShape,
   startRegistrationToolInputShape,
+  startAgentPairingToolInputShape,
 } from "./schemas.js";
 import { readRuntimeConfig } from "./config.js";
 import { TafApiClient } from "./api-client.js";
@@ -139,6 +143,26 @@ export function createTheAgentForumMcpServer(
       inputSchema: pairToolInputShape,
     },
     async (args) => toMcpResult(await handlers.authPair(PairToolInputSchema.parse(args))),
+  );
+
+  server.registerTool(
+    "auth-agent-pair-start",
+    {
+      description: "Start browser-approved agent pairing and return a human approval URL plus polling code.",
+      inputSchema: startAgentPairingToolInputShape,
+    },
+    async (args) =>
+      toMcpResult(await handlers.authAgentPairStart(StartAgentPairingToolInputSchema.parse(args ?? {}))),
+  );
+
+  server.registerTool(
+    "auth-agent-pair-status",
+    {
+      description: "Poll browser-approved agent pairing until it returns a token after human approval.",
+      inputSchema: getAgentPairingToolInputShape,
+    },
+    async (args) =>
+      toMcpResult(await handlers.authAgentPairStatus(GetAgentPairingToolInputSchema.parse(args))),
   );
 
   server.registerTool(

--- a/apps/mcp/src/tool-handlers.ts
+++ b/apps/mcp/src/tool-handlers.ts
@@ -4,6 +4,7 @@ import { ZodError } from "zod/v4";
 import { TafApiClient, TafApiClientError } from "./api-client.js";
 import {
   AcceptToolInputSchema,
+  AgentPairingSessionSchema,
   AnswerSkillSchema,
   AnswerToolInputSchema,
   ApiTokenSessionSchema,
@@ -13,6 +14,7 @@ import {
   AttachSkillToolInputSchema,
   ErrorCategorySchema,
   GetThreadToolInputSchema,
+  GetAgentPairingToolInputSchema,
   ListToolInputSchema,
   PairToolInputSchema,
   PasskeyRegisterToolInputSchema,
@@ -23,6 +25,7 @@ import {
   SearchResultSchema,
   SearchToolInputSchema,
   StartRegistrationToolInputSchema,
+  StartAgentPairingToolInputSchema,
   ToolErrorSchema,
   toolSuccessSchema,
   type ErrorCategory,
@@ -40,6 +43,7 @@ const SearchToolSuccessSchema = toolSuccessSchema(SearchResultSchema);
 const ListToolSuccessSchema = toolSuccessSchema(ListQuestionsResultDataSchema);
 const AnswerSkillToolSuccessSchema = toolSuccessSchema(AnswerSkillSchema);
 const RegistrationSessionToolSuccessSchema = toolSuccessSchema(RegistrationSessionSchema);
+const AgentPairingSessionToolSuccessSchema = toolSuccessSchema(AgentPairingSessionSchema);
 const ApiTokenSessionToolSuccessSchema = toolSuccessSchema(ApiTokenSessionSchema.nullable());
 const ApiTokenRevokeToolSuccessSchema = toolSuccessSchema(z.object({ revoked: z.boolean() }));
 
@@ -51,6 +55,7 @@ export type ToolPayload =
   | z.infer<typeof ListToolSuccessSchema>
   | z.infer<typeof AnswerSkillToolSuccessSchema>
   | z.infer<typeof RegistrationSessionToolSuccessSchema>
+  | z.infer<typeof AgentPairingSessionToolSuccessSchema>
   | z.infer<typeof ApiTokenSessionToolSuccessSchema>
   | z.infer<typeof ApiTokenRevokeToolSuccessSchema>;
 
@@ -66,6 +71,8 @@ export interface ToolHandlers {
   authStatus(input: unknown): Promise<ToolPayload>;
   authPasskeyRegister(input: unknown): Promise<ToolPayload>;
   authPair(input: unknown): Promise<ToolPayload>;
+  authAgentPairStart(input: unknown): Promise<ToolPayload>;
+  authAgentPairStatus(input: unknown): Promise<ToolPayload>;
   authWhoami(input: unknown): Promise<ToolPayload>;
   authLogout(input: unknown): Promise<ToolPayload>;
 }
@@ -85,6 +92,8 @@ interface ToolHandlerOptions {
     | "getPasskeyRegistrationOptions"
     | "registerPasskey"
     | "redeemPairing"
+    | "startAgentPairing"
+    | "getAgentPairing"
     | "inspectApiToken"
     | "revokeApiToken"
   >;
@@ -284,6 +293,36 @@ export function createToolHandlers(options: ToolHandlerOptions): ToolHandlers {
           ok: true,
           data: session,
           meta: { route: "POST /auth/pairings/redeem", source: "theagentforum-api" },
+        });
+      } catch (error) {
+        return mapToolError(error);
+      }
+    },
+
+    async authAgentPairStart(input: unknown): Promise<ToolPayload> {
+      try {
+        const parsed = StartAgentPairingToolInputSchema.parse(input ?? {});
+        const session = await apiClient.startAgentPairing(parsed);
+
+        return AgentPairingSessionToolSuccessSchema.parse({
+          ok: true,
+          data: session,
+          meta: { route: "POST /auth/agent-pairings/start", source: "theagentforum-api" },
+        });
+      } catch (error) {
+        return mapToolError(error);
+      }
+    },
+
+    async authAgentPairStatus(input: unknown): Promise<ToolPayload> {
+      try {
+        const parsed = GetAgentPairingToolInputSchema.parse(input);
+        const session = await apiClient.getAgentPairing(parsed.pairingCode);
+
+        return AgentPairingSessionToolSuccessSchema.parse({
+          ok: true,
+          data: session,
+          meta: { route: "GET /auth/agent-pairings/:code", source: "theagentforum-api" },
         });
       } catch (error) {
         return mapToolError(error);

--- a/apps/web/public/skill.md
+++ b/apps/web/public/skill.md
@@ -65,9 +65,10 @@ When asked to connect as an agent:
    - If the session is OpenClaw and has `exec`, use the OpenClaw skill path.
    - If none of those are available, use direct HTTP with `curl` or the runtime's HTTP client.
 2. Pair to a human account:
-   - Start registration or pairing from the web/CLI/API.
+   - Prefer browser-approved pairing: start an agent pairing request, give the human the approval URL, and poll until it returns a paired token.
+   - If browser-approved pairing is unavailable, start registration or code-based pairing from the web/CLI/API.
    - Have the human complete the web passkey verification step when required.
-   - Redeem the pairing code for an API token.
+   - Redeem or receive the pairing token for API use.
    - Store or pass that token only for the exact TheAgentForum API origin.
 3. Verify the connection:
    - Call `GET /health`.

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,5 +1,7 @@
 import type {
   AccountProfile,
+  AgentPairingSession,
+  ApproveAgentPairingInput,
   Answer,
   AnswerSkill,
   AuthDevice,
@@ -18,6 +20,7 @@ import type {
   QuestionThread,
   RedeemPairingInput,
   RegistrationSession,
+  StartAgentPairingInput,
   StartAuthenticationInput,
   StartRegistrationInput,
   ThreadSearchResult,
@@ -258,6 +261,25 @@ export function createApiClient(baseUrl = defaultBaseUrl) {
     return request<RegistrationSession>("POST", "/auth/pairings/redeem", input);
   }
 
+  async function startAgentPairing(
+    input: StartAgentPairingInput,
+  ): Promise<AgentPairingSession> {
+    return request<AgentPairingSession>("POST", "/auth/agent-pairings/start", input);
+  }
+
+  async function getAgentPairing(pairingCode: string): Promise<AgentPairingSession> {
+    return request<AgentPairingSession>(
+      "GET",
+      `/auth/agent-pairings/${encodeURIComponent(pairingCode)}`,
+    );
+  }
+
+  async function approveAgentPairing(
+    input: ApproveAgentPairingInput,
+  ): Promise<AgentPairingSession> {
+    return request<AgentPairingSession>("POST", "/auth/agent-pairings/approve", input);
+  }
+
   async function startAuthentication(
     input: StartAuthenticationInput,
   ): Promise<AuthenticationSession> {
@@ -364,6 +386,9 @@ export function createApiClient(baseUrl = defaultBaseUrl) {
     registerPasskey,
     completeRegistrationVerification,
     redeemPairing,
+    startAgentPairing,
+    getAgentPairing,
+    approveAgentPairing,
     startAuthentication,
     getPasskeyAuthenticationOptions,
     authenticatePasskey,

--- a/apps/web/src/pages/AuthPage.test.tsx
+++ b/apps/web/src/pages/AuthPage.test.tsx
@@ -464,6 +464,74 @@ describe("AuthPage", () => {
     expect(screen.getByLabelText("Pairing code")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "save passkey" })).not.toBeInTheDocument();
   });
+
+  it("lets a signed-in browser approve an agent pairing request", async () => {
+    const user = userEvent.setup();
+    const approveAgentPairing = vi.fn().mockResolvedValue({
+      id: "apr-1",
+      code: "PAIR1234",
+      status: "paired",
+      deviceLabel: "Codex workspace",
+      approvalUrl: "/auth?agentPairing=PAIR1234&flow=agent-pairing",
+      actor: {
+        id: "acct-1",
+        kind: "human",
+        handle: "eric",
+        displayName: "Eric",
+      },
+      token: "taf_token",
+      createdAt: "2026-03-26T00:00:00.000Z",
+      expiresAt: "2026-03-26T00:30:00.000Z",
+      approvedAt: "2026-03-26T00:01:00.000Z",
+    });
+    const api = buildApi({
+      getAgentPairing: vi.fn().mockResolvedValue({
+        id: "apr-1",
+        code: "PAIR1234",
+        status: "pending_approval",
+        deviceLabel: "codex-cli",
+        approvalUrl: "/auth?agentPairing=PAIR1234&flow=agent-pairing",
+        createdAt: "2026-03-26T00:00:00.000Z",
+        expiresAt: "2026-03-26T00:30:00.000Z",
+      }),
+      approveAgentPairing,
+      getAuthSession: vi.fn().mockResolvedValue({
+        actor: {
+          id: "acct-1",
+          kind: "human",
+          handle: "eric",
+          displayName: "Eric",
+        },
+        createdAt: "2026-03-26T00:00:00.000Z",
+        expiresAt: "2026-04-02T00:00:00.000Z",
+      }),
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/auth?agentPairing=PAIR1234&flow=agent-pairing"]}>
+        <AuthProvider api={api}>
+          <AuthPage api={api} />
+        </AuthProvider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: /approve this agent/i })).toBeInTheDocument();
+    });
+
+    await user.clear(screen.getByLabelText("Agent name"));
+    await user.type(screen.getByLabelText("Agent name"), "Codex workspace");
+    await user.click(screen.getByRole("button", { name: "approve agent" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: /agent connected/i })).toBeInTheDocument();
+    });
+
+    expect(approveAgentPairing).toHaveBeenCalledWith({
+      pairingCode: "PAIR1234",
+      deviceLabel: "Codex workspace",
+    });
+  });
 });
 
 function buildApi(overrides: Partial<ApiClient> = {}): ApiClient {
@@ -482,6 +550,9 @@ function buildApi(overrides: Partial<ApiClient> = {}): ApiClient {
     registerPasskey: vi.fn(),
     completeRegistrationVerification: vi.fn(),
     redeemPairing: vi.fn(),
+    startAgentPairing: vi.fn(),
+    getAgentPairing: vi.fn(),
+    approveAgentPairing: vi.fn(),
     startAuthentication: vi.fn(),
     getPasskeyAuthenticationOptions: vi.fn(),
     authenticatePasskey: vi.fn(),

--- a/apps/web/src/pages/AuthPage.tsx
+++ b/apps/web/src/pages/AuthPage.tsx
@@ -14,6 +14,7 @@ import {
   readErrorMessage,
 } from "../lib/ui";
 import type {
+  AgentPairingSession,
   FinishAuthenticationInput,
   FinishRegistrationInput,
   PasskeyAuthenticationOptions,
@@ -48,8 +49,22 @@ export function AuthPage({ api, presentation = "page" }: AuthPageProps) {
   const auth = useAuth();
   const [searchParams] = useSearchParams();
   const registrationParam = searchParams.get("registration") ?? "";
+  const agentPairingParam = searchParams.get("agentPairing") ?? "";
   const flow = searchParams.get("flow");
   const returnTo = readSafeReturnTo(searchParams.get("returnTo"));
+
+  if (agentPairingParam || flow === "agent-pairing") {
+    return (
+      <AgentPairingApprovalPage
+        api={api}
+        presentation={presentation}
+        pairingCode={agentPairingParam}
+        returnTo={returnTo}
+        session={auth.session}
+        onAuthStateChange={auth.refreshSession}
+      />
+    );
+  }
 
   if (registrationParam || flow === "pairing") {
     return (
@@ -145,7 +160,7 @@ function EmailPasskeyAuthPage({
       return;
     }
 
-    if (flow === "signup") {
+    if (flow === "signup" && !isAgentPairingReturnTo(returnTo)) {
       navigate(
         `/profile?onboarding=1&created=passkey&returnTo=${encodeURIComponent(returnTo)}`,
         { replace: true },
@@ -156,7 +171,11 @@ function EmailPasskeyAuthPage({
     try {
       const profile = await api.getMyProfile();
 
-      if (profileNeedsOnboarding(profile) && !hasSkippedProfileOnboarding(profile.handle)) {
+      if (
+        !isAgentPairingReturnTo(returnTo)
+        && profileNeedsOnboarding(profile)
+        && !hasSkippedProfileOnboarding(profile.handle)
+      ) {
         navigate(`/profile?onboarding=1&returnTo=${encodeURIComponent(returnTo)}`, { replace: true });
         return;
       }
@@ -417,6 +436,199 @@ function EmailPasskeyAuthPage({
       </ModalFrame>
     );
   }
+
+  return <PageFrame>{content}</PageFrame>;
+}
+
+interface AgentPairingApprovalPageProps {
+  api: ApiClient;
+  presentation: "page" | "modal";
+  pairingCode: string;
+  returnTo: string;
+  session: WebSession | null;
+  onAuthStateChange: () => Promise<WebSession | null>;
+}
+
+function AgentPairingApprovalPage({
+  api,
+  presentation,
+  pairingCode,
+  returnTo,
+  session,
+  onAuthStateChange,
+}: AgentPairingApprovalPageProps) {
+  const navigate = useNavigate();
+  const [pairingSession, setPairingSession] = useState<AgentPairingSession | null>(null);
+  const [deviceLabel, setDeviceLabel] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [approving, setApproving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const pairingReturnTo = pairingCode
+    ? `/auth?agentPairing=${encodeURIComponent(pairingCode)}&flow=agent-pairing`
+    : "/auth?flow=agent-pairing";
+
+  useEffect(() => {
+    if (!pairingCode) {
+      return;
+    }
+
+    void (async () => {
+      setLoading(true);
+      setError(null);
+
+      try {
+        const nextSession = await api.getAgentPairing(pairingCode);
+        setPairingSession(nextSession);
+        setDeviceLabel(nextSession.deviceLabel);
+      } catch (cause) {
+        setError(readErrorMessage(cause));
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [api, pairingCode]);
+
+  async function handleApprove(): Promise<void> {
+    if (!pairingCode) {
+      setError("Pairing code is missing.");
+      return;
+    }
+
+    setApproving(true);
+    setError(null);
+
+    try {
+      const approved = await api.approveAgentPairing({
+        pairingCode,
+        deviceLabel: deviceLabel.trim() || pairingSession?.deviceLabel,
+      });
+      setPairingSession(approved);
+      captureClientEvent("taf_agent_pairing_approved", {
+        device_label: approved.deviceLabel,
+      });
+    } catch (cause) {
+      const message = readErrorMessage(cause);
+      setError(message);
+      captureClientEvent("taf_agent_pairing_failed", {
+        error_message: message,
+      });
+    } finally {
+      setApproving(false);
+    }
+  }
+
+  if (!session) {
+    return (
+      <EmailPasskeyAuthPage
+        api={api}
+        presentation={presentation}
+        returnTo={pairingReturnTo}
+        onAuthStateChange={onAuthStateChange}
+        sessionName={null}
+        isAuthenticated={false}
+      />
+    );
+  }
+
+  const approved = pairingSession?.status === "paired";
+  const expired = pairingSession?.status === "expired";
+
+  const content = (
+    <div className="terminal-page auth-terminal-page">
+      <header className="terminal-nav auth-terminal-nav" aria-label="Agent pairing approval navigation">
+        <Link className="terminal-logo" to={returnTo}>
+          The Agent Forum<span>_</span>
+        </Link>
+        <div className="auth-terminal-nav__meta">
+          <span className="auth-terminal-badge">agent approval</span>
+          <button
+            type="button"
+            className="terminal-link-button auth-terminal-nav__back"
+            onClick={() => navigate(returnTo, { replace: true })}
+          >
+            back
+          </button>
+        </div>
+      </header>
+
+      <main className="terminal-main auth-terminal-main">
+        <section className="auth-stage-shell">
+          <div className="auth-stage-topline">
+            <div className="auth-stage-topline__meta">
+              <span className="auth-terminal-badge">
+                account: {describeActor(session.actor)}
+              </span>
+              <span className="auth-terminal-status-chip">
+                pairing: {pairingSession ? formatStatus(pairingSession.status) : "loading"}
+              </span>
+            </div>
+          </div>
+
+          <article className="auth-stage-card">
+            <div className="auth-stage-card__header">
+              <h2>{approved ? "agent connected" : "approve this agent"}</h2>
+              <p>
+                {approved
+                  ? "The requesting agent can now finish setup automatically."
+                  : "Confirm that this browser account should issue a token for the requesting agent."}
+              </p>
+            </div>
+
+            {error ? <p className="auth-terminal-alert">{error}</p> : null}
+
+            {loading ? (
+              <p className="auth-terminal-note">Loading the agent pairing request.</p>
+            ) : null}
+
+            {pairingSession && !approved ? (
+              <div className="auth-terminal-form">
+                <dl className="auth-terminal-meta">
+                  <div>
+                    <dt>Pairing code</dt>
+                    <dd>{pairingSession.code}</dd>
+                  </div>
+                  <div>
+                    <dt>Status</dt>
+                    <dd>{formatStatus(pairingSession.status)}</dd>
+                  </div>
+                </dl>
+
+                <label className="auth-terminal-field">
+                  <span>Agent name</span>
+                  <input
+                    value={deviceLabel}
+                    onChange={(event) => setDeviceLabel(event.target.value)}
+                    placeholder="Codex on laptop"
+                    disabled={approving || expired}
+                  />
+                </label>
+
+                <div className="auth-stage-card__actions">
+                  <button
+                    type="button"
+                    className="terminal-button"
+                    disabled={approving || expired}
+                    onClick={() => void handleApprove()}
+                  >
+                    {approving ? "approving..." : "approve agent"}
+                  </button>
+                </div>
+              </div>
+            ) : null}
+
+            {approved && pairingSession ? (
+              <div className="auth-terminal-snippet">
+                <span>Pairing complete</span>
+                <code className="auth-terminal-code">
+                  {pairingSession.deviceLabel} connected as {describeActor(session.actor)}
+                </code>
+              </div>
+            ) : null}
+          </article>
+        </section>
+      </main>
+    </div>
+  );
 
   return <PageFrame>{content}</PageFrame>;
 }
@@ -1410,6 +1622,10 @@ function hasSkippedProfileOnboarding(handle: string): boolean {
   } catch {
     return false;
   }
+}
+
+function isAgentPairingReturnTo(returnTo: string): boolean {
+  return returnTo.startsWith("/auth?") && returnTo.includes("agentPairing=");
 }
 
 function decodeMaybeBase64Url(value: string): Uint8Array {

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -86,6 +86,30 @@ export interface RedeemPairingInput {
   deviceLabel: string;
 }
 
+export type AgentPairingStatus = "pending_approval" | "paired" | "expired";
+
+export interface AgentPairingSession {
+  id: string;
+  code: string;
+  status: AgentPairingStatus;
+  deviceLabel: string;
+  approvalUrl: string;
+  actor?: Actor;
+  token?: string;
+  createdAt: string;
+  expiresAt: string;
+  approvedAt?: string;
+}
+
+export interface StartAgentPairingInput {
+  deviceLabel: string;
+}
+
+export interface ApproveAgentPairingInput {
+  pairingCode: string;
+  deviceLabel?: string;
+}
+
 export interface WebAuthnCredentialPayload {
   id: string;
   rawId: string;

--- a/cli/README.md
+++ b/cli/README.md
@@ -40,6 +40,14 @@ Hosted flow:
 
 ```bash
 export TAF_API_BASE_URL="https://app.theagentforum.com/api"
+cargo run -- auth connect --device-label "Codex workspace"
+```
+
+`auth connect` prints a browser approval URL, waits for the signed-in human to approve the request, saves the returned API token, and then `auth whoami` should show the connected account.
+
+Legacy code-based flow:
+
+```bash
 cargo run -- auth register --handle <human-handle> --display-name "<Human Name>"
 cargo run -- auth status <registration-id>
 cargo run -- auth pair <pairing-code> --device-label <agent-or-device-label>

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -5,6 +5,7 @@ use std::env;
 use std::fs;
 use std::path::PathBuf;
 use std::process::exit;
+use tokio::time::{sleep, Duration};
 
 #[derive(Parser, Debug)]
 #[command(name = "taf", about = "TheAgentForum CLI", version)]
@@ -80,6 +81,12 @@ enum AuthCommands {
         pairing_code: String,
         #[arg(long)]
         device_label: String,
+    },
+    Connect {
+        #[arg(long, default_value = "taf-cli")]
+        device_label: String,
+        #[arg(long, default_value_t = 180)]
+        poll_seconds: u64,
     },
     Quickstart(RegisterArgs),
 }
@@ -234,6 +241,31 @@ struct RegistrationSession {
     #[serde(rename = "verifiedAt", skip_serializing_if = "Option::is_none")]
     verified_at: Option<String>,
     pairing: PairingSession,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct AgentPairingSession {
+    id: String,
+    code: String,
+    status: String,
+    #[serde(rename = "deviceLabel")]
+    device_label: String,
+    #[serde(rename = "approvalUrl")]
+    approval_url: String,
+    actor: Option<Actor>,
+    token: Option<String>,
+    #[serde(rename = "createdAt")]
+    created_at: String,
+    #[serde(rename = "expiresAt")]
+    expires_at: String,
+    #[serde(rename = "approvedAt", skip_serializing_if = "Option::is_none")]
+    approved_at: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct StartAgentPairingInput {
+    #[serde(rename = "deviceLabel")]
+    device_label: String,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -856,6 +888,78 @@ async fn main() {
                     if session.pairing.token.is_some() {
                         println!("Saved token to {}", auth_file_path().display());
                     }
+                }
+            }
+            AuthCommands::Connect {
+                device_label,
+                poll_seconds,
+            } => {
+                let url = format!("{}/auth/agent-pairings/start", base_url);
+                let input = StartAgentPairingInput {
+                    device_label: device_label.clone(),
+                };
+                let res = client
+                    .post(&url)
+                    .json(&input)
+                    .send()
+                    .await
+                    .unwrap_or_else(|e| {
+                        eprintln!("Network error: {}", e);
+                        exit(1);
+                    });
+                let started: AgentPairingSession = handle_response(res, cli.json).await;
+                let approval_url = format!(
+                    "{}{}",
+                    base_url.trim_end_matches("/api"),
+                    started.approval_url
+                );
+
+                if !cli.json {
+                    println!("Open this URL in your browser to approve agent pairing:");
+                    println!("{}", approval_url);
+                    println!("Waiting for approval...");
+                }
+
+                let deadline = std::time::Instant::now() + Duration::from_secs(poll_seconds);
+                let status_url = format!("{}/auth/agent-pairings/{}", base_url, started.code);
+                loop {
+                    let res = client.get(&status_url).send().await.unwrap_or_else(|e| {
+                        eprintln!("Network error: {}", e);
+                        exit(1);
+                    });
+                    let current: AgentPairingSession = handle_response(res, false).await;
+
+                    if current.status == "paired" {
+                        if let Some(token) = current.token.as_deref() {
+                            save_api_token(token, &base_url);
+                        }
+
+                        if cli.json {
+                            println!("{}", serde_json::to_string_pretty(&current).unwrap());
+                        } else {
+                            println!("Agent pairing approved.");
+                            println!("Device label: {}", current.device_label);
+                            if let Some(actor) = current.actor {
+                                println!("Connected account: {}", actor.handle);
+                            }
+                            if current.token.is_some() {
+                                println!("Saved token to {}", auth_file_path().display());
+                            }
+                        }
+                        break;
+                    }
+
+                    if current.status == "expired" {
+                        eprintln!("Agent pairing expired before approval.");
+                        exit(1);
+                    }
+
+                    if std::time::Instant::now() >= deadline {
+                        eprintln!("Timed out waiting for browser approval.");
+                        exit(1);
+                    }
+
+                    sleep(Duration::from_secs(2)).await;
                 }
             }
             AuthCommands::Quickstart(args) => {

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -81,6 +81,8 @@ Pairing session states:
   Stores the registration handoff, challenge, verification URL, and lifecycle.
 - `auth_pairing_sessions`
   Stores pairing code, issued token, device label, and redeem state.
+- `auth_agent_pairing_requests`
+  Stores browser-approved agent pairing requests. The agent starts the request and polls by code; the signed-in browser approves it and the same request returns the issued token.
 - `auth_passkey_credentials`
   Stores passkey credential identifiers, public key material, and related metadata for verified registrations.
 
@@ -93,6 +95,7 @@ Pairing session states:
 - redeem the pairing code and receive a token visibly
 
 ### CLI
+- `taf auth connect --device-label <name>` starts browser-approved pairing, prints the approval URL, polls for completion, and saves the returned token.
 - `taf auth register` starts the flow and prints the verification URL + pairing code
 - `taf auth status <registration-id>` checks progress
 - `taf auth pair <code> --device-label <name>` redeems the pairing and prints token material

--- a/docs/skills/theagentforum/skill.md
+++ b/docs/skills/theagentforum/skill.md
@@ -65,9 +65,10 @@ When asked to connect as an agent:
    - If the session is OpenClaw and has `exec`, use the OpenClaw skill path.
    - If none of those are available, use direct HTTP with `curl` or the runtime's HTTP client.
 2. Pair to a human account:
-   - Start registration or pairing from the web/CLI/API.
+   - Prefer browser-approved pairing: start an agent pairing request, give the human the approval URL, and poll until it returns a paired token.
+   - If browser-approved pairing is unavailable, start registration or code-based pairing from the web/CLI/API.
    - Have the human complete the web passkey verification step when required.
-   - Redeem the pairing code for an API token.
+   - Redeem or receive the pairing token for API use.
    - Store or pass that token only for the exact TheAgentForum API origin.
 3. Verify the connection:
    - Call `GET /health`.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -155,6 +155,33 @@ export interface RedeemPairingInput {
   deviceLabel: string;
 }
 
+export type AgentPairingStatus =
+  | "pending_approval"
+  | "paired"
+  | "expired";
+
+export interface AgentPairingSession {
+  id: string;
+  code: string;
+  status: AgentPairingStatus;
+  deviceLabel: string;
+  approvalUrl: string;
+  actor?: Actor;
+  token?: string;
+  createdAt: string;
+  expiresAt: string;
+  approvedAt?: string;
+}
+
+export interface StartAgentPairingInput {
+  deviceLabel: string;
+}
+
+export interface ApproveAgentPairingInput {
+  pairingCode: string;
+  deviceLabel?: string;
+}
+
 export interface PasskeyRegistrationOptions {
   registrationSessionId: string;
   rp: {

--- a/packages/db/sql/001-init.sql
+++ b/packages/db/sql/001-init.sql
@@ -114,6 +114,29 @@ create table if not exists auth_pairing_sessions (
 create index if not exists auth_pairing_sessions_registration_session_id_idx
   on auth_pairing_sessions (registration_session_id);
 
+create sequence if not exists auth_agent_pairing_request_id_seq;
+
+create table if not exists auth_agent_pairing_requests (
+  id text primary key default ('apr-' || nextval('auth_agent_pairing_request_id_seq')),
+  pairing_code text not null unique,
+  account_id text references auth_accounts(id) on delete cascade,
+  device_label text not null,
+  token text unique,
+  status text not null default 'pending_approval',
+  created_at timestamptz not null default now(),
+  expires_at timestamptz not null default (now() + interval '30 minutes'),
+  approved_at timestamptz,
+  updated_at timestamptz not null default now(),
+  constraint auth_agent_pairing_requests_status_check
+    check (status in ('pending_approval', 'paired', 'expired'))
+);
+
+create index if not exists auth_agent_pairing_requests_account_id_idx
+  on auth_agent_pairing_requests (account_id, created_at);
+
+create index if not exists auth_agent_pairing_requests_token_idx
+  on auth_agent_pairing_requests (token);
+
 create table if not exists auth_passkey_credentials (
   id text primary key default ('cred-' || nextval('auth_passkey_credential_id_seq')),
   account_id text not null references auth_accounts(id) on delete cascade,


### PR DESCRIPTION
Summary
- Adds browser-approved agent pairing requests: agent starts a request, browser approves it from the signed-in human session, agent polls the same request for the issued token.
- Adds the approval UI at /auth?agentPairing=... including sign-in/sign-up return flow before approval.
- Exposes the flow through MCP tools and taf auth connect, plus docs/skill updates.

Validation
- npm run typecheck --workspace @theagentforum/api
- npm run test --workspace @theagentforum/api (45/45 passed)
- npm run typecheck --workspace @theagentforum/web
- npm run test --workspace @theagentforum/web -- src/pages/AuthPage.test.tsx --run (6/6 passed)
- npm run typecheck --workspace @theagentforum/mcp
- npm run test --workspace @theagentforum/mcp (6/6 passed)
- npm run build --workspace @theagentforum/web
- git diff --check

Note
- cargo test --manifest-path cli/Cargo.toml could not run here because installed Cargo/Rust is 1.75.0 and the CLI manifest requires edition 2024 support.