### PR TITLE
feat: add Research Notes verification layer

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -10,7 +10,10 @@ import type {
   CreateCommentInput,
   FinishAuthenticationInput,
   FinishRegistrationInput,
+  CreateResearchNoteInput,
+  EvaluateResearchNoteInput,
   RedeemPairingInput,
+  ResearchNoteType,
   StartAgentPairingInput,
   StartAuthenticationInput,
   StartRegistrationInput,
@@ -21,6 +24,8 @@ import type { ArticleStore } from "./article-store";
 import type { QuestionStore } from "./question-store";
 import type { ForumStore } from "./forum-store";
 import { createForumAdapter } from "./forum-adapter";
+import { createInMemoryResearchNoteStore } from "./memory-research-note-store";
+import type { ResearchNoteStore } from "./research-note-store";
 import {
   createNoopRateLimitService,
   launchCompanionIpPolicies,
@@ -41,6 +46,7 @@ interface CreateAppOptions {
   articleStore?: ArticleStore;
   corsAllowOrigin?: string;
   rateLimiter?: RateLimitService;
+  researchNoteStore?: ResearchNoteStore;
 }
 
 const SESSION_COOKIE_NAME = "taf_session";
@@ -53,6 +59,7 @@ export function createApp(
   const corsAllowOrigin = options.corsAllowOrigin ?? "*";
   const forumStore: ForumStore = createForumAdapter(questionStore, options.articleStore);
   const rateLimiter = options.rateLimiter ?? createNoopRateLimitService();
+  const researchNoteStore = options.researchNoteStore ?? createInMemoryResearchNoteStore();
 
   return async function app(
     req: IncomingMessage,
@@ -61,7 +68,16 @@ export function createApp(
     const corsHeaders = buildCorsHeaders(corsAllowOrigin, req.headers.origin);
 
     try {
-      await routeRequest(questionStore, authStore, forumStore, rateLimiter, req, res, corsHeaders);
+      await routeRequest(
+        questionStore,
+        authStore,
+        forumStore,
+        researchNoteStore,
+        rateLimiter,
+        req,
+        res,
+        corsHeaders,
+      );
     } catch (error) {
       if (isHttpError(error)) {
         sendError(
@@ -100,6 +116,7 @@ async function routeRequest(
   questionStore: QuestionStore,
   authStore: AuthStore,
   forumStore: ForumStore,
+  researchNoteStore: ResearchNoteStore,
   rateLimiter: RateLimitService,
   req: IncomingMessage,
   res: ServerResponse,
@@ -691,6 +708,77 @@ async function routeRequest(
     }
 
     sendJson(res, corsHeaders, 200, { ok: true, data: thread });
+    return;
+  }
+
+  const contentNotesMatch = matchPath(path, /^\/v2\/contents\/([^/]+)\/notes$/);
+
+  if (method === "GET" && contentNotesMatch) {
+    const contentId = contentNotesMatch[1];
+    const thread = await forumStore.getContentThread(contentId);
+
+    if (!thread) {
+      sendError(res, corsHeaders, 404, "content_not_found", "Content not found.");
+      return;
+    }
+
+    sendJson(res, corsHeaders, 200, {
+      ok: true,
+      data: await researchNoteStore.listNotesForContent(contentId),
+    });
+    return;
+  }
+
+  if (method === "POST" && contentNotesMatch) {
+    const contentId = contentNotesMatch[1];
+    const thread = await forumStore.getContentThread(contentId);
+
+    if (!thread) {
+      sendError(res, corsHeaders, 404, "content_not_found", "Content not found.");
+      return;
+    }
+
+    const actor = requireAuthenticatedActor(authenticatedSession);
+    const payload = await readJsonBody(req);
+    const input = parseCreateResearchNoteInput(payload);
+    const note = await researchNoteStore.createNote(contentId, {
+      ...input,
+      author: actor,
+    });
+
+    sendJson(res, corsHeaders, 201, { ok: true, data: note });
+    return;
+  }
+
+  const noteEvaluationsMatch = matchPath(path, /^\/v2\/notes\/([^/]+)\/evaluations$/);
+
+  if (method === "GET" && noteEvaluationsMatch) {
+    const evaluations = await researchNoteStore.listEvaluations(noteEvaluationsMatch[1]);
+
+    if (!evaluations) {
+      sendError(res, corsHeaders, 404, "research_note_not_found", "Research note not found.");
+      return;
+    }
+
+    sendJson(res, corsHeaders, 200, { ok: true, data: evaluations });
+    return;
+  }
+
+  if (method === "POST" && noteEvaluationsMatch) {
+    const actor = requireAuthenticatedActor(authenticatedSession);
+    const payload = await readJsonBody(req);
+    const input = parseEvaluateResearchNoteInput(payload);
+    const note = await researchNoteStore.evaluateNote(noteEvaluationsMatch[1], {
+      ...input,
+      author: actor,
+    });
+
+    if (!note) {
+      sendError(res, corsHeaders, 404, "research_note_not_found", "Research note not found.");
+      return;
+    }
+
+    sendJson(res, corsHeaders, 201, { ok: true, data: note });
     return;
   }
 
@@ -1628,6 +1716,54 @@ function parseCreateCommentInput(payload: unknown): CreateCommentInput {
   };
 }
 
+const researchNoteTypes: ResearchNoteType[] = [
+  "missing_context",
+  "weak_source",
+  "factual_error",
+  "outdated_claim",
+  "unsupported_inference",
+  "contradicted_by_newer_evidence",
+  "replication_result",
+  "alternative_interpretation",
+];
+
+function parseCreateResearchNoteInput(payload: unknown): CreateResearchNoteInput {
+  const input = asRecord(payload, "Request body must be an object.");
+  const type = readRequiredString(input.type, "type") as ResearchNoteType;
+
+  if (!researchNoteTypes.includes(type)) {
+    throw createHttpError(
+      400,
+      "validation_error",
+      `type must be one of: ${researchNoteTypes.join(", ")}.`,
+    );
+  }
+
+  return {
+    claimId: readOptionalNonEmptyString(input.claimId, "claimId"),
+    type,
+    body: readRequiredString(input.body, "body"),
+    sources: readOptionalUrlStringArray(input.sources, "sources"),
+    author: parseActor(input.author),
+  };
+}
+
+function parseEvaluateResearchNoteInput(payload: unknown): EvaluateResearchNoteInput {
+  const input = asRecord(payload, "Request body must be an object.");
+
+  return {
+    helpful: readRequiredBoolean(input.helpful, "helpful"),
+    wellSourced: readRequiredBoolean(input.wellSourced, "wellSourced"),
+    resolvesIssue: readRequiredBoolean(input.resolvesIssue, "resolvesIssue"),
+    independentVerification: readRequiredBoolean(
+      input.independentVerification,
+      "independentVerification",
+    ),
+    comment: readOptionalBoundedString(input.comment, "comment", 1000),
+    author: parseActor(input.author),
+  };
+}
+
 function parseUpdateAccountProfileInput(payload: unknown): UpdateAccountProfileInput {
   const input = asRecord(payload, "Request body must be an object.");
 
@@ -1867,6 +2003,18 @@ function readOptionalString(value: unknown, fieldName: string): string | undefin
   return value.trim();
 }
 
+function readRequiredBoolean(value: unknown, fieldName: string): boolean {
+  if (typeof value !== "boolean") {
+    throw createHttpError(
+      400,
+      "validation_error",
+      `${fieldName} must be a boolean.`,
+    );
+  }
+
+  return value;
+}
+
 function readEmailString(value: string, fieldName: string): string {
   const email = value.trim().toLowerCase();
 
@@ -1968,6 +2116,29 @@ function readOptionalNonEmptyString(
   }
 
   return value;
+}
+
+function readOptionalUrlStringArray(
+  value: unknown,
+  fieldName: string,
+): string[] | undefined {
+  const strings = readOptionalStringArray(value, fieldName);
+
+  if (!strings) {
+    return undefined;
+  }
+
+  return strings.map((entry, index) => {
+    const parsed = readOptionalUrlString(entry, `${fieldName}[${index}]`);
+    if (!parsed) {
+      throw createHttpError(
+        400,
+        "validation_error",
+        `${fieldName}[${index}] must be a non-empty URL.`,
+      );
+    }
+    return parsed;
+  });
 }
 
 function readOptionalQuestionStatus(value: string | null): "open" | "answered" | undefined {

--- a/apps/api/src/http.v2.test.ts
+++ b/apps/api/src/http.v2.test.ts
@@ -150,6 +150,111 @@ describe("HTTP API v2 forum", () => {
     assert.deepEqual(search.body.data.matches[0].matchSources, ["body"]);
   });
 
+  it("creates, lists, and evaluates research notes for content", async () => {
+    const authStore = createInMemoryAuthStore();
+    const app = createApp(createInMemoryQuestionStore(), authStore);
+    const cookieHeader = await createAuthenticatedCookie(authStore, {
+      handle: "researcher",
+      displayName: "Researcher",
+    });
+
+    const article = await requestJson(app, "/v2/contents", {
+      method: "POST",
+      headers: {
+        cookie: cookieHeader,
+      },
+      body: {
+        type: "article",
+        title: "Verification target",
+        body: "A research artifact that needs notes.",
+        author: spoofedAgent,
+      },
+    });
+    assert.equal(article.status, 201);
+
+    const anonymousCreate = await requestJson(app, `/v2/contents/${article.body.data.id}/notes`, {
+      method: "POST",
+      body: {
+        type: "missing_context",
+        body: "This needs a source.",
+        author: spoofedAgent,
+      },
+    });
+    assert.equal(anonymousCreate.status, 401);
+
+    const createdNote = await requestJson(app, `/v2/contents/${article.body.data.id}/notes`, {
+      method: "POST",
+      headers: {
+        cookie: cookieHeader,
+      },
+      body: {
+        type: "missing_context",
+        body: "The article needs the primary benchmark source.",
+        sources: ["https://example.com/source"],
+        author: spoofedAgent,
+      },
+    });
+    assert.equal(createdNote.status, 201);
+    assert.equal(createdNote.body.data.contentId, article.body.data.id);
+    assert.equal(createdNote.body.data.author.handle, "researcher");
+    assert.equal(createdNote.body.data.status, "needs_review");
+    assert.deepEqual(createdNote.body.data.evaluationCounts, {
+      helpful: 0,
+      notHelpful: 0,
+      wellSourced: 0,
+      poorlySourced: 0,
+      resolvesIssue: 0,
+      addsNoise: 0,
+      independentVerification: 0,
+      opinionOnly: 0,
+    });
+
+    const listedNotes = await requestJson(app, `/v2/contents/${article.body.data.id}/notes`);
+    assert.equal(listedNotes.status, 200);
+    assert.equal(listedNotes.body.data.length, 1);
+    assert.equal(listedNotes.body.data[0].id, createdNote.body.data.id);
+
+    const firstEvaluation = await requestJson(app, `/v2/notes/${createdNote.body.data.id}/evaluations`, {
+      method: "POST",
+      headers: {
+        cookie: cookieHeader,
+      },
+      body: {
+        helpful: true,
+        wellSourced: true,
+        resolvesIssue: true,
+        independentVerification: true,
+        comment: "Source checks out.",
+        author: spoofedHuman,
+      },
+    });
+    assert.equal(firstEvaluation.status, 201);
+    assert.equal(firstEvaluation.body.data.status, "needs_more_ratings");
+    assert.equal(firstEvaluation.body.data.evaluationCounts.helpful, 1);
+
+    const secondEvaluation = await requestJson(app, `/v2/notes/${createdNote.body.data.id}/evaluations`, {
+      method: "POST",
+      headers: {
+        cookie: cookieHeader,
+      },
+      body: {
+        helpful: true,
+        wellSourced: true,
+        resolvesIssue: true,
+        independentVerification: false,
+        author: spoofedHuman,
+      },
+    });
+    assert.equal(secondEvaluation.status, 201);
+    assert.equal(secondEvaluation.body.data.status, "accepted_context");
+    assert.equal(secondEvaluation.body.data.evaluationCounts.helpful, 2);
+
+    const evaluations = await requestJson(app, `/v2/notes/${createdNote.body.data.id}/evaluations`);
+    assert.equal(evaluations.status, 200);
+    assert.equal(evaluations.body.data.length, 2);
+    assert.equal(evaluations.body.data[0].author.handle, "researcher");
+  });
+
 });
 
 async function createAuthenticatedCookie(

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -4,6 +4,7 @@ import { createPostgresArticleStore } from "./postgres-article-store";
 import { createPostgresAuthStore } from "./postgres-auth-store";
 import { createPostgresRateLimitStore } from "./postgres-rate-limit-store";
 import { createPostgresQuestionStore } from "./postgres-question-store";
+import { createPostgresResearchNoteStore } from "./postgres-research-note-store";
 import { runSqlFile } from "./postgres";
 import { createConsoleServerEventSink, createRateLimitService } from "./rate-limit";
 
@@ -16,11 +17,13 @@ async function main(): Promise<void> {
   const questionStore = createPostgresQuestionStore();
   const authStore = createPostgresAuthStore();
   const articleStore = createPostgresArticleStore();
+  const researchNoteStore = createPostgresResearchNoteStore();
   const rateLimiter = createRateLimitService(createPostgresRateLimitStore(), {
     eventSink: createConsoleServerEventSink(),
   });
   const app = createApp(questionStore, authStore, {
     articleStore,
+    researchNoteStore,
     corsAllowOrigin,
     rateLimiter,
   });

--- a/apps/api/src/memory-research-note-store.ts
+++ b/apps/api/src/memory-research-note-store.ts
@@ -1,0 +1,176 @@
+import type {
+  EvaluateResearchNoteInput,
+  ResearchNote,
+  ResearchNoteEvaluation,
+  ResearchNoteEvaluationAggregate,
+  CreateResearchNoteInput,
+} from "@theagentforum/core";
+import type { ResearchNoteStore } from "./research-note-store";
+
+export function createInMemoryResearchNoteStore(): ResearchNoteStore {
+  const notes = new Map<string, ResearchNote>();
+  const noteIdsByContentId = new Map<string, string[]>();
+  const evaluationsByNoteId = new Map<string, ResearchNoteEvaluation[]>();
+  let noteSequence = 1;
+  let evaluationSequence = 1;
+
+  async function listNotesForContent(contentId: string): Promise<ResearchNote[]> {
+    return (noteIdsByContentId.get(contentId) ?? [])
+      .map((noteId) => notes.get(noteId))
+      .filter((note): note is ResearchNote => Boolean(note))
+      .sort(compareNotes)
+      .map(cloneNote);
+  }
+
+  async function createNote(contentId: string, input: CreateResearchNoteInput): Promise<ResearchNote> {
+    const now = new Date().toISOString();
+    const note: ResearchNote = {
+      id: `rn-${noteSequence++}`,
+      contentId,
+      claimId: input.claimId,
+      type: input.type,
+      body: input.body,
+      sources: input.sources ?? [],
+      author: input.author,
+      status: "needs_review",
+      createdAt: now,
+      updatedAt: now,
+      evaluationCounts: emptyAggregate(),
+    };
+
+    notes.set(note.id, note);
+    noteIdsByContentId.set(contentId, [...(noteIdsByContentId.get(contentId) ?? []), note.id]);
+    evaluationsByNoteId.set(note.id, []);
+
+    return cloneNote(note);
+  }
+
+  async function evaluateNote(noteId: string, input: EvaluateResearchNoteInput): Promise<ResearchNote | null> {
+    const note = notes.get(noteId);
+
+    if (!note) {
+      return null;
+    }
+
+    const evaluation: ResearchNoteEvaluation = {
+      id: `rne-${evaluationSequence++}`,
+      noteId,
+      author: input.author,
+      helpful: input.helpful,
+      wellSourced: input.wellSourced,
+      resolvesIssue: input.resolvesIssue,
+      independentVerification: input.independentVerification,
+      comment: input.comment,
+      createdAt: new Date().toISOString(),
+    };
+    const evaluations = evaluationsByNoteId.get(noteId) ?? [];
+    evaluations.push(evaluation);
+    evaluationsByNoteId.set(noteId, evaluations);
+
+    note.evaluationCounts = summarizeEvaluations(evaluations);
+    note.status = deriveStatus(note.evaluationCounts);
+    note.updatedAt = evaluation.createdAt;
+
+    return cloneNote(note);
+  }
+
+  async function listEvaluations(noteId: string): Promise<ResearchNoteEvaluation[] | null> {
+    if (!notes.has(noteId)) {
+      return null;
+    }
+
+    return (evaluationsByNoteId.get(noteId) ?? []).map(cloneEvaluation);
+  }
+
+  return { listNotesForContent, createNote, evaluateNote, listEvaluations };
+}
+
+function summarizeEvaluations(evaluations: ResearchNoteEvaluation[]): ResearchNoteEvaluationAggregate {
+  const aggregate = emptyAggregate();
+
+  for (const evaluation of evaluations) {
+    if (evaluation.helpful) {
+      aggregate.helpful += 1;
+    } else {
+      aggregate.notHelpful += 1;
+    }
+
+    if (evaluation.wellSourced) {
+      aggregate.wellSourced += 1;
+    } else {
+      aggregate.poorlySourced += 1;
+    }
+
+    if (evaluation.resolvesIssue) {
+      aggregate.resolvesIssue += 1;
+    } else {
+      aggregate.addsNoise += 1;
+    }
+
+    if (evaluation.independentVerification) {
+      aggregate.independentVerification += 1;
+    } else {
+      aggregate.opinionOnly += 1;
+    }
+  }
+
+  return aggregate;
+}
+
+function deriveStatus(aggregate: ResearchNoteEvaluationAggregate): ResearchNote["status"] {
+  const total = aggregate.helpful + aggregate.notHelpful;
+
+  if (total < 2) {
+    return "needs_more_ratings";
+  }
+
+  if (aggregate.helpful >= 2 && aggregate.helpful > aggregate.notHelpful) {
+    return "accepted_context";
+  }
+
+  if (aggregate.notHelpful >= 2 && aggregate.notHelpful > aggregate.helpful) {
+    return "rejected";
+  }
+
+  return "disputed";
+}
+
+function emptyAggregate(): ResearchNoteEvaluationAggregate {
+  return {
+    helpful: 0,
+    notHelpful: 0,
+    wellSourced: 0,
+    poorlySourced: 0,
+    resolvesIssue: 0,
+    addsNoise: 0,
+    independentVerification: 0,
+    opinionOnly: 0,
+  };
+}
+
+function cloneNote(note: ResearchNote): ResearchNote {
+  return {
+    ...note,
+    sources: [...note.sources],
+    author: { ...note.author },
+    evaluationCounts: { ...note.evaluationCounts },
+  };
+}
+
+function cloneEvaluation(evaluation: ResearchNoteEvaluation): ResearchNoteEvaluation {
+  return {
+    ...evaluation,
+    author: { ...evaluation.author },
+  };
+}
+
+function compareNotes(left: ResearchNote, right: ResearchNote): number {
+  const leftScore = left.evaluationCounts.helpful - left.evaluationCounts.notHelpful;
+  const rightScore = right.evaluationCounts.helpful - right.evaluationCounts.notHelpful;
+
+  if (leftScore !== rightScore) {
+    return rightScore - leftScore;
+  }
+
+  return right.createdAt.localeCompare(left.createdAt);
+}

--- a/apps/api/src/postgres-research-note-store.ts
+++ b/apps/api/src/postgres-research-note-store.ts
@@ -1,0 +1,165 @@
+import type {
+  EvaluateResearchNoteInput,
+  ResearchNote,
+  ResearchNoteEvaluation,
+  CreateResearchNoteInput,
+} from "@theagentforum/core";
+import { runSql } from "./postgres";
+import type { ResearchNoteStore } from "./research-note-store";
+
+export function createPostgresResearchNoteStore(): ResearchNoteStore {
+  return { listNotesForContent, createNote, evaluateNote, listEvaluations };
+}
+
+async function listNotesForContent(contentId: string): Promise<ResearchNote[]> {
+  return queryJson<ResearchNote[]>(
+    `
+      select coalesce(json_agg(note order by helpful_score desc, created_at desc), '[]'::json) :: text
+      from (
+        select
+          build_research_note_json(rn.*) as note,
+          (
+            select count(*) filter (where helpful) - count(*) filter (where not helpful)
+            from research_note_evaluations rne
+            where rne.note_id = rn.id
+          ) as helpful_score,
+          rn.created_at
+        from research_notes rn
+        where rn.content_id = :'content_id'
+      ) listed;
+    `,
+    { content_id: contentId },
+  );
+}
+
+async function createNote(contentId: string, input: CreateResearchNoteInput): Promise<ResearchNote> {
+  return queryJson<ResearchNote>(
+    `
+      insert into research_notes (content_id, claim_id, type, body, sources, author)
+      values (
+        :'content_id',
+        nullif(:'claim_id', ''),
+        :'type',
+        :'body',
+        cast(:'sources' as jsonb),
+        cast(:'author' as jsonb)
+      )
+      returning build_research_note_json(research_notes.*) :: text;
+    `,
+    {
+      content_id: contentId,
+      claim_id: input.claimId ?? "",
+      type: input.type,
+      body: input.body,
+      sources: JSON.stringify(input.sources ?? []),
+      author: JSON.stringify(input.author),
+    },
+  );
+}
+
+async function evaluateNote(noteId: string, input: EvaluateResearchNoteInput): Promise<ResearchNote | null> {
+  const output = await runSql(
+    `
+      with target as (
+        select id
+        from research_notes
+        where id = :'note_id'
+      ),
+      inserted as (
+        insert into research_note_evaluations (
+          note_id,
+          author,
+          helpful,
+          well_sourced,
+          resolves_issue,
+          independent_verification,
+          comment
+        )
+        select
+          id,
+          cast(:'author' as jsonb),
+          :'helpful'::boolean,
+          :'well_sourced'::boolean,
+          :'resolves_issue'::boolean,
+          :'independent_verification'::boolean,
+          nullif(:'comment', '')
+        from target
+        returning note_id, created_at
+      ),
+      aggregate as (
+        select
+          rn.id,
+          count(rne.*) as total,
+          count(*) filter (where rne.helpful) as helpful_count,
+          count(*) filter (where not rne.helpful) as not_helpful_count
+        from research_notes rn
+        join inserted i on i.note_id = rn.id
+        left join research_note_evaluations rne on rne.note_id = rn.id
+        group by rn.id
+      ),
+      updated as (
+        update research_notes rn
+        set
+          status = case
+            when a.total < 2 then 'needs_more_ratings'
+            when a.helpful_count >= 2 and a.helpful_count > a.not_helpful_count then 'accepted_context'
+            when a.not_helpful_count >= 2 and a.not_helpful_count > a.helpful_count then 'rejected'
+            else 'disputed'
+          end,
+          updated_at = (select max(created_at) from inserted)
+        from aggregate a
+        where rn.id = a.id
+        returning rn.*
+      )
+      select build_research_note_json(updated.*) :: text
+      from updated;
+    `,
+    {
+      note_id: noteId,
+      author: JSON.stringify(input.author),
+      helpful: String(input.helpful),
+      well_sourced: String(input.wellSourced),
+      resolves_issue: String(input.resolvesIssue),
+      independent_verification: String(input.independentVerification),
+      comment: input.comment ?? "",
+    },
+  );
+
+  return output ? JSON.parse(output) as ResearchNote : null;
+}
+
+async function listEvaluations(noteId: string): Promise<ResearchNoteEvaluation[] | null> {
+  const exists = await runSql("select id from research_notes where id = :'note_id';", { note_id: noteId });
+
+  if (!exists) {
+    return null;
+  }
+
+  return queryJson<ResearchNoteEvaluation[]>(
+    `
+      select coalesce(json_agg(evaluation order by created_at), '[]'::json) :: text
+      from (
+        select json_strip_nulls(json_build_object(
+          'id', id,
+          'noteId', note_id,
+          'author', author,
+          'helpful', helpful,
+          'wellSourced', well_sourced,
+          'resolvesIssue', resolves_issue,
+          'independentVerification', independent_verification,
+          'comment', comment,
+          'createdAt', to_char(created_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+        )) as evaluation,
+        created_at
+        from research_note_evaluations
+        where note_id = :'note_id'
+      ) listed;
+    `,
+    { note_id: noteId },
+  );
+}
+
+async function queryJson<T>(sql: string, variables?: Record<string, string>): Promise<T> {
+  const output = await runSql(sql, variables);
+  return JSON.parse(output) as T;
+}

--- a/apps/api/src/research-note-store.ts
+++ b/apps/api/src/research-note-store.ts
@@ -1,0 +1,13 @@
+import type {
+  EvaluateResearchNoteInput,
+  ResearchNote,
+  CreateResearchNoteInput,
+  ResearchNoteEvaluation,
+} from "@theagentforum/core";
+
+export interface ResearchNoteStore {
+  listNotesForContent(contentId: string): Promise<ResearchNote[]>;
+  createNote(contentId: string, input: CreateResearchNoteInput): Promise<ResearchNote>;
+  evaluateNote(noteId: string, input: EvaluateResearchNoteInput): Promise<ResearchNote | null>;
+  listEvaluations(noteId: string): Promise<ResearchNoteEvaluation[] | null>;
+}

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -1,8 +1,11 @@
 export { createPostgresArticleStore } from "./postgres-article-store";
 export { createPostgresQuestionStore, createPostgresQuestionStore as createQuestionStore } from "./postgres-question-store";
+export { createPostgresResearchNoteStore } from "./postgres-research-note-store";
 export { createInMemoryArticleStore } from "./memory-article-store";
 export { createInMemoryQuestionStore } from "./memory-question-store";
+export { createInMemoryResearchNoteStore } from "./memory-research-note-store";
 export { createPostgresAuthStore } from "./postgres-auth-store";
 export { createInMemoryAuthStore } from "./memory-auth-store";
 export type { QuestionStore, QuestionThread } from "./question-store";
+export type { ResearchNoteStore } from "./research-note-store";
 export type { AuthStore } from "./auth-store";

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -83,6 +83,63 @@ export interface ForumSearchResult {
   matches: ForumSearchMatch[];
 }
 
+export type ResearchNoteType =
+  | "missing_context"
+  | "weak_source"
+  | "factual_error"
+  | "outdated_claim"
+  | "unsupported_inference"
+  | "contradicted_by_newer_evidence"
+  | "replication_result"
+  | "alternative_interpretation";
+
+export type ResearchNoteStatus =
+  | "needs_review"
+  | "needs_more_ratings"
+  | "accepted_context"
+  | "disputed"
+  | "rejected";
+
+export interface ResearchNoteEvaluationAggregate {
+  helpful: number;
+  notHelpful: number;
+  wellSourced: number;
+  poorlySourced: number;
+  resolvesIssue: number;
+  addsNoise: number;
+  independentVerification: number;
+  opinionOnly: number;
+}
+
+export interface ResearchNote {
+  id: string;
+  contentId: string;
+  claimId?: string;
+  type: ResearchNoteType;
+  body: string;
+  sources: string[];
+  author: Question["author"];
+  status: ResearchNoteStatus;
+  createdAt: string;
+  updatedAt: string;
+  evaluationCounts: ResearchNoteEvaluationAggregate;
+}
+
+export interface CreateResearchNoteInput {
+  claimId?: string;
+  type: ResearchNoteType;
+  body: string;
+  sources?: string[];
+}
+
+export interface EvaluateResearchNoteInput {
+  helpful: boolean;
+  wellSourced: boolean;
+  resolvesIssue: boolean;
+  independentVerification: boolean;
+  comment?: string;
+}
+
 export class ApiClientError extends Error {
   readonly statusCode: number;
   readonly code?: string;
@@ -198,6 +255,49 @@ export function createApiClient(baseUrl = defaultBaseUrl) {
     );
 
     return mapContentThreadToQuestionThread(thread);
+  }
+
+  async function listResearchNotes(contentId: string): Promise<ResearchNote[]> {
+    return request<ResearchNote[]>(
+      "GET",
+      `/v2/contents/${encodeURIComponent(contentId)}/notes`,
+    );
+  }
+
+  async function createResearchNote(
+    contentId: string,
+    input: CreateResearchNoteInput,
+  ): Promise<ResearchNote> {
+    return request<ResearchNote>(
+      "POST",
+      `/v2/contents/${encodeURIComponent(contentId)}/notes`,
+      {
+        ...input,
+        author: {
+          id: "client-placeholder",
+          kind: "human",
+          handle: "client-placeholder",
+        },
+      },
+    );
+  }
+
+  async function evaluateResearchNote(
+    noteId: string,
+    input: EvaluateResearchNoteInput,
+  ): Promise<ResearchNote> {
+    return request<ResearchNote>(
+      "POST",
+      `/v2/notes/${encodeURIComponent(noteId)}/evaluations`,
+      {
+        ...input,
+        author: {
+          id: "client-placeholder",
+          kind: "human",
+          handle: "client-placeholder",
+        },
+      },
+    );
   }
 
   async function listAnswerSkills(questionId: string, answerId: string): Promise<AnswerSkill[]> {
@@ -378,6 +478,9 @@ export function createApiClient(baseUrl = defaultBaseUrl) {
     getQuestionThread,
     createAnswer,
     acceptAnswer,
+    listResearchNotes,
+    createResearchNote,
+    evaluateResearchNote,
     listAnswerSkills,
     startRegistration,
     getRegistrationSession,

--- a/apps/web/src/pages/TerminalGraphPages.test.tsx
+++ b/apps/web/src/pages/TerminalGraphPages.test.tsx
@@ -162,6 +162,9 @@ function buildApi(overrides: Partial<ApiClient> = {}): ApiClient {
       ...thread,
       question: { ...thread.question, acceptedAnswerId: "a-1", status: "answered" },
     }),
+    listResearchNotes: vi.fn().mockResolvedValue([]),
+    createResearchNote: vi.fn(),
+    evaluateResearchNote: vi.fn(),
     listAnswerSkills: vi.fn().mockImplementation(async (_questionId: string, answerId: string) => {
       if (answerId !== "a-2") {
         return [];

--- a/apps/web/src/pages/TerminalGraphPages.tsx
+++ b/apps/web/src/pages/TerminalGraphPages.tsx
@@ -4,7 +4,7 @@ import { useAuth } from "../auth/AuthContext";
 import { AuthRequiredPanel } from "../components/AuthRequiredPanel";
 import { CreateQuestionForm, type CreateQuestionFormValues } from "../components/CreateQuestionForm";
 import { TerminalPage } from "../components/TerminalChrome";
-import type { ApiClient, ForumContent, ForumSearchResult } from "../lib/api";
+import type { ApiClient, ForumContent, ForumSearchResult, ResearchNote, ResearchNoteType } from "../lib/api";
 import { useAuthNavigation } from "../lib/auth-routing";
 import type { Answer, AnswerSkill, Question, QuestionThread } from "../types";
 import { AnswerForm, type AnswerFormValues } from "../components/AnswerForm";
@@ -132,6 +132,19 @@ interface ArticleTocEntry {
   label: string;
   level: number;
 }
+
+const researchNoteTypeLabels: Record<ResearchNoteType, string> = {
+  missing_context: "missing context",
+  weak_source: "weak source",
+  factual_error: "factual error",
+  outdated_claim: "outdated claim",
+  unsupported_inference: "unsupported inference",
+  contradicted_by_newer_evidence: "contradicted by newer evidence",
+  replication_result: "replication result",
+  alternative_interpretation: "alternative interpretation",
+};
+
+const researchNoteTypes = Object.keys(researchNoteTypeLabels) as ResearchNoteType[];
 
 const paperSectionTitles = new Map([
   ["abstract", "Abstract"],
@@ -756,6 +769,183 @@ function ArticleTableOfContents({ entries }: { entries: ArticleTocEntry[] }) {
   );
 }
 
+function ResearchNotesPanel({
+  api,
+  contentId,
+  notes,
+  loading,
+  authenticated,
+  onNotesChange,
+}: {
+  api: ApiClient;
+  contentId: string;
+  notes: ResearchNote[];
+  loading: boolean;
+  authenticated: boolean;
+  onNotesChange: (notes: ResearchNote[]) => void;
+}) {
+  const [type, setType] = useState<ResearchNoteType>("missing_context");
+  const [body, setBody] = useState("");
+  const [sources, setSources] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [evaluatingNoteId, setEvaluatingNoteId] = useState<string | null>(null);
+
+  async function handleCreateNote(event: FormEvent<HTMLFormElement>): Promise<void> {
+    event.preventDefault();
+
+    if (!authenticated || submitting) {
+      return;
+    }
+
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      const sourceList = sources
+        .split("\n")
+        .map((source) => source.trim())
+        .filter(Boolean);
+      const note = await api.createResearchNote(contentId, {
+        type,
+        body,
+        sources: sourceList.length > 0 ? sourceList : undefined,
+      });
+      onNotesChange([note, ...notes]);
+      setBody("");
+      setSources("");
+      setType("missing_context");
+    } catch (cause) {
+      setError(readErrorMessage(cause));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function handleEvaluate(note: ResearchNote, helpful: boolean): Promise<void> {
+    if (!authenticated || evaluatingNoteId) {
+      return;
+    }
+
+    setEvaluatingNoteId(note.id);
+    setError(null);
+
+    try {
+      const updatedNote = await api.evaluateResearchNote(note.id, {
+        helpful,
+        wellSourced: helpful,
+        resolvesIssue: helpful,
+        independentVerification: false,
+      });
+      onNotesChange(notes.map((current) => (current.id === note.id ? updatedNote : current)));
+    } catch (cause) {
+      setError(readErrorMessage(cause));
+    } finally {
+      setEvaluatingNoteId(null);
+    }
+  }
+
+  return (
+    <section className="terminal-side-card terminal-research-notes" aria-label="Research notes">
+      <div className="terminal-research-notes__header">
+        <h2>research notes</h2>
+        <span>{loading ? "sync" : notes.length}</span>
+      </div>
+      <p className="terminal-side-card__note">
+        Community Notes-style context for claims, sources, and verification.
+      </p>
+
+      {loading ? <p className="terminal-side-card__note">Loading notes…</p> : null}
+      {error ? <p className="terminal-inline-error" role="alert">{error}</p> : null}
+
+      {!loading && notes.length === 0 ? (
+        <p className="terminal-side-card__note">No research notes yet.</p>
+      ) : null}
+
+      <div className="terminal-research-note-list">
+        {notes.map((note) => (
+          <article key={note.id} className="terminal-research-note">
+            <div className="terminal-comment-card__meta">
+              <span className="terminal-type-badge">{researchNoteTypeLabels[note.type]}</span>
+              <span>{note.status.replace(/_/g, " ")}</span>
+            </div>
+            <p>{note.body}</p>
+            {note.sources.length > 0 ? (
+              <ul className="terminal-research-note__sources">
+                {note.sources.map((source) => (
+                  <li key={source}>
+                    <a href={source} target="_blank" rel="noreferrer">{source}</a>
+                  </li>
+                ))}
+              </ul>
+            ) : null}
+            <div className="terminal-research-note__score">
+              <span>{note.evaluationCounts.helpful} helpful</span>
+              <span>{note.evaluationCounts.notHelpful} not helpful</span>
+            </div>
+            {authenticated ? (
+              <div className="terminal-research-note__actions">
+                <button
+                  type="button"
+                  className="terminal-mini-button"
+                  disabled={Boolean(evaluatingNoteId)}
+                  onClick={() => void handleEvaluate(note, true)}
+                >
+                  helpful
+                </button>
+                <button
+                  type="button"
+                  className="terminal-mini-button"
+                  disabled={Boolean(evaluatingNoteId)}
+                  onClick={() => void handleEvaluate(note, false)}
+                >
+                  not helpful
+                </button>
+              </div>
+            ) : null}
+          </article>
+        ))}
+      </div>
+
+      {authenticated ? (
+        <form className="terminal-research-note-form" onSubmit={(event) => void handleCreateNote(event)}>
+          <label>
+            <span>type</span>
+            <select value={type} onChange={(event) => setType(event.target.value as ResearchNoteType)}>
+              {researchNoteTypes.map((noteType) => (
+                <option key={noteType} value={noteType}>{researchNoteTypeLabels[noteType]}</option>
+              ))}
+            </select>
+          </label>
+          <label>
+            <span>note</span>
+            <textarea
+              required
+              minLength={8}
+              value={body}
+              onChange={(event) => setBody(event.target.value)}
+              placeholder="Add missing context, a source concern, or a verification result."
+            />
+          </label>
+          <label>
+            <span>sources</span>
+            <textarea
+              value={sources}
+              onChange={(event) => setSources(event.target.value)}
+              placeholder="https://example.com/source"
+            />
+          </label>
+          <button type="submit" className="terminal-button terminal-button--full" disabled={submitting}>
+            {submitting ? "adding note" : "add research note"}
+          </button>
+        </form>
+      ) : (
+        <TerminalInlineAuthAction label="sign in to add notes" />
+      )}
+    </section>
+  );
+}
+
 interface PostDetailPageProps extends TerminalApiProps {}
 
 export function PostDetailPage({ api }: PostDetailPageProps) {
@@ -764,6 +954,8 @@ export function PostDetailPage({ api }: PostDetailPageProps) {
   const resolvedId = postId ?? questionId;
   const [thread, setThread] = useState<QuestionThread | null>(null);
   const [answerSkills, setAnswerSkills] = useState<Record<string, AnswerSkill[]>>({});
+  const [researchNotes, setResearchNotes] = useState<ResearchNote[]>([]);
+  const [notesLoading, setNotesLoading] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [acceptingAnswerId, setAcceptingAnswerId] = useState<string | null>(null);
@@ -780,11 +972,16 @@ export function PostDetailPage({ api }: PostDetailPageProps) {
     }
 
     setLoading(true);
+    setNotesLoading(true);
     setError(null);
 
     try {
-      const nextThread = await api.getQuestionThread(resolvedId);
+      const [nextThread, nextNotes] = await Promise.all([
+        api.getQuestionThread(resolvedId),
+        api.listResearchNotes(resolvedId),
+      ]);
       setThread(nextThread);
+      setResearchNotes(nextNotes);
 
       const nextSkills = Object.fromEntries(
         await Promise.all(
@@ -800,8 +997,10 @@ export function PostDetailPage({ api }: PostDetailPageProps) {
       setError(readErrorMessage(cause));
       setThread(null);
       setAnswerSkills({});
+      setResearchNotes([]);
     } finally {
       setLoading(false);
+      setNotesLoading(false);
     }
   }
 
@@ -992,6 +1191,15 @@ export function PostDetailPage({ api }: PostDetailPageProps) {
 
           {isArticle ? (
             <aside className="terminal-side-stack terminal-reader-rail" aria-label="Article tools">
+              <ResearchNotesPanel
+                api={api}
+                contentId={thread.question.id}
+                notes={researchNotes}
+                loading={notesLoading}
+                authenticated={Boolean(auth.ready && auth.session)}
+                onNotesChange={setResearchNotes}
+              />
+
               <section className="terminal-side-card">
                 <h2>reader</h2>
                 <ul className="terminal-artifact-list">
@@ -1008,6 +1216,15 @@ export function PostDetailPage({ api }: PostDetailPageProps) {
             </aside>
           ) : (
             <aside className="terminal-side-stack" aria-label="Thread metadata">
+              <ResearchNotesPanel
+                api={api}
+                contentId={thread.question.id}
+                notes={researchNotes}
+                loading={notesLoading}
+                authenticated={Boolean(auth.ready && auth.session)}
+                onNotesChange={setResearchNotes}
+              />
+
               <section className="terminal-side-card">
                 <h2>thread graph</h2>
                 <ThreadGraph answerCount={thread.answers.length} skillCount={skillCount} status={thread.question.status} />

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -4427,3 +4427,98 @@ img.markdown-media {
   color: var(--terminal-muted);
   font-size: 0.86rem;
 }
+
+.terminal-research-notes {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.terminal-research-notes__header,
+.terminal-research-note__score,
+.terminal-research-note__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.terminal-research-notes__header {
+  justify-content: space-between;
+}
+
+.terminal-research-notes__header span,
+.terminal-research-note__score span {
+  color: var(--terminal-muted);
+  font-size: 0.78rem;
+}
+
+.terminal-research-note-list {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.terminal-research-note {
+  display: grid;
+  gap: 0.65rem;
+  padding: 0.85rem;
+  border: 1px solid rgba(25, 242, 211, 0.12);
+  border-radius: 0.75rem;
+  background: rgba(3, 4, 11, 0.34);
+}
+
+.terminal-research-note p {
+  margin: 0;
+  color: var(--terminal-text);
+  font-size: 0.88rem;
+  line-height: 1.55;
+}
+
+.terminal-research-note__sources {
+  display: grid;
+  gap: 0.35rem;
+  margin: 0;
+  padding-left: 1rem;
+  overflow-wrap: anywhere;
+}
+
+.terminal-research-note__sources a {
+  color: var(--terminal-cyan);
+  font-size: 0.78rem;
+}
+
+.terminal-research-note__actions {
+  flex-wrap: wrap;
+}
+
+.terminal-research-note-form {
+  display: grid;
+  gap: 0.75rem;
+  padding-top: 0.25rem;
+}
+
+.terminal-research-note-form label {
+  display: grid;
+  gap: 0.35rem;
+  color: var(--terminal-muted);
+  font-size: 0.78rem;
+}
+
+.terminal-research-note-form select,
+.terminal-research-note-form textarea {
+  width: 100%;
+  border: 1px solid rgba(25, 242, 211, 0.16);
+  border-radius: 0.65rem;
+  background: rgba(3, 4, 11, 0.62);
+  color: var(--terminal-text);
+  font: inherit;
+}
+
+.terminal-research-note-form select {
+  min-height: 2.35rem;
+  padding: 0 0.7rem;
+}
+
+.terminal-research-note-form textarea {
+  min-height: 5.5rem;
+  padding: 0.7rem;
+  resize: vertical;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -370,3 +370,74 @@ export interface ContentThreadSearchResult {
   returned: number;
   matches: ContentThreadSearchMatch[];
 }
+
+export type ResearchNoteType =
+  | "missing_context"
+  | "weak_source"
+  | "factual_error"
+  | "outdated_claim"
+  | "unsupported_inference"
+  | "contradicted_by_newer_evidence"
+  | "replication_result"
+  | "alternative_interpretation";
+
+export type ResearchNoteStatus =
+  | "needs_review"
+  | "needs_more_ratings"
+  | "accepted_context"
+  | "disputed"
+  | "rejected";
+
+export interface ResearchNoteEvaluationAggregate {
+  helpful: number;
+  notHelpful: number;
+  wellSourced: number;
+  poorlySourced: number;
+  resolvesIssue: number;
+  addsNoise: number;
+  independentVerification: number;
+  opinionOnly: number;
+}
+
+export interface ResearchNote {
+  id: string;
+  contentId: string;
+  claimId?: string;
+  type: ResearchNoteType;
+  body: string;
+  sources: string[];
+  author: Actor;
+  status: ResearchNoteStatus;
+  createdAt: string;
+  updatedAt: string;
+  evaluationCounts: ResearchNoteEvaluationAggregate;
+}
+
+export interface ResearchNoteEvaluation {
+  id: string;
+  noteId: string;
+  author: Actor;
+  helpful: boolean;
+  wellSourced: boolean;
+  resolvesIssue: boolean;
+  independentVerification: boolean;
+  comment?: string;
+  createdAt: string;
+}
+
+export interface CreateResearchNoteInput {
+  claimId?: string;
+  type: ResearchNoteType;
+  body: string;
+  sources?: string[];
+  author: Actor;
+}
+
+export interface EvaluateResearchNoteInput {
+  helpful: boolean;
+  wellSourced: boolean;
+  resolvesIssue: boolean;
+  independentVerification: boolean;
+  comment?: string;
+  author: Actor;
+}

--- a/packages/db/sql/001-init.sql
+++ b/packages/db/sql/001-init.sql
@@ -1,6 +1,8 @@
 create sequence if not exists question_id_seq;
 create sequence if not exists answer_id_seq;
 create sequence if not exists article_id_seq;
+create sequence if not exists research_note_id_seq;
+create sequence if not exists research_note_evaluation_id_seq;
 create sequence if not exists auth_registration_session_id_seq;
 create sequence if not exists auth_pairing_session_id_seq;
 create sequence if not exists auth_account_id_seq;
@@ -53,6 +55,89 @@ create table if not exists articles (
 
 create index if not exists articles_created_at_idx
   on articles (created_at desc);
+
+create table if not exists research_notes (
+  id text primary key default ('rn-' || nextval('research_note_id_seq')),
+  content_id text not null,
+  claim_id text,
+  type text not null,
+  body text not null,
+  sources jsonb not null default '[]'::jsonb,
+  author jsonb not null,
+  status text not null default 'needs_review',
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint research_notes_type_check
+    check (type in (
+      'missing_context',
+      'weak_source',
+      'factual_error',
+      'outdated_claim',
+      'unsupported_inference',
+      'contradicted_by_newer_evidence',
+      'replication_result',
+      'alternative_interpretation'
+    )),
+  constraint research_notes_status_check
+    check (status in (
+      'needs_review',
+      'needs_more_ratings',
+      'accepted_context',
+      'disputed',
+      'rejected'
+    ))
+);
+
+create index if not exists research_notes_content_id_created_at_idx
+  on research_notes (content_id, created_at desc);
+
+create table if not exists research_note_evaluations (
+  id text primary key default ('rne-' || nextval('research_note_evaluation_id_seq')),
+  note_id text not null references research_notes(id) on delete cascade,
+  author jsonb not null,
+  helpful boolean not null,
+  well_sourced boolean not null,
+  resolves_issue boolean not null,
+  independent_verification boolean not null,
+  comment text,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists research_note_evaluations_note_id_created_at_idx
+  on research_note_evaluations (note_id, created_at);
+
+create or replace function build_research_note_json(rn research_notes)
+returns json
+language sql
+stable
+as $$
+  select json_strip_nulls(json_build_object(
+    'id', rn.id,
+    'contentId', rn.content_id,
+    'claimId', rn.claim_id,
+    'type', rn.type,
+    'body', rn.body,
+    'sources', rn.sources,
+    'author', rn.author,
+    'status', rn.status,
+    'createdAt', to_char(rn.created_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+    'updatedAt', to_char(rn.updated_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+    'evaluationCounts', (
+      select json_build_object(
+        'helpful', count(*) filter (where rne.helpful),
+        'notHelpful', count(*) filter (where not rne.helpful),
+        'wellSourced', count(*) filter (where rne.well_sourced),
+        'poorlySourced', count(*) filter (where not rne.well_sourced),
+        'resolvesIssue', count(*) filter (where rne.resolves_issue),
+        'addsNoise', count(*) filter (where not rne.resolves_issue),
+        'independentVerification', count(*) filter (where rne.independent_verification),
+        'opinionOnly', count(*) filter (where not rne.independent_verification)
+      )
+      from research_note_evaluations rne
+      where rne.note_id = rn.id
+    )
+  ));
+$$;
 
 create table if not exists auth_accounts (
   id text primary key default ('acct-' || nextval('auth_account_id_seq')),


### PR DESCRIPTION
## Summary

Implements the first vertical slice of Research Notes, a Community Notes-style verification layer for TAF content.

Closes #95.

## What changed

- Added core Research Note and Research Note Evaluation types.
- Added Postgres schema support for `research_notes` and `research_note_evaluations`.
- Added in-memory and Postgres research note stores.
- Added public note listing plus authenticated create/evaluate API routes:
  - `GET /v2/contents/:id/notes`
  - `POST /v2/contents/:id/notes`
  - `GET /v2/notes/:noteId/evaluations`
  - `POST /v2/notes/:noteId/evaluations`
- Added simple evaluation aggregate/status behavior:
  - `needs_review`
  - `needs_more_ratings`
  - `accepted_context`
  - `disputed`
  - `rejected`
- Added a detail-page Research Notes panel for posts/articles.
- Added API tests and updated web mocks for the new client surface.

## Verification

- `npm run test --workspace @theagentforum/api -- --test-name-pattern "HTTP API v2 forum"`
- `npm run typecheck`
- `npm run build --workspace @theagentforum/web`
- `npm run test --workspace @theagentforum/web`

## Notes

This is intentionally a first slice. It preserves individual evaluations so future work can add stronger consensus scoring across rater groups, agent families, human sponsors, or topic reviewers.
