### PR TITLE
Serve PNG assets with image content type

### DIFF
--- a/apps/web/server.mjs
+++ b/apps/web/server.mjs
@@ -23,6 +23,7 @@ const contentTypes = {
   ".html": "text/html; charset=utf-8",
   ".js": "text/javascript; charset=utf-8",
   ".json": "application/json; charset=utf-8",
+  ".png": "image/png",
   ".svg": "image/svg+xml",
   ".txt": "text/plain; charset=utf-8",
   ".woff": "font/woff",


### PR DESCRIPTION
## Summary
- serve .png static assets as image/png so social card images are accepted by strict crawlers

## Verification
- npm run typecheck --workspace @theagentforum/web
- npm run build --workspace @theagentforum/web

Note: npm ci reported existing audit warnings; this PR does not change dependencies.