### PR TITLE
Version social card image URL

### DIFF
--- a/apps/web/server.mjs
+++ b/apps/web/server.mjs
@@ -7,7 +7,7 @@ import { pathToFileURL } from "node:url";
 import { createProxyHeaders } from "./src/lib/proxy-headers.js";
 
 export const DEFAULT_SITE_URL = "https://app.theagentforum.com";
-const SOCIAL_CARD_IMAGE_PATH = "/social-card.png";
+const SOCIAL_CARD_IMAGE_PATH = "/social-card.png?v=20260613";
 
 const port = Number(process.env.PORT ?? 5173);
 const defaultApiProxyTarget = process.env.API_PROXY_TARGET ?? "http://127.0.0.1:3001";

--- a/apps/web/src/pages/TerminalGraphPages.test.tsx
+++ b/apps/web/src/pages/TerminalGraphPages.test.tsx
@@ -309,12 +309,12 @@ describe("TerminalGraphPages", () => {
     expect(html).toContain('<link rel="canonical" href="https://app.example.test/posts/context-protocols">');
     expect(html).toContain('<meta property="og:title" content="How should agents share durable context?">');
     expect(html).toContain('<meta property="og:description" content="By @syntax-fox (@syntax-fox): Looking for patterns that survive across sessions, tools, and runtimes.">');
-    expect(html).toContain('<meta property="og:image" content="https://app.example.test/social-card.png">');
+    expect(html).toContain('<meta property="og:image" content="https://app.example.test/social-card.png?v=20260613">');
     expect(html).toContain('<meta property="og:image:width" content="1200">');
     expect(html).toContain('<meta property="og:image:height" content="630">');
     expect(html).toContain('<meta property="article:author" content="@syntax-fox (@syntax-fox)">');
     expect(html).toContain('<meta name="twitter:card" content="summary_large_image">');
-    expect(html).toContain('<meta name="twitter:image" content="https://app.example.test/social-card.png">');
+    expect(html).toContain('<meta name="twitter:image" content="https://app.example.test/social-card.png?v=20260613">');
     expect(html).toContain('<meta name="twitter:data2" content="Post">');
     expect(html).toContain('<div id="root"></div>');
   });


### PR DESCRIPTION
## Summary
- add a version query to the social-card image URL used in Open Graph/Twitter metadata so crawlers bypass stale edge-cached headers

## Verification
- npm run test --workspace @theagentforum/web -- TerminalGraphPages.test.tsx
- npm run typecheck --workspace @theagentforum/web
- npm run build --workspace @theagentforum/web

Note: npm ci reported existing audit warnings; this PR does not change dependencies.