### PR TITLE
fix(web): simplify forum stream and add article toc

### DIFF
--- a/apps/web/src/components/MarkdownContent.tsx
+++ b/apps/web/src/components/MarkdownContent.tsx
@@ -1,15 +1,67 @@
+import { Children, isValidElement, type ReactNode } from "react";
 import ReactMarkdown from "react-markdown";
+import type { Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 
 interface MarkdownContentProps {
   content: string;
   className?: string;
+  withHeadingIds?: boolean;
 }
 
-export function MarkdownContent({ content, className }: MarkdownContentProps) {
+export function getMarkdownHeadingId(value: string): string {
+  const slug = value
+    .toLowerCase()
+    .replace(/[`*_~[\]()]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+  return slug || "section";
+}
+
+function getNodeText(node: ReactNode): string {
+  if (typeof node === "string" || typeof node === "number") {
+    return String(node);
+  }
+
+  if (Array.isArray(node)) {
+    return node.map(getNodeText).join("");
+  }
+
+  if (isValidElement<{ children?: ReactNode }>(node)) {
+    return getNodeText(node.props.children);
+  }
+
+  return "";
+}
+
+const headingComponents: Components = {
+  h1({ node: _node, children, ...props }) {
+    return <h1 id={getMarkdownHeadingId(getNodeText(children))} {...props}>{children}</h1>;
+  },
+  h2({ node: _node, children, ...props }) {
+    return <h2 id={getMarkdownHeadingId(getNodeText(children))} {...props}>{children}</h2>;
+  },
+  h3({ node: _node, children, ...props }) {
+    return <h3 id={getMarkdownHeadingId(getNodeText(children))} {...props}>{children}</h3>;
+  },
+  h4({ node: _node, children, ...props }) {
+    return <h4 id={getMarkdownHeadingId(getNodeText(children))} {...props}>{children}</h4>;
+  },
+  h5({ node: _node, children, ...props }) {
+    return <h5 id={getMarkdownHeadingId(getNodeText(children))} {...props}>{children}</h5>;
+  },
+  h6({ node: _node, children, ...props }) {
+    return <h6 id={getMarkdownHeadingId(getNodeText(children))} {...props}>{children}</h6>;
+  },
+};
+
+export function MarkdownContent({ content, className, withHeadingIds = false }: MarkdownContentProps) {
   return (
     <div className={className}>
-      <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+      <ReactMarkdown components={withHeadingIds ? headingComponents : undefined} remarkPlugins={[remarkGfm]}>
+        {content}
+      </ReactMarkdown>
     </div>
   );
 }

--- a/apps/web/src/pages/TerminalGraphPages.test.tsx
+++ b/apps/web/src/pages/TerminalGraphPages.test.tsx
@@ -305,7 +305,7 @@ describe("TerminalGraphPages", () => {
       </MemoryRouter>,
     );
 
-    expect(screen.getByRole("heading", { level: 1, name: /forum stream/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 1, name: /^forum$/i })).toBeInTheDocument();
     expect(screen.getByRole("searchbox", { name: /search forum/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /all/i })).toHaveAttribute("aria-pressed", "true");
 
@@ -351,7 +351,7 @@ describe("TerminalGraphPages", () => {
       question: {
         id: "art-1",
         title: "Reusable context report",
-        body: "Long-form article content for durable context.",
+        body: "Abstract\n\nShort summary.\n\nIntroduction\n\nContext setup.\n\n## Results\n\nUseful findings.\n\nConclusion\n\nFinal note.\n\nReferences\n\n- Source",
         status: "open",
         createdAt: "2026-04-25T03:00:00.000Z",
         author: questions[0].author,
@@ -374,6 +374,13 @@ describe("TerminalGraphPages", () => {
       expect(within(breadcrumb).getByRole("link", { name: "forum" })).toHaveAttribute("href", "/forum");
       expect(within(breadcrumb).getByRole("link", { name: "articles" })).toHaveAttribute("href", "/forum?type=article");
       expect(within(breadcrumb).getByText("art-1")).toHaveAttribute("aria-current", "page");
+      const toc = screen.getByRole("complementary", { name: /article table of contents/i });
+      expect(within(toc).getByRole("link", { name: "Abstract" })).toHaveAttribute("href", "#abstract");
+      expect(within(toc).getByRole("link", { name: "Introduction" })).toHaveAttribute("href", "#introduction");
+      expect(within(toc).getByRole("link", { name: "Results" })).toHaveAttribute("href", "#results");
+      expect(within(toc).getByRole("link", { name: "Conclusion" })).toHaveAttribute("href", "#conclusion");
+      expect(within(toc).getByRole("link", { name: "References" })).toHaveAttribute("href", "#references");
+      expect(screen.getByRole("heading", { name: "Abstract" })).toHaveAttribute("id", "abstract");
     });
   });
 

--- a/apps/web/src/pages/TerminalGraphPages.tsx
+++ b/apps/web/src/pages/TerminalGraphPages.tsx
@@ -8,7 +8,7 @@ import type { ApiClient, ForumContent, ForumSearchResult } from "../lib/api";
 import { useAuthNavigation } from "../lib/auth-routing";
 import type { Answer, AnswerSkill, Question, QuestionThread } from "../types";
 import { AnswerForm, type AnswerFormValues } from "../components/AnswerForm";
-import { MarkdownContent } from "../components/MarkdownContent";
+import { getMarkdownHeadingId, MarkdownContent } from "../components/MarkdownContent";
 import { captureClientEvent } from "../lib/posthog";
 import { describeActor, formatDate, readErrorMessage } from "../lib/ui";
 
@@ -127,26 +127,83 @@ function formatSkillType(skill: AnswerSkill): string {
   return "inline artifact";
 }
 
-function deriveLiveHandles(questions: Question[]): Array<{ handle: string; kind: string }> {
-  const seen = new Set<string>();
-  const handles: Array<{ handle: string; kind: string }> = [];
+interface ArticleTocEntry {
+  id: string;
+  label: string;
+  level: number;
+}
 
-  for (const question of questions) {
-    const handle = displayActor(question.author);
-    const key = `${question.author.kind}:${handle}`;
-    if (seen.has(key)) {
+const paperSectionTitles = new Map([
+  ["abstract", "Abstract"],
+  ["introduction", "Introduction"],
+  ["intro", "Introduction"],
+  ["background", "Background"],
+  ["method", "Methods"],
+  ["methods", "Methods"],
+  ["methodology", "Methods"],
+  ["results", "Results"],
+  ["findings", "Results"],
+  ["discussion", "Discussion"],
+  ["conclusion", "Conclusion"],
+  ["conclusions", "Conclusion"],
+  ["references", "References"],
+  ["bibliography", "References"],
+]);
+
+function normalizeArticleMarkdown(value: string): string {
+  return value
+    .split("\n")
+    .map((line) => {
+      const trimmed = line.trim();
+      const sectionMatch = trimmed.match(/^([A-Za-z][A-Za-z\s]{1,32}):?$/);
+
+      if (!sectionMatch || trimmed.startsWith("#")) {
+        return line;
+      }
+
+      const canonicalTitle = paperSectionTitles.get(sectionMatch[1].trim().toLowerCase());
+      return canonicalTitle ? `## ${canonicalTitle}` : line;
+    })
+    .join("\n");
+}
+
+function stripInlineMarkdown(value: string): string {
+  return value
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/\[([^\]]+)]\([^)]+\)/g, "$1")
+    .replace(/[*_~]/g, "")
+    .trim();
+}
+
+function extractArticleToc(markdown: string, title: string): ArticleTocEntry[] {
+  const titleKey = title.trim().toLowerCase();
+  const seen = new Set<string>();
+  const entries: ArticleTocEntry[] = [];
+
+  for (const line of markdown.split("\n")) {
+    const headingMatch = line.match(/^(#{1,3})\s+(.+?)\s*#*\s*$/);
+
+    if (!headingMatch) {
       continue;
     }
 
-    seen.add(key);
-    handles.push({ handle, kind: question.author.kind });
+    const label = stripInlineMarkdown(headingMatch[2]);
+
+    if (!label || label.toLowerCase() === titleKey) {
+      continue;
+    }
+
+    const id = getMarkdownHeadingId(label);
+
+    if (seen.has(id)) {
+      continue;
+    }
+
+    seen.add(id);
+    entries.push({ id, label, level: headingMatch[1].length });
   }
 
-  if (handles.length > 0) {
-    return handles.slice(0, 5);
-  }
-
-  return fallbackHandleNodes.map((node) => ({ handle: node.handle, kind: node.kind }));
+  return entries;
 }
 
 function TerminalExchangePanel({ questionCount, answeredCount, articleCount }: { questionCount: number; answeredCount: number; articleCount: number }) {
@@ -504,7 +561,6 @@ export function ForumPage({ api }: TerminalApiProps) {
   const filteredContents = contentFilter === "all" ? contents : contents.filter((content) => content.type === contentFilter);
   const displayedContents = searchResult ? displayedMatches.map((match) => match.content) : filteredContents;
   const answeredCount = questions.filter((question) => question.status === "answered").length;
-  const liveHandles = deriveLiveHandles(questions);
   const contentFilterLabel = contentFilter === "article" ? "articles" : contentFilter === "question" ? "posts" : "items";
   const resultCount = displayedContents.length;
   const searchSummary = searchResult
@@ -519,8 +575,8 @@ export function ForumPage({ api }: TerminalApiProps) {
   return (
     <TerminalPage>
       <section className="terminal-page-heading">
-        <p className="terminal-eyebrow">/forum/stream</p>
-        <h1>{contentFilter === "article" ? "article stream" : contentFilter === "question" ? "post stream" : "forum stream"}</h1>
+        <p className="terminal-eyebrow">/forum</p>
+        <h1>{contentFilter === "article" ? "articles" : contentFilter === "question" ? "posts" : "forum"}</h1>
         <p className="terminal-lead">Browse questions, read articles, search the archive, or sign in to start a post.</p>
       </section>
 
@@ -611,18 +667,6 @@ export function ForumPage({ api }: TerminalApiProps) {
           </section>
 
           <section className="terminal-side-card">
-            <h2>live handles</h2>
-            <ul className="terminal-handle-list">
-              {liveHandles.map((handle) => (
-                <li key={`${handle.kind}:${handle.handle}`}>
-                  <span>{handle.handle}</span>
-                  <KindBadge kind={handle.kind} />
-                </li>
-              ))}
-            </ul>
-          </section>
-
-          <section className="terminal-side-card">
             <h2>content types</h2>
             <dl className="terminal-counter-list">
               <div><dt><Link to="/forum?type=question">posts</Link></dt><dd><Link to="/forum?type=question">{questions.length}</Link></dd></div>
@@ -632,12 +676,6 @@ export function ForumPage({ api }: TerminalApiProps) {
             </dl>
           </section>
 
-          <section className="terminal-side-card terminal-pulse-card">
-            <h2>api pulse</h2>
-            <code>{contentFilter === "all" ? "GET /api/v2/contents" : `GET /api/v2/contents?type=${contentFilter}`}</code>
-            <p><span className="terminal-status-dot" /> {error ? "degraded" : loading ? "syncing" : "healthy"}</p>
-            <button type="button" className="terminal-mini-button" onClick={() => void refreshQuestions()} disabled={loading}>refresh</button>
-          </section>
         </aside>
       </div>
     </TerminalPage>
@@ -694,6 +732,27 @@ function AnswerSkillPanel({ skills }: { skills: AnswerSkill[] }) {
         ))}
       </ul>
     </section>
+  );
+}
+
+function ArticleTableOfContents({ entries }: { entries: ArticleTocEntry[] }) {
+  return (
+    <aside className="terminal-side-stack terminal-article-toc" aria-label="Article table of contents">
+      <section className="terminal-side-card">
+        <h2>contents</h2>
+        {entries.length > 0 ? (
+          <ol className="terminal-toc-list">
+            {entries.map((entry) => (
+              <li key={entry.id} className={`terminal-toc-list__item terminal-toc-list__item--level-${entry.level}`}>
+                <a href={`#${entry.id}`}>{entry.label}</a>
+              </li>
+            ))}
+          </ol>
+        ) : (
+          <p className="terminal-side-card__note">No section headings yet.</p>
+        )}
+      </section>
+    </aside>
   );
 }
 
@@ -813,6 +872,8 @@ export function PostDetailPage({ api }: PostDetailPageProps) {
   const isArticle = resolvedId?.startsWith("art-") ?? false;
   const contentListPath = isArticle ? "/forum?type=article" : "/forum?type=question";
   const contentListLabel = isArticle ? "articles" : "posts";
+  const articleMarkdown = thread && isArticle ? normalizeArticleMarkdown(thread.question.body) : thread?.question.body ?? "";
+  const articleTocEntries = thread && isArticle ? extractArticleToc(articleMarkdown, thread.question.title) : [];
 
   return (
     <TerminalPage>
@@ -828,7 +889,8 @@ export function PostDetailPage({ api }: PostDetailPageProps) {
       {loading ? <p className="terminal-feed-card">Loading live post from the forum API…</p> : null}
 
       {!loading && thread ? (
-        <div className="terminal-layout terminal-layout--thread">
+        <div className={`terminal-layout terminal-layout--thread${isArticle ? " terminal-layout--article" : ""}`}>
+          {isArticle ? <ArticleTableOfContents entries={articleTocEntries} /> : null}
           <article className="terminal-thread-main">
             <div className="terminal-feed-card__meta">
               <span className="terminal-type-badge">{resolvedId?.startsWith("art-") ? "article" : "post"}</span>
@@ -839,7 +901,11 @@ export function PostDetailPage({ api }: PostDetailPageProps) {
               <span>{skillCount} runnable skills linked</span>
             </div>
             <h1>{thread.question.title}</h1>
-            <MarkdownContent className="markdown-content terminal-markdown terminal-thread-body" content={thread.question.body} />
+            <MarkdownContent
+              className="markdown-content terminal-markdown terminal-thread-body"
+              content={isArticle ? articleMarkdown : thread.question.body}
+              withHeadingIds={isArticle}
+            />
 
             <section className="terminal-comment-stack" aria-label="Thread comments">
               {thread.answers.length === 0 ? (
@@ -848,7 +914,7 @@ export function PostDetailPage({ api }: PostDetailPageProps) {
                     <span className="terminal-type-badge">empty</span>
                     <span>no comments yet</span>
                   </div>
-                  <p>This post is live, but nobody has left a trace on it yet.</p>
+                  <p>This {isArticle ? "article" : "post"} is live, but nobody has left a trace on it yet.</p>
                 </article>
               ) : null}
 
@@ -908,7 +974,7 @@ export function PostDetailPage({ api }: PostDetailPageProps) {
             )}
           </article>
 
-          <aside className="terminal-side-stack" aria-label="Thread metadata">
+          {!isArticle ? <aside className="terminal-side-stack" aria-label="Thread metadata">
             <section className="terminal-side-card">
               <h2>thread graph</h2>
               <ThreadGraph answerCount={thread.answers.length} skillCount={skillCount} status={thread.question.status} />
@@ -926,9 +992,9 @@ export function PostDetailPage({ api }: PostDetailPageProps) {
             <section className="terminal-side-card terminal-followup-card">
               <h2>ask follow-up</h2>
               <p>Fork this post into a new question or turn the accepted pattern into a skill.</p>
-              <Link className="terminal-button terminal-button--full" to="/forum">back to stream</Link>
+              <Link className="terminal-button terminal-button--full" to="/forum">back to forum</Link>
             </section>
-          </aside>
+          </aside> : null}
         </div>
       ) : null}
     </TerminalPage>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3034,6 +3034,45 @@ ul {
   grid-template-columns: minmax(0, 1fr) 20rem;
 }
 
+.terminal-layout--article {
+  grid-template-columns: minmax(12rem, 16rem) minmax(0, 1fr);
+}
+
+.terminal-article-toc {
+  position: sticky;
+  top: 1rem;
+}
+
+.terminal-toc-list {
+  display: grid;
+  gap: 0.55rem;
+  margin: 0.85rem 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.terminal-toc-list__item {
+  font-size: 0.86rem;
+  line-height: 1.35;
+}
+
+.terminal-toc-list__item--level-3 {
+  padding-left: 0.85rem;
+  font-size: 0.8rem;
+}
+
+.terminal-toc-list a {
+  color: var(--terminal-muted);
+  text-decoration: none;
+}
+
+.terminal-toc-list a:hover,
+.terminal-toc-list a:focus-visible {
+  color: var(--terminal-cyan);
+  text-decoration: underline;
+  text-underline-offset: 0.18em;
+}
+
 .terminal-command-input {
   display: grid;
   grid-template-columns: auto minmax(0, 1fr) auto;
@@ -3133,6 +3172,7 @@ ul {
 
 .terminal-feed-card p,
 .terminal-side-card p,
+.terminal-side-card__note,
 .terminal-thread-body,
 .terminal-comment-card p,
 .terminal-artifact-list {
@@ -3622,8 +3662,13 @@ ul {
 
   .terminal-hero--home,
   .terminal-layout--feed,
-  .terminal-layout--thread {
+  .terminal-layout--thread,
+  .terminal-layout--article {
     grid-template-columns: 1fr;
+  }
+
+  .terminal-article-toc {
+    position: static;
   }
 
   .terminal-hero__graph {


### PR DESCRIPTION
## Summary
- renames stream headings to plain `forum`, `articles`, and `posts`
- removes the forum `live handles` and `api pulse` side cards
- adds article table-of-contents support in a left rail
- normalizes paper-style section labels such as Abstract, Introduction, Results, Conclusion, and References into anchored article sections

## Verification
- `npm run test --workspace @theagentforum/web -- TerminalGraphPages.test.tsx MarkdownContent.test.tsx`
- `npm run typecheck --workspace @theagentforum/web`
- `npm run build --workspace @theagentforum/web`