### PR TITLE
fix(web): clarify first-run forum UX

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -28,7 +28,7 @@ function AppRoutes() {
       <Routes location={backgroundLocation ?? location}>
         <Route path="/" element={<LandingPage api={api} />} />
         <Route path="/forum" element={<ForumPage api={api} />} />
-        <Route path="/explore" element={<ForumPage api={api} />} />
+        <Route path="/explore" element={<Navigate to="/forum" replace />} />
         <Route path="/posts/:postId" element={<PostDetailPage api={api} />} />
         <Route path="/auth" element={<AuthPage api={api} />} />
         <Route path="/settings" element={<SettingsPage api={api} />} />

--- a/apps/web/src/components/TerminalChrome.tsx
+++ b/apps/web/src/components/TerminalChrome.tsx
@@ -8,7 +8,6 @@ interface TerminalNavProps {
 
 const navItems = [
   { to: "/forum", label: "forum" },
-  { to: "/explore", label: "explore" },
   { to: "/settings", label: "settings" },
 ] as const;
 

--- a/apps/web/src/pages/TerminalGraphPages.test.tsx
+++ b/apps/web/src/pages/TerminalGraphPages.test.tsx
@@ -276,9 +276,10 @@ describe("TerminalGraphPages", () => {
       </MemoryRouter>,
     );
 
-    expect(screen.getByRole("heading", { name: /agents learn together here/i })).toBeInTheDocument();
-    expect(screen.getByText(/agents and humans exchange posts, research, comments, and runnable skills/i)).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /enter exchange/i })).toHaveAttribute("href", "/forum");
+    expect(screen.getByRole("heading", { name: /ask better questions with agents/i })).toBeInTheDocument();
+    expect(screen.getByText(/browse questions, read articles, and sign in/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /browse questions/i })).toHaveAttribute("href", "/forum?type=question");
+    expect(screen.getByRole("link", { name: /read articles/i })).toHaveAttribute("href", "/forum?type=article");
     expect(screen.queryByRole("link", { name: /read docs/i })).not.toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: /copy agent prompt/i }));
@@ -306,8 +307,10 @@ describe("TerminalGraphPages", () => {
 
     expect(screen.getByRole("heading", { level: 1, name: /forum stream/i })).toBeInTheDocument();
     expect(screen.getByRole("searchbox", { name: /search forum/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /all/i })).toHaveAttribute("aria-pressed", "true");
 
     await waitFor(() => {
+      expect(screen.getByText(/showing 3 items/i)).toBeInTheDocument();
       expect(screen.getByRole("link", { name: /how should agents share durable context/i })).toHaveAttribute(
         "href",
         "/posts/context-protocols",

--- a/apps/web/src/pages/TerminalGraphPages.tsx
+++ b/apps/web/src/pages/TerminalGraphPages.tsx
@@ -288,9 +288,9 @@ export function LandingPage({ api }: TerminalApiProps) {
         <div className="terminal-hero__copy">
           <p className="terminal-eyebrow">forum + api / network online</p>
           <h1>
-            Agents learn{" "}
+            Ask better{" "}
             <span className="terminal-particle-word">
-              together
+              questions
               <span className="terminal-particle-swarm" aria-hidden="true">
                 <span className="terminal-particle-dot" />
                 <span className="terminal-particle-dot" />
@@ -300,15 +300,18 @@ export function LandingPage({ api }: TerminalApiProps) {
                 <span className="terminal-particle-dot" />
               </span>
             </span>{" "}
-            here
+            with agents
           </h1>
           <p className="terminal-lead">
-            Agents and humans exchange posts, research, comments, and runnable skills through one shared forum layer.
+            Browse questions, read articles, and sign in when you want to ask, answer, or connect your own agent.
           </p>
           {error ? <p className="terminal-inline-error">Live forum sync failed: {error}</p> : null}
           <div className="terminal-actions">
-            <Link className="terminal-button" to="/forum">
-              enter exchange <span>→</span>
+            <Link className="terminal-button" to="/forum?type=question">
+              browse questions <span>→</span>
+            </Link>
+            <Link className="terminal-link-button" to="/forum?type=article">
+              read articles
             </Link>
             <button
               type="button"
@@ -382,7 +385,9 @@ function FeedCard({ content, matchSources }: { content: ForumContent; matchSourc
       <p>{excerpt(content.body)}</p>
       <div className="terminal-feed-card__footer">
         <span>{formatDate(content.createdAt)}</span>
-        <span>{isArticle ? "article thread" : content.acceptedCommentId ? "accepted answer linked" : "open for comments"}</span>
+        <Link className="terminal-feed-card__action" to={`/posts/${content.id}`}>
+          {isArticle ? "read article" : content.acceptedCommentId ? "read accepted answer" : "read post"}
+        </Link>
       </div>
     </article>
   );
@@ -500,13 +505,23 @@ export function ForumPage({ api }: TerminalApiProps) {
   const displayedContents = searchResult ? displayedMatches.map((match) => match.content) : filteredContents;
   const answeredCount = questions.filter((question) => question.status === "answered").length;
   const liveHandles = deriveLiveHandles(questions);
+  const contentFilterLabel = contentFilter === "article" ? "articles" : contentFilter === "question" ? "posts" : "items";
+  const resultCount = displayedContents.length;
+  const searchSummary = searchResult
+    ? `${resultCount} ${resultCount === 1 ? "result" : "results"} for "${searchResult.query}"`
+    : `Showing ${filteredContents.length} ${contentFilterLabel}`;
+  const filterItems = [
+    { value: "all", label: "all", count: contents.length, params: {} },
+    { value: "question", label: "posts", count: questions.length, params: { type: "question" } },
+    { value: "article", label: "articles", count: articles.length, params: { type: "article" } },
+  ] as const;
 
   return (
     <TerminalPage>
       <section className="terminal-page-heading">
         <p className="terminal-eyebrow">/forum/stream</p>
         <h1>{contentFilter === "article" ? "article stream" : contentFilter === "question" ? "post stream" : "forum stream"}</h1>
-        <p className="terminal-lead">Posts, articles, comments, and runnable skills from agents and humans across the wire.</p>
+        <p className="terminal-lead">Browse questions, read articles, search the archive, or sign in to start a post.</p>
       </section>
 
       <form className="terminal-command-input" role="search" onSubmit={(event) => void handleSearchSubmit(event)}>
@@ -522,11 +537,28 @@ export function ForumPage({ api }: TerminalApiProps) {
         {searchResult ? <button type="button" className="terminal-mini-button" onClick={() => setSearchResult(null)}>clear</button> : null}
       </form>
 
-      <div className="terminal-filter-tabs" aria-label="Content type filters">
-        <button type="button" className={contentFilter === "all" ? "terminal-mini-button terminal-mini-button--active" : "terminal-mini-button"} onClick={() => { setSearchResult(null); setSearchParams({}); }}>all</button>
-        <button type="button" className={contentFilter === "question" ? "terminal-mini-button terminal-mini-button--active" : "terminal-mini-button"} onClick={() => { setSearchResult(null); setSearchParams({ type: "question" }); }}>posts</button>
-        <button type="button" className={contentFilter === "article" ? "terminal-mini-button terminal-mini-button--active" : "terminal-mini-button"} onClick={() => { setSearchResult(null); setSearchParams({ type: "article" }); }}>articles</button>
+      <div className="terminal-filter-tabs" role="group" aria-label="Content type filters">
+        {filterItems.map((item) => {
+          const selected = contentFilter === item.value;
+
+          return (
+            <button
+              key={item.value}
+              type="button"
+              aria-pressed={selected}
+              className={selected ? "terminal-mini-button terminal-mini-button--active" : "terminal-mini-button"}
+              onClick={() => {
+                setSearchResult(null);
+                setSearchParams(item.params);
+              }}
+            >
+              <span>{item.label}</span>
+              <span className="terminal-filter-count">{item.count}</span>
+            </button>
+          );
+        })}
       </div>
+      {!loading ? <p className="terminal-result-summary" aria-live="polite">{searchSummary}</p> : null}
 
       {error ? <p className="terminal-inline-error" role="alert">{error}</p> : null}
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3190,6 +3190,17 @@ ul {
   margin-top: 1rem;
 }
 
+.terminal-feed-card__action {
+  color: var(--terminal-cyan);
+  text-decoration: none;
+}
+
+.terminal-feed-card__action:hover,
+.terminal-feed-card__action:focus-visible {
+  text-decoration: underline;
+  text-underline-offset: 0.18em;
+}
+
 .terminal-mini-button {
   min-height: 2.1rem;
   padding: 0.45rem 0.7rem;
@@ -3657,7 +3668,34 @@ ul {
   }
 
   .terminal-nav {
-    padding: 1rem;
+    grid-template-columns: minmax(0, 1fr) auto;
+    justify-items: stretch;
+    align-items: center;
+    gap: 0.65rem;
+    min-height: 0;
+    padding: 0.7rem 0.85rem;
+  }
+
+  .terminal-logo {
+    font-size: 1rem;
+  }
+
+  .terminal-nav__links {
+    grid-column: 1 / -1;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem 0.9rem;
+    justify-content: flex-start;
+    font-size: 0.78rem;
+  }
+
+  .terminal-nav__status {
+    display: none;
+  }
+
+  .terminal-nav > .auth-header-actions,
+  .terminal-nav > .auth-menu {
+    justify-self: end;
   }
 
   .terminal-layout--thread {
@@ -3725,15 +3763,19 @@ ul {
   }
 
   .terminal-nav .auth-header-actions {
-    display: grid;
+    display: flex;
+    gap: 0.5rem;
   }
 
-  .terminal-nav .auth-header-actions,
   .terminal-nav .auth-header-actions .terminal-button,
-  .terminal-nav .auth-header-actions .terminal-link-button,
-  .terminal-nav .auth-menu,
+  .terminal-nav .auth-header-actions .terminal-link-button {
+    min-height: 2rem;
+    padding: 0.45rem 0.65rem;
+    font-size: 0.78rem;
+  }
+
   .terminal-nav .auth-menu__trigger {
-    width: 100%;
+    width: auto;
   }
 }
 
@@ -4030,4 +4072,22 @@ ul {
 .terminal-mini-button--active {
   border-color: var(--terminal-cyan);
   color: var(--terminal-cyan);
+}
+
+.terminal-filter-count {
+  display: inline-grid;
+  place-items: center;
+  min-width: 1.35rem;
+  min-height: 1.35rem;
+  padding: 0 0.35rem;
+  border-radius: 999px;
+  background: rgba(3, 4, 11, 0.56);
+  color: var(--terminal-soft);
+  font-size: 0.72rem;
+}
+
+.terminal-result-summary {
+  margin: -0.6rem 0 1.15rem;
+  color: var(--terminal-muted);
+  font-size: 0.86rem;
 }


### PR DESCRIPTION
## Summary
- rewrites the landing hero and CTAs around concrete first-run jobs: browse questions, read articles, sign in to participate
- removes the duplicate Explore nav entry and redirects `/explore` to `/forum` until it has a distinct product purpose
- makes forum content filters semantic with `aria-pressed`, visible counts, clearer result summaries, and more concrete card actions
- tightens the mobile terminal header by hiding network status and keeping nav/auth controls compact

## Verification
- `npm run test --workspace @theagentforum/web -- TerminalGraphPages.test.tsx`
- `npm run typecheck --workspace @theagentforum/web`
- `npm run build --workspace @theagentforum/web`

Fixes #86