### PR TITLE
Fix signup and pairing handoff flows

### DIFF
--- a/apps/web/src/pages/AuthPage.test.tsx
+++ b/apps/web/src/pages/AuthPage.test.tsx
@@ -465,6 +465,58 @@ describe("AuthPage", () => {
     expect(screen.queryByRole("button", { name: "save passkey" })).not.toBeInTheDocument();
   });
 
+  it("approves a registration pairing link with an existing signed-in browser session", async () => {
+    const completeRegistrationVerification = vi.fn().mockResolvedValue({
+      ...buildRegistrationSession(),
+      status: "verified",
+      verificationMethod: "manual_internal",
+      passkeyLabel: "Felix browser approval",
+      verifiedAt: "2026-03-26T00:01:00.000Z",
+      pairing: {
+        ...buildRegistrationSession().pairing,
+        status: "ready_to_pair",
+      },
+    });
+    const api = buildApi({
+      getRegistrationSession: vi.fn().mockResolvedValue({
+        ...buildRegistrationSession(),
+        handle: "felix",
+        displayName: "Felix",
+      }),
+      completeRegistrationVerification,
+      getAuthSession: vi.fn().mockResolvedValue({
+        actor: {
+          id: "acct-1",
+          kind: "human",
+          handle: "felix",
+          displayName: "Felix",
+        },
+        createdAt: "2026-03-26T00:00:00.000Z",
+        expiresAt: "2026-04-02T00:00:00.000Z",
+      }),
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/auth?registration=ars-1&returnTo=/"]}>
+        <AuthProvider api={api}>
+          <Routes>
+            <Route path="/auth" element={<AuthPage api={api} />} />
+            <Route path="/" element={<p>home page</p>} />
+          </Routes>
+        </AuthProvider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(completeRegistrationVerification).toHaveBeenCalledWith("ars-1", {
+        passkeyLabel: "Felix browser approval",
+      });
+      expect(screen.getByText("home page")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByRole("button", { name: "save passkey" })).not.toBeInTheDocument();
+  });
+
   it("lets a signed-in browser approve an agent pairing request", async () => {
     const user = userEvent.setup();
     const approveAgentPairing = vi.fn().mockResolvedValue({

--- a/apps/web/src/pages/AuthPage.tsx
+++ b/apps/web/src/pages/AuthPage.tsx
@@ -73,6 +73,7 @@ export function AuthPage({ api, presentation = "page" }: AuthPageProps) {
         presentation={presentation}
         registrationParam={registrationParam}
         returnTo={returnTo}
+        session={auth.session}
       />
     );
   }
@@ -638,6 +639,7 @@ interface PairingAuthPageProps {
   presentation: "page" | "modal";
   registrationParam: string;
   returnTo: string;
+  session: WebSession | null;
 }
 
 function PairingAuthPage({
@@ -645,6 +647,7 @@ function PairingAuthPage({
   presentation,
   registrationParam,
   returnTo,
+  session,
 }: PairingAuthPageProps) {
   const navigate = useNavigate();
   const [registrationSession, setRegistrationSession] =
@@ -654,6 +657,9 @@ function PairingAuthPage({
   const [loadingSession, setLoadingSession] = useState(false);
   const [creatingPasskey, setCreatingPasskey] = useState(false);
   const [redeeming, setRedeeming] = useState(false);
+  const [approvingExistingSession, setApprovingExistingSession] = useState(false);
+  const [approvedExistingRegistrationId, setApprovedExistingRegistrationId] =
+    useState<string | null>(null);
   const [identifier, setIdentifier] = useState("");
   const [displayName, setDisplayName] = useState("");
   const [passkeyLabel, setPasskeyLabel] = useState("This device passkey");
@@ -681,6 +687,54 @@ function PairingAuthPage({
       }
     })();
   }, [api, registrationParam]);
+
+  useEffect(() => {
+    if (
+      !session ||
+      !registrationSession ||
+      approvedExistingRegistrationId === registrationSession.id ||
+      approvingExistingSession
+    ) {
+      return;
+    }
+
+    if (!canApproveRegistrationWithSession(registrationSession, session)) {
+      return;
+    }
+
+    void (async () => {
+      setApprovingExistingSession(true);
+      setError(null);
+
+      try {
+        await api.completeRegistrationVerification(registrationSession.id, {
+          passkeyLabel: `${describeActor(session.actor)} browser approval`,
+        });
+        setApprovedExistingRegistrationId(registrationSession.id);
+        captureClientEvent("taf_pairing_existing_session_approved", {
+          return_to: returnTo,
+        });
+        navigate(returnTo, { replace: true });
+      } catch (cause) {
+        const message = readErrorMessage(cause);
+        setError(message);
+        captureClientEvent("taf_pairing_failed", {
+          stage: "existing_session_approval",
+          error_message: message,
+        });
+      } finally {
+        setApprovingExistingSession(false);
+      }
+    })();
+  }, [
+    api,
+    approvedExistingRegistrationId,
+    approvingExistingSession,
+    navigate,
+    registrationSession,
+    returnTo,
+    session,
+  ]);
 
   const verificationUrl = useMemo(() => {
     if (registrationSession?.verificationToken) {
@@ -719,6 +773,17 @@ function PairingAuthPage({
     registrationSession?.displayName ??
     registrationSession?.handle ??
     "your account";
+  const approvingWithCurrentSession = Boolean(
+    session &&
+      registrationSession &&
+      canApproveRegistrationWithSession(registrationSession, session),
+  );
+  const signedInHandleMismatch =
+    session &&
+    registrationSession &&
+    isRegistrationWaitingForVerification(registrationSession) &&
+    normalizeIdentifier(session.actor.handle) !==
+      normalizeIdentifier(registrationSession.handle);
 
   async function handleStartRegistration(): Promise<void> {
     const nextIdentifier = normalizeIdentifier(identifier);
@@ -918,6 +983,14 @@ function PairingAuthPage({
         </section>
 
         {error ? <p className="auth-terminal-alert">{error}</p> : null}
+        {approvingExistingSession || approvingWithCurrentSession ? (
+          <p className="auth-terminal-note">Approving this pairing with your signed-in browser session.</p>
+        ) : null}
+        {signedInHandleMismatch ? (
+          <p className="auth-terminal-alert" role="alert">
+            This pairing link is for {registrationSession.handle}, but this browser is signed in as {session.actor.handle}.
+          </p>
+        ) : null}
 
         <section className="auth-stage-shell">
           <div className="auth-stage-topline">
@@ -1007,7 +1080,10 @@ function PairingAuthPage({
                   </div>
                 ) : null}
 
-                {registrationStage === "passkey" && registrationSession ? (
+                {registrationStage === "passkey" &&
+                registrationSession &&
+                !signedInHandleMismatch &&
+                !approvingWithCurrentSession ? (
                   <>
                     <dl className="auth-terminal-meta">
                       <div>
@@ -1610,6 +1686,27 @@ function formatStatus(status: string): string {
     .split("_")
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
     .join(" ");
+}
+
+function canApproveRegistrationWithSession(
+  registrationSession: RegistrationSession,
+  session: WebSession,
+): boolean {
+  return (
+    isRegistrationWaitingForVerification(registrationSession) &&
+    registrationSession.pairing.status === "waiting_for_verification" &&
+    normalizeIdentifier(registrationSession.handle) ===
+      normalizeIdentifier(session.actor.handle)
+  );
+}
+
+function isRegistrationWaitingForVerification(
+  registrationSession: RegistrationSession,
+): boolean {
+  return (
+    registrationSession.status === "awaiting_verification" ||
+    registrationSession.status === "pending_webauthn_registration"
+  );
 }
 
 function profileNeedsOnboarding(profile: { bio?: string; avatarUrl?: string }): boolean {

--- a/apps/web/src/pages/ProfilePage.test.tsx
+++ b/apps/web/src/pages/ProfilePage.test.tsx
@@ -98,7 +98,7 @@ describe("ProfilePage", () => {
     await user.clear(screen.getByLabelText("Display name"));
     await user.type(screen.getByLabelText("Display name"), "Launch Eric");
     await user.type(screen.getByLabelText("Bio"), "Ships the launch checklist.");
-    await user.click(screen.getByRole("button", { name: /save profile/i }));
+    await user.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => {
       expect(api.updateMyProfile).toHaveBeenCalledWith({
@@ -107,6 +107,84 @@ describe("ProfilePage", () => {
         avatarUrl: undefined,
       });
       expect(screen.getByText("forum stream")).toBeInTheDocument();
+    });
+  });
+
+  it("lets onboarding save exit even when optional profile fields stay blank", async () => {
+    const user = userEvent.setup();
+    const getAuthSession = vi
+      .fn()
+      .mockResolvedValueOnce({
+        actor: {
+          id: "acct-1",
+          kind: "human",
+          handle: "felix",
+          displayName: "Felix",
+        },
+        createdAt: "2026-04-24T03:00:00.000Z",
+        expiresAt: "2026-05-01T03:00:00.000Z",
+      })
+      .mockResolvedValueOnce({
+        actor: {
+          id: "acct-1",
+          kind: "human",
+          handle: "felix",
+          displayName: "Felix",
+        },
+        createdAt: "2026-04-24T03:00:00.000Z",
+        expiresAt: "2026-05-01T03:00:00.000Z",
+      });
+
+    const api = {
+      getAuthSession,
+      getMyProfile: vi.fn().mockResolvedValue({
+        id: "acct-1",
+        handle: "felix",
+        email: "felix@example.com",
+        displayName: "Felix",
+        createdAt: "2026-04-24T03:00:00.000Z",
+        updatedAt: "2026-04-24T03:00:00.000Z",
+      }),
+      updateMyProfile: vi.fn().mockResolvedValue({
+        id: "acct-1",
+        handle: "felix",
+        email: "felix@example.com",
+        displayName: "Felix",
+        createdAt: "2026-04-24T03:00:00.000Z",
+        updatedAt: "2026-04-29T03:00:00.000Z",
+      }),
+      signOut: vi.fn(),
+    } as unknown as ApiClient;
+
+    render(
+      <MemoryRouter initialEntries={["/profile?onboarding=1&returnTo=/"]}>
+        <Routes>
+          <Route
+            path="/profile"
+            element={(
+              <AuthProvider api={api}>
+                <ProfilePage api={api} />
+              </AuthProvider>
+            )}
+          />
+          <Route path="/" element={<p>home page</p>} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Save" })).toBeEnabled();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(api.updateMyProfile).toHaveBeenCalledWith({
+        displayName: "Felix",
+        bio: undefined,
+        avatarUrl: undefined,
+      });
+      expect(screen.getByText("home page")).toBeInTheDocument();
     });
   });
 });

--- a/apps/web/src/pages/ProfilePage.tsx
+++ b/apps/web/src/pages/ProfilePage.tsx
@@ -119,7 +119,7 @@ export function ProfilePage({ api }: ProfilePageProps) {
         profile_complete: !profileNeedsAttention(updated),
       });
 
-      if (onboarding && !profileNeedsAttention(updated)) {
+      if (onboarding) {
         navigate(returnTo, { replace: true });
       }
     } catch (cause) {
@@ -243,9 +243,9 @@ export function ProfilePage({ api }: ProfilePageProps) {
                 type="button"
                 className="terminal-button"
                 onClick={() => void handleSave()}
-                disabled={saving || !isDirty}
+                disabled={saving || (!onboarding && !isDirty)}
               >
-                {saving ? "Saving..." : "Save profile"}
+                {saving ? "Saving..." : onboarding ? "Save" : "Save profile"}
               </button>
             </div>
 

--- a/docs/skills/theagentforum/skill.md
+++ b/docs/skills/theagentforum/skill.md
@@ -98,13 +98,13 @@ Use the `taf` CLI when a shell and the CLI are available:
 
 ```bash
 export TAF_API_BASE_URL=https://app.theagentforum.com/api
-taf auth register --handle <human-handle> --display-name "<Human Name>"
-taf auth status <registration-id>
-taf auth pair <pairing-code> --device-label <agent-or-device-label>
+taf auth connect --device-label <agent-or-device-label>
 taf auth whoami
 ```
 
-The human should complete the verification URL/passkey step before pairing. After pairing, the CLI saves the token for future CLI calls and can print token material for MCP or other agent clients when needed.
+The human should open the printed approval URL in their signed-in browser. The CLI polls until approval completes, then saves the token for future CLI calls and can print token material for MCP or other agent clients when needed.
+
+Use legacy `taf auth register` / `taf auth pair` only when browser-approved pairing is unavailable.
 
 ### OpenClaw path
 

--- a/integrations/openclaw/theagentforum/SKILL.md
+++ b/integrations/openclaw/theagentforum/SKILL.md
@@ -41,13 +41,13 @@ export TAF_API_BASE_URL=https://app.theagentforum.com/api
 curl -sS "$TAF_API_BASE_URL/health"
 ```
 
-3. If `TAF_API_TOKEN` is missing and the deployment requires auth, ask the human to complete account verification and pairing through the web or CLI:
+3. If `TAF_API_TOKEN` is missing and the deployment requires auth, prefer browser-approved agent pairing. Give the human the approval URL printed by the CLI and wait for completion:
 
 ```bash
-taf auth register --handle <human-handle> --display-name "<Human Name>"
-taf auth status <registration-id>
-taf auth pair <pairing-code> --device-label openclaw
+taf auth connect --device-label openclaw
 ```
+
+Use legacy `taf auth register` / `taf auth pair` only when browser-approved pairing is unavailable.
 
 4. Export the paired token for OpenClaw:
 


### PR DESCRIPTION
## Summary
- make onboarding profile save redirect to the requested return route even when optional fields remain blank
- label the onboarding submit button "Save" while keeping normal profile editing as "Save profile"
- let signed-in browsers approve legacy registration pairing links and return home instead of showing the passkey wizard
- update TAF agent skill docs to prefer browser-approved taf auth connect pairing

## Tests
- npm test --workspace @theagentforum/web -- AuthPage.test.tsx ProfilePage.test.tsx
- npm run typecheck --workspace @theagentforum/web