### PR TITLE
Add content comments, likes, and event notifications

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -8,6 +8,7 @@ import type {
   CreateQuestionInput,
   CreateContentInput,
   CreateCommentInput,
+  ContentReactionType,
   FinishAuthenticationInput,
   FinishRegistrationInput,
   CreateResearchNoteInput,
@@ -23,6 +24,8 @@ import type { AuthStore } from "./auth-store";
 import type { ArticleStore } from "./article-store";
 import type { QuestionStore } from "./question-store";
 import type { ForumStore } from "./forum-store";
+import type { EngagementStore } from "./engagement-store";
+import { createInMemoryEngagementStore } from "./memory-engagement-store";
 import { createForumAdapter } from "./forum-adapter";
 import { createInMemoryResearchNoteStore } from "./memory-research-note-store";
 import type { ResearchNoteStore } from "./research-note-store";
@@ -47,6 +50,7 @@ interface CreateAppOptions {
   corsAllowOrigin?: string;
   rateLimiter?: RateLimitService;
   researchNoteStore?: ResearchNoteStore;
+  engagementStore?: EngagementStore;
 }
 
 const SESSION_COOKIE_NAME = "taf_session";
@@ -60,6 +64,7 @@ export function createApp(
   const forumStore: ForumStore = createForumAdapter(questionStore, options.articleStore);
   const rateLimiter = options.rateLimiter ?? createNoopRateLimitService();
   const researchNoteStore = options.researchNoteStore ?? createInMemoryResearchNoteStore();
+  const engagementStore = options.engagementStore ?? createInMemoryEngagementStore();
 
   return async function app(
     req: IncomingMessage,
@@ -73,6 +78,7 @@ export function createApp(
         authStore,
         forumStore,
         researchNoteStore,
+        engagementStore,
         rateLimiter,
         req,
         res,
@@ -117,6 +123,7 @@ async function routeRequest(
   authStore: AuthStore,
   forumStore: ForumStore,
   researchNoteStore: ResearchNoteStore,
+  engagementStore: EngagementStore,
   rateLimiter: RateLimitService,
   req: IncomingMessage,
   res: ServerResponse,
@@ -711,6 +718,73 @@ async function routeRequest(
     return;
   }
 
+  const contentReactionsMatch = matchPath(path, /^\/v2\/contents\/([^/]+)\/reactions$/);
+
+  if (method === "GET" && contentReactionsMatch) {
+    const contentId = contentReactionsMatch[1];
+    const thread = await forumStore.getContentThread(contentId);
+
+    if (!thread) {
+      sendError(res, corsHeaders, 404, "content_not_found", "Content not found.");
+      return;
+    }
+
+    sendJson(res, corsHeaders, 200, {
+      ok: true,
+      data: await engagementStore.getReactionState(contentId, authenticatedSession?.actor.id),
+    });
+    return;
+  }
+
+  const contentReactionMatch = matchPath(path, /^\/v2\/contents\/([^/]+)\/reactions\/([^/]+)$/);
+
+  if ((method === "POST" || method === "PUT") && contentReactionMatch) {
+    const actor = requireAuthenticatedActor(authenticatedSession);
+    const contentId = contentReactionMatch[1];
+    const reactionType = parseContentReactionType(contentReactionMatch[2]);
+    const thread = await forumStore.getContentThread(contentId);
+
+    if (!thread) {
+      sendError(res, corsHeaders, 404, "content_not_found", "Content not found.");
+      return;
+    }
+
+    sendJson(res, corsHeaders, 200, {
+      ok: true,
+      data: await engagementStore.addReaction(contentId, reactionType, actor),
+    });
+    return;
+  }
+
+  if (method === "DELETE" && contentReactionMatch) {
+    const actor = requireAuthenticatedActor(authenticatedSession);
+    const contentId = contentReactionMatch[1];
+    const reactionType = parseContentReactionType(contentReactionMatch[2]);
+    const thread = await forumStore.getContentThread(contentId);
+
+    if (!thread) {
+      sendError(res, corsHeaders, 404, "content_not_found", "Content not found.");
+      return;
+    }
+
+    sendJson(res, corsHeaders, 200, {
+      ok: true,
+      data: await engagementStore.removeReaction(contentId, reactionType, actor),
+    });
+    return;
+  }
+
+  if (method === "GET" && path === "/v2/events") {
+    const contentId = readOptionalString(url.searchParams.get("contentId"), "contentId");
+    const limit = readOptionalPositiveInteger(url.searchParams.get("limit"), "limit") ?? 50;
+
+    sendJson(res, corsHeaders, 200, {
+      ok: true,
+      data: await engagementStore.listEvents({ contentId, limit }),
+    });
+    return;
+  }
+
   const contentNotesMatch = matchPath(path, /^\/v2\/contents\/([^/]+)\/notes$/);
 
   if (method === "GET" && contentNotesMatch) {
@@ -805,6 +879,16 @@ async function routeRequest(
     if (!thread) {
       sendError(res, corsHeaders, 404, "content_not_found", "Content not found.");
       return;
+    }
+
+    const createdComment = thread.comments[thread.comments.length - 1];
+    if (createdComment) {
+      await engagementStore.recordEvent({
+        type: "content_comment_created",
+        contentId: commentsMatch[1],
+        commentId: createdComment.id,
+        actor,
+      });
     }
 
     sendJson(res, corsHeaders, 201, { ok: true, data: thread });
@@ -1714,6 +1798,16 @@ function parseCreateCommentInput(payload: unknown): CreateCommentInput {
     body: readRequiredString(input.body, "body"),
     author: parseActor(input.author),
   };
+}
+
+function parseContentReactionType(value: string): ContentReactionType {
+  const decoded = decodeURIComponent(value);
+
+  if (decoded !== "like") {
+    throw createHttpError(400, "validation_error", "reaction type must be: like.");
+  }
+
+  return decoded;
 }
 
 const researchNoteTypes: ResearchNoteType[] = [

--- a/apps/api/src/article-store.ts
+++ b/apps/api/src/article-store.ts
@@ -1,4 +1,4 @@
-import type { ArticleContent, Actor } from "@theagentforum/core";
+import type { ArticleContent, Actor, Comment } from "@theagentforum/core";
 
 export interface CreateArticleInput {
   title: string;
@@ -10,4 +10,6 @@ export interface ArticleStore {
   listArticles(): Promise<ArticleContent[]>;
   createArticle(input: CreateArticleInput): Promise<ArticleContent>;
   getArticle(articleId: string): Promise<ArticleContent | null>;
+  listArticleComments(articleId: string): Promise<Comment[] | null>;
+  createArticleComment(articleId: string, input: { body: string; author: Actor }): Promise<Comment[] | null>;
 }

--- a/apps/api/src/engagement-store.ts
+++ b/apps/api/src/engagement-store.ts
@@ -1,0 +1,23 @@
+import type {
+  Actor,
+  ContentEvent,
+  ContentEventType,
+  ContentReactionState,
+  ContentReactionType,
+} from "@theagentforum/core";
+
+export interface RecordContentEventInput {
+  type: ContentEventType;
+  contentId: string;
+  actor: Actor;
+  commentId?: string;
+  reactionType?: ContentReactionType;
+}
+
+export interface EngagementStore {
+  getReactionState(contentId: string, actorId?: string): Promise<ContentReactionState>;
+  addReaction(contentId: string, reactionType: ContentReactionType, actor: Actor): Promise<ContentReactionState>;
+  removeReaction(contentId: string, reactionType: ContentReactionType, actor: Actor): Promise<ContentReactionState>;
+  recordEvent(input: RecordContentEventInput): Promise<ContentEvent>;
+  listEvents(options?: { contentId?: string; limit?: number }): Promise<ContentEvent[]>;
+}

--- a/apps/api/src/forum-adapter.ts
+++ b/apps/api/src/forum-adapter.ts
@@ -130,7 +130,9 @@ export function createForumAdapter(
   async function getContentThread(contentId: string): Promise<ContentThread | null> {
     if (isArticleId(contentId)) {
       const article = await articleStore.getArticle(contentId);
-      return article ? { content: article, comments: [] } : null;
+      if (!article) return null;
+      const comments = await articleStore.listArticleComments(contentId);
+      return { content: article, comments: comments ?? [] };
     }
 
     if (!isQuestionId(contentId)) {
@@ -146,6 +148,13 @@ export function createForumAdapter(
     contentId: string,
     input: CreateCommentInput,
   ): Promise<ContentThread | null> {
+    if (isArticleId(contentId)) {
+      const article = await articleStore.getArticle(contentId);
+      if (!article) return null;
+      const comments = await articleStore.createArticleComment(contentId, input);
+      return comments ? { content: article, comments } : null;
+    }
+
     if (!isQuestionId(contentId)) {
       return null;
     }

--- a/apps/api/src/http.v2.test.ts
+++ b/apps/api/src/http.v2.test.ts
@@ -150,6 +150,74 @@ describe("HTTP API v2 forum", () => {
     assert.deepEqual(search.body.data.matches[0].matchSources, ["body"]);
   });
 
+  it("lets authenticated users comment on articles, react, and poll content events", async () => {
+    const authStore = createInMemoryAuthStore();
+    const app = createApp(createInMemoryQuestionStore(), authStore);
+    const cookieHeader = await createAuthenticatedCookie(authStore, {
+      handle: "article-reader",
+      displayName: "Article Reader",
+    });
+
+    const article = await requestJson(app, "/v2/contents", {
+      method: "POST",
+      headers: { cookie: cookieHeader },
+      body: {
+        type: "article",
+        title: "Commentable article",
+        body: "A durable article body.",
+        author: spoofedAgent,
+      },
+    });
+    assert.equal(article.status, 201);
+
+    const anonymousComment = await requestJson(app, `/v2/contents/${article.body.data.id}/comments`, {
+      method: "POST",
+      body: { body: "Anonymous comment", author: spoofedHuman },
+    });
+    assert.equal(anonymousComment.status, 401);
+
+    const commented = await requestJson(app, `/v2/contents/${article.body.data.id}/comments`, {
+      method: "POST",
+      headers: { cookie: cookieHeader },
+      body: { body: "This article should allow comments.", author: spoofedHuman },
+    });
+    assert.equal(commented.status, 201);
+    assert.equal(commented.body.data.content.type, "article");
+    assert.equal(commented.body.data.comments.length, 1);
+    assert.match(commented.body.data.comments[0].id, /^ac-/);
+    assert.equal(commented.body.data.comments[0].author.handle, "article-reader");
+
+    const liked = await requestJson(app, `/v2/contents/${article.body.data.id}/reactions/like`, {
+      method: "POST",
+      headers: { cookie: cookieHeader },
+    });
+    assert.equal(liked.status, 200);
+    assert.deepEqual(liked.body.data.reactions, [{ type: "like", count: 1 }]);
+    assert.deepEqual(liked.body.data.myReactions, ["like"]);
+
+    const listedReactions = await requestJson(app, `/v2/contents/${article.body.data.id}/reactions`, {
+      headers: { cookie: cookieHeader },
+    });
+    assert.equal(listedReactions.status, 200);
+    assert.deepEqual(listedReactions.body.data.myReactions, ["like"]);
+
+    const events = await requestJson(app, `/v2/events?contentId=${article.body.data.id}&limit=10`);
+    assert.equal(events.status, 200);
+    assert.deepEqual(
+      events.body.data.map((event: any) => event.type),
+      ["content_reaction_added", "content_comment_created"],
+    );
+    assert.equal(events.body.data[1].commentId, commented.body.data.comments[0].id);
+
+    const unliked = await requestJson(app, `/v2/contents/${article.body.data.id}/reactions/like`, {
+      method: "DELETE",
+      headers: { cookie: cookieHeader },
+    });
+    assert.equal(unliked.status, 200);
+    assert.deepEqual(unliked.body.data.reactions, []);
+    assert.deepEqual(unliked.body.data.myReactions, []);
+  });
+
   it("creates, lists, and evaluates research notes for content", async () => {
     const authStore = createInMemoryAuthStore();
     const app = createApp(createInMemoryQuestionStore(), authStore);

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -2,6 +2,7 @@ import { createServer } from "node:http";
 import { createApp } from "./app";
 import { createPostgresArticleStore } from "./postgres-article-store";
 import { createPostgresAuthStore } from "./postgres-auth-store";
+import { createPostgresEngagementStore } from "./postgres-engagement-store";
 import { createPostgresRateLimitStore } from "./postgres-rate-limit-store";
 import { createPostgresQuestionStore } from "./postgres-question-store";
 import { createPostgresResearchNoteStore } from "./postgres-research-note-store";
@@ -18,11 +19,13 @@ async function main(): Promise<void> {
   const authStore = createPostgresAuthStore();
   const articleStore = createPostgresArticleStore();
   const researchNoteStore = createPostgresResearchNoteStore();
+  const engagementStore = createPostgresEngagementStore();
   const rateLimiter = createRateLimitService(createPostgresRateLimitStore(), {
     eventSink: createConsoleServerEventSink(),
   });
   const app = createApp(questionStore, authStore, {
     articleStore,
+    engagementStore,
     researchNoteStore,
     corsAllowOrigin,
     rateLimiter,

--- a/apps/api/src/memory-article-store.ts
+++ b/apps/api/src/memory-article-store.ts
@@ -1,9 +1,11 @@
-import type { ArticleContent } from "@theagentforum/core";
+import type { Actor, ArticleContent, Comment } from "@theagentforum/core";
 import type { ArticleStore, CreateArticleInput } from "./article-store";
 
 export function createInMemoryArticleStore(): ArticleStore {
   const articles = new Map<string, ArticleContent>();
+  const comments = new Map<string, Comment[]>();
   let articleSequence = 1;
+  let commentSequence = 1;
 
   async function listArticles(): Promise<ArticleContent[]> {
     return Array.from(articles.values()).sort(compareByCreatedAtDesc).map(cloneArticle);
@@ -20,6 +22,7 @@ export function createInMemoryArticleStore(): ArticleStore {
     };
 
     articles.set(article.id, article);
+    comments.set(article.id, []);
     return cloneArticle(article);
   }
 
@@ -28,13 +31,49 @@ export function createInMemoryArticleStore(): ArticleStore {
     return article ? cloneArticle(article) : null;
   }
 
-  return { listArticles, createArticle, getArticle };
+  async function listArticleComments(articleId: string): Promise<Comment[] | null> {
+    if (!articles.has(articleId)) {
+      return null;
+    }
+
+    return (comments.get(articleId) ?? []).map(cloneComment);
+  }
+
+  async function createArticleComment(
+    articleId: string,
+    input: { body: string; author: Actor },
+  ): Promise<Comment[] | null> {
+    if (!articles.has(articleId)) {
+      return null;
+    }
+
+    const comment: Comment = {
+      id: `ac-${commentSequence++}`,
+      contentId: articleId,
+      body: input.body,
+      author: input.author,
+      createdAt: new Date().toISOString(),
+    };
+
+    const nextComments = [...(comments.get(articleId) ?? []), comment];
+    comments.set(articleId, nextComments);
+    return nextComments.map(cloneComment);
+  }
+
+  return { listArticles, createArticle, getArticle, listArticleComments, createArticleComment };
 }
 
 function cloneArticle(article: ArticleContent): ArticleContent {
   return {
     ...article,
     author: { ...article.author },
+  };
+}
+
+function cloneComment(comment: Comment): Comment {
+  return {
+    ...comment,
+    author: { ...comment.author },
   };
 }
 

--- a/apps/api/src/memory-engagement-store.ts
+++ b/apps/api/src/memory-engagement-store.ts
@@ -1,0 +1,103 @@
+import type {
+  Actor,
+  ContentEvent,
+  ContentReactionState,
+  ContentReactionSummary,
+  ContentReactionType,
+} from "@theagentforum/core";
+import type { EngagementStore, RecordContentEventInput } from "./engagement-store";
+
+interface StoredReaction {
+  contentId: string;
+  reactionType: ContentReactionType;
+  author: Actor;
+  createdAt: string;
+}
+
+export function createInMemoryEngagementStore(): EngagementStore {
+  const reactions = new Map<string, StoredReaction>();
+  const events: ContentEvent[] = [];
+  let eventSequence = 1;
+
+  async function getReactionState(contentId: string, actorId?: string): Promise<ContentReactionState> {
+    return buildReactionState(contentId, actorId);
+  }
+
+  async function addReaction(
+    contentId: string,
+    reactionType: ContentReactionType,
+    actor: Actor,
+  ): Promise<ContentReactionState> {
+    reactions.set(reactionKey(contentId, reactionType, actor.id), {
+      contentId,
+      reactionType,
+      author: actor,
+      createdAt: new Date().toISOString(),
+    });
+    await recordEvent({ type: "content_reaction_added", contentId, reactionType, actor });
+    return buildReactionState(contentId, actor.id);
+  }
+
+  async function removeReaction(
+    contentId: string,
+    reactionType: ContentReactionType,
+    actor: Actor,
+  ): Promise<ContentReactionState> {
+    reactions.delete(reactionKey(contentId, reactionType, actor.id));
+    await recordEvent({ type: "content_reaction_removed", contentId, reactionType, actor });
+    return buildReactionState(contentId, actor.id);
+  }
+
+  async function recordEvent(input: RecordContentEventInput): Promise<ContentEvent> {
+    const event: ContentEvent = {
+      id: `ce-${eventSequence++}`,
+      type: input.type,
+      contentId: input.contentId,
+      commentId: input.commentId,
+      reactionType: input.reactionType,
+      actor: { ...input.actor },
+      createdAt: new Date().toISOString(),
+    };
+    events.unshift(event);
+    return cloneEvent(event);
+  }
+
+  async function listEvents(options: { contentId?: string; limit?: number } = {}): Promise<ContentEvent[]> {
+    return events
+      .filter((event) => !options.contentId || event.contentId === options.contentId)
+      .slice(0, options.limit ?? 50)
+      .map(cloneEvent);
+  }
+
+  function buildReactionState(contentId: string, actorId?: string): ContentReactionState {
+    const matching = Array.from(reactions.values()).filter((reaction) => reaction.contentId === contentId);
+    const summaries = new Map<ContentReactionType, number>();
+    const myReactions = new Set<ContentReactionType>();
+
+    for (const reaction of matching) {
+      summaries.set(reaction.reactionType, (summaries.get(reaction.reactionType) ?? 0) + 1);
+      if (actorId && reaction.author.id === actorId) {
+        myReactions.add(reaction.reactionType);
+      }
+    }
+
+    return {
+      contentId,
+      reactions: Array.from(summaries.entries()).map(([type, count]): ContentReactionSummary => ({ type, count })),
+      myReactions: Array.from(myReactions),
+    };
+  }
+
+  return { getReactionState, addReaction, removeReaction, recordEvent, listEvents };
+}
+
+function reactionKey(contentId: string, reactionType: ContentReactionType, authorId: string): string {
+  return `${contentId}:${reactionType}:${authorId}`;
+}
+
+function cloneEvent(event: ContentEvent): ContentEvent {
+  return {
+    ...event,
+    actor: { ...event.actor },
+  };
+}

--- a/apps/api/src/postgres-article-store.ts
+++ b/apps/api/src/postgres-article-store.ts
@@ -1,9 +1,9 @@
-import type { ArticleContent } from "@theagentforum/core";
+import type { Actor, ArticleContent, Comment } from "@theagentforum/core";
 import type { ArticleStore, CreateArticleInput } from "./article-store";
 import { runSql } from "./postgres";
 
 export function createPostgresArticleStore(): ArticleStore {
-  return { listArticles, createArticle, getArticle };
+  return { listArticles, createArticle, getArticle, listArticleComments, createArticleComment };
 }
 
 async function listArticles(): Promise<ArticleContent[]> {
@@ -70,6 +70,64 @@ async function getArticle(articleId: string): Promise<ArticleContent | null> {
   }
 
   return JSON.parse(output) as ArticleContent;
+}
+
+async function listArticleComments(articleId: string): Promise<Comment[] | null> {
+  const output = await runSql(
+    `
+      select coalesce(json_agg(comment order by created_at), '[]'::json) :: text
+      from (
+        select
+          json_strip_nulls(json_build_object(
+            'id', c.id,
+            'contentId', c.article_id,
+            'body', c.body,
+            'author', c.author,
+            'createdAt', to_char(c.created_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+          )) as comment,
+          c.created_at
+        from article_comments c
+        where c.article_id = :'article_id'
+        order by c.created_at
+      ) listed
+      where exists (select 1 from articles a where a.id = :'article_id');
+    `,
+    { article_id: articleId },
+  );
+
+  if (!output) {
+    return null;
+  }
+
+  return JSON.parse(output) as Comment[];
+}
+
+async function createArticleComment(
+  articleId: string,
+  input: { body: string; author: Actor },
+): Promise<Comment[] | null> {
+  const articleExists = await runSql(
+    `select 'true' where exists (select 1 from articles where id = :'article_id');`,
+    { article_id: articleId },
+  );
+
+  if (!articleExists) {
+    return null;
+  }
+
+  await runSql(
+    `
+      insert into article_comments (article_id, body, author)
+      values (:'article_id', :'body', cast(:'author' as jsonb));
+    `,
+    {
+      article_id: articleId,
+      body: input.body,
+      author: JSON.stringify(input.author),
+    },
+  );
+
+  return listArticleComments(articleId);
 }
 
 async function queryJson<T>(sql: string, variables?: Record<string, string>): Promise<T> {

--- a/apps/api/src/postgres-engagement-store.ts
+++ b/apps/api/src/postgres-engagement-store.ts
@@ -1,0 +1,155 @@
+import type {
+  Actor,
+  ContentEvent,
+  ContentReactionState,
+  ContentReactionType,
+} from "@theagentforum/core";
+import type { EngagementStore, RecordContentEventInput } from "./engagement-store";
+import { runSql } from "./postgres";
+
+export function createPostgresEngagementStore(): EngagementStore {
+  return { getReactionState, addReaction, removeReaction, recordEvent, listEvents };
+}
+
+async function getReactionState(contentId: string, actorId?: string): Promise<ContentReactionState> {
+  const output = await runSql(
+    `
+      with reaction_counts as (
+        select reaction_type, count(*)::int as count
+        from content_reactions
+        where content_id = :'content_id'
+        group by reaction_type
+      ),
+      my_reactions as (
+        select reaction_type
+        from content_reactions
+        where content_id = :'content_id'
+          and author_id = :'actor_id'
+      )
+      select json_build_object(
+        'contentId', :'content_id',
+        'reactions', coalesce((
+          select json_agg(json_build_object('type', reaction_type, 'count', count) order by reaction_type)
+          from reaction_counts
+        ), '[]'::json),
+        'myReactions', coalesce((
+          select json_agg(reaction_type order by reaction_type)
+          from my_reactions
+        ), '[]'::json)
+      ) :: text;
+    `,
+    { content_id: contentId, actor_id: actorId ?? "" },
+  );
+
+  return JSON.parse(output) as ContentReactionState;
+}
+
+async function addReaction(
+  contentId: string,
+  reactionType: ContentReactionType,
+  actor: Actor,
+): Promise<ContentReactionState> {
+  await runSql(
+    `
+      insert into content_reactions (content_id, reaction_type, author_id, author)
+      values (:'content_id', :'reaction_type', :'author_id', cast(:'author' as jsonb))
+      on conflict (content_id, reaction_type, author_id)
+      do update set author = excluded.author;
+    `,
+    {
+      content_id: contentId,
+      reaction_type: reactionType,
+      author_id: actor.id,
+      author: JSON.stringify(actor),
+    },
+  );
+  await recordEvent({ type: "content_reaction_added", contentId, reactionType, actor });
+  return getReactionState(contentId, actor.id);
+}
+
+async function removeReaction(
+  contentId: string,
+  reactionType: ContentReactionType,
+  actor: Actor,
+): Promise<ContentReactionState> {
+  await runSql(
+    `
+      delete from content_reactions
+      where content_id = :'content_id'
+        and reaction_type = :'reaction_type'
+        and author_id = :'author_id';
+    `,
+    {
+      content_id: contentId,
+      reaction_type: reactionType,
+      author_id: actor.id,
+    },
+  );
+  await recordEvent({ type: "content_reaction_removed", contentId, reactionType, actor });
+  return getReactionState(contentId, actor.id);
+}
+
+async function recordEvent(input: RecordContentEventInput): Promise<ContentEvent> {
+  const output = await runSql(
+    `
+      insert into content_events (type, content_id, comment_id, reaction_type, actor)
+      values (
+        :'type',
+        :'content_id',
+        nullif(:'comment_id', ''),
+        nullif(:'reaction_type', ''),
+        cast(:'actor' as jsonb)
+      )
+      returning json_strip_nulls(json_build_object(
+        'id', id,
+        'type', type,
+        'contentId', content_id,
+        'commentId', comment_id,
+        'reactionType', reaction_type,
+        'actor', actor,
+        'createdAt', to_char(created_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+      )) :: text;
+    `,
+    {
+      type: input.type,
+      content_id: input.contentId,
+      comment_id: input.commentId ?? "",
+      reaction_type: input.reactionType ?? "",
+      actor: JSON.stringify(input.actor),
+    },
+  );
+
+  return JSON.parse(output) as ContentEvent;
+}
+
+async function listEvents(options: { contentId?: string; limit?: number } = {}): Promise<ContentEvent[]> {
+  const output = await runSql(
+    `
+      select coalesce(json_agg(event order by created_at desc, id desc), '[]'::json) :: text
+      from (
+        select
+          json_strip_nulls(json_build_object(
+            'id', id,
+            'type', type,
+            'contentId', content_id,
+            'commentId', comment_id,
+            'reactionType', reaction_type,
+            'actor', actor,
+            'createdAt', to_char(created_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+          )) as event,
+          created_at,
+          id
+        from content_events
+        where (:'content_id' = '' or content_id = :'content_id')
+        order by created_at desc, id desc
+        limit (:'limit')::int
+      ) listed;
+    `,
+    {
+      content_id: options.contentId ?? "",
+      limit: String(options.limit ?? 50),
+    },
+  );
+
+  return JSON.parse(output) as ContentEvent[];
+}

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -1,11 +1,14 @@
 export { createPostgresArticleStore } from "./postgres-article-store";
 export { createPostgresQuestionStore, createPostgresQuestionStore as createQuestionStore } from "./postgres-question-store";
 export { createPostgresResearchNoteStore } from "./postgres-research-note-store";
+export { createPostgresEngagementStore } from "./postgres-engagement-store";
 export { createInMemoryArticleStore } from "./memory-article-store";
 export { createInMemoryQuestionStore } from "./memory-question-store";
 export { createInMemoryResearchNoteStore } from "./memory-research-note-store";
+export { createInMemoryEngagementStore } from "./memory-engagement-store";
 export { createPostgresAuthStore } from "./postgres-auth-store";
 export { createInMemoryAuthStore } from "./memory-auth-store";
 export type { QuestionStore, QuestionThread } from "./question-store";
 export type { ResearchNoteStore } from "./research-note-store";
+export type { EngagementStore } from "./engagement-store";
 export type { AuthStore } from "./auth-store";

--- a/apps/web/src/components/AnswerForm.tsx
+++ b/apps/web/src/components/AnswerForm.tsx
@@ -8,12 +8,20 @@ interface AnswerFormProps {
   onSubmit(values: AnswerFormValues): Promise<void> | void;
   disabled?: boolean;
   authorLabel?: string;
+  bodyLabel?: string;
+  placeholder?: string;
+  submitLabel?: string;
+  submittingLabel?: string;
 }
 
 export function AnswerForm({
   onSubmit,
   disabled = false,
   authorLabel,
+  bodyLabel = "Answer",
+  placeholder = "Share a practical solution...",
+  submitLabel = "Post answer",
+  submittingLabel = "Posting...",
 }: AnswerFormProps) {
   const [body, setBody] = useState("");
   const [submitting, setSubmitting] = useState(false);
@@ -49,13 +57,13 @@ export function AnswerForm({
       ) : null}
 
       <div className="field">
-        <label htmlFor="answer-body">Answer</label>
+        <label htmlFor="answer-body">{bodyLabel}</label>
         <textarea
           id="answer-body"
           value={body}
           onChange={(event) => setBody(event.target.value)}
           rows={7}
-          placeholder="Share a practical solution..."
+          placeholder={placeholder}
           disabled={isDisabled}
           aria-describedby={answerHintId}
         />
@@ -65,7 +73,7 @@ export function AnswerForm({
       </div>
 
       <button type="submit" className="button" disabled={isDisabled}>
-        {submitting ? "Posting..." : "Post answer"}
+        {submitting ? submittingLabel : submitLabel}
       </button>
     </form>
   );

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -83,6 +83,29 @@ export interface ForumSearchResult {
   matches: ForumSearchMatch[];
 }
 
+export type ContentReactionType = "like";
+
+export interface ContentReactionSummary {
+  type: ContentReactionType;
+  count: number;
+}
+
+export interface ContentReactionState {
+  contentId: string;
+  reactions: ContentReactionSummary[];
+  myReactions: ContentReactionType[];
+}
+
+export interface ContentEvent {
+  id: string;
+  type: "content_comment_created" | "content_reaction_added" | "content_reaction_removed";
+  contentId: string;
+  commentId?: string;
+  reactionType?: ContentReactionType;
+  actor: Question["author"];
+  createdAt: string;
+}
+
 export type ResearchNoteType =
   | "missing_context"
   | "weak_source"
@@ -255,6 +278,48 @@ export function createApiClient(baseUrl = defaultBaseUrl) {
     );
 
     return mapContentThreadToQuestionThread(thread);
+  }
+
+  async function listContentReactions(contentId: string): Promise<ContentReactionState> {
+    return request<ContentReactionState>(
+      "GET",
+      `/v2/contents/${encodeURIComponent(contentId)}/reactions`,
+    );
+  }
+
+  async function addContentReaction(
+    contentId: string,
+    reactionType: ContentReactionType,
+  ): Promise<ContentReactionState> {
+    return request<ContentReactionState>(
+      "POST",
+      `/v2/contents/${encodeURIComponent(contentId)}/reactions/${encodeURIComponent(reactionType)}`,
+    );
+  }
+
+  async function removeContentReaction(
+    contentId: string,
+    reactionType: ContentReactionType,
+  ): Promise<ContentReactionState> {
+    return request<ContentReactionState>(
+      "DELETE",
+      `/v2/contents/${encodeURIComponent(contentId)}/reactions/${encodeURIComponent(reactionType)}`,
+    );
+  }
+
+  async function listContentEvents(options: { contentId?: string; limit?: number } = {}): Promise<ContentEvent[]> {
+    const params = new URLSearchParams();
+
+    if (options.contentId) {
+      params.set("contentId", options.contentId);
+    }
+
+    if (options.limit !== undefined) {
+      params.set("limit", String(options.limit));
+    }
+
+    const query = params.toString();
+    return request<ContentEvent[]>("GET", `/v2/events${query ? `?${query}` : ""}`);
   }
 
   async function listResearchNotes(contentId: string): Promise<ResearchNote[]> {
@@ -478,6 +543,10 @@ export function createApiClient(baseUrl = defaultBaseUrl) {
     getQuestionThread,
     createAnswer,
     acceptAnswer,
+    listContentReactions,
+    addContentReaction,
+    removeContentReaction,
+    listContentEvents,
     listResearchNotes,
     createResearchNote,
     evaluateResearchNote,

--- a/apps/web/src/pages/TerminalGraphPages.test.tsx
+++ b/apps/web/src/pages/TerminalGraphPages.test.tsx
@@ -162,6 +162,22 @@ function buildApi(overrides: Partial<ApiClient> = {}): ApiClient {
       ...thread,
       question: { ...thread.question, acceptedAnswerId: "a-1", status: "answered" },
     }),
+    listContentReactions: vi.fn().mockResolvedValue({
+      contentId: "context-protocols",
+      reactions: [],
+      myReactions: [],
+    }),
+    addContentReaction: vi.fn().mockResolvedValue({
+      contentId: "context-protocols",
+      reactions: [{ type: "like", count: 1 }],
+      myReactions: ["like"],
+    }),
+    removeContentReaction: vi.fn().mockResolvedValue({
+      contentId: "context-protocols",
+      reactions: [],
+      myReactions: [],
+    }),
+    listContentEvents: vi.fn().mockResolvedValue([]),
     listResearchNotes: vi.fn().mockResolvedValue([]),
     createResearchNote: vi.fn(),
     evaluateResearchNote: vi.fn(),
@@ -485,7 +501,7 @@ describe("TerminalGraphPages", () => {
       expect(screen.getByRole("table").closest(".markdown-table-scroll")).toBeInTheDocument();
       expect(container.querySelector(".katex")).toBeInTheDocument();
       expect(screen.getByRole("complementary", { name: /article tools/i })).toBeInTheDocument();
-      expect(screen.queryByRole("heading", { name: /post an answer/i })).not.toBeInTheDocument();
+      expect(screen.getByRole("heading", { name: /post a comment/i })).toBeInTheDocument();
       const toc = screen.getByRole("complementary", { name: /article table of contents/i });
       expect(within(toc).getByRole("link", { name: "Abstract" })).toHaveAttribute("href", "#abstract");
       expect(within(toc).getByRole("link", { name: "Introduction" })).toHaveAttribute("href", "#introduction");

--- a/apps/web/src/pages/TerminalGraphPages.tsx
+++ b/apps/web/src/pages/TerminalGraphPages.tsx
@@ -4,7 +4,7 @@ import { useAuth } from "../auth/AuthContext";
 import { AuthRequiredPanel } from "../components/AuthRequiredPanel";
 import { CreateQuestionForm, type CreateQuestionFormValues } from "../components/CreateQuestionForm";
 import { TerminalPage } from "../components/TerminalChrome";
-import type { ApiClient, ForumContent, ForumSearchResult, ResearchNote, ResearchNoteType } from "../lib/api";
+import type { ApiClient, ContentReactionState, ForumContent, ForumSearchResult, ResearchNote, ResearchNoteType } from "../lib/api";
 import { useAuthNavigation } from "../lib/auth-routing";
 import type { Answer, AnswerSkill, Question, QuestionThread } from "../types";
 import { AnswerForm, type AnswerFormValues } from "../components/AnswerForm";
@@ -959,6 +959,8 @@ export function PostDetailPage({ api }: PostDetailPageProps) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [acceptingAnswerId, setAcceptingAnswerId] = useState<string | null>(null);
+  const [reactionState, setReactionState] = useState<ContentReactionState | null>(null);
+  const [reactionBusy, setReactionBusy] = useState(false);
 
   useEffect(() => {
     void refreshThread();
@@ -982,6 +984,7 @@ export function PostDetailPage({ api }: PostDetailPageProps) {
       ]);
       setThread(nextThread);
       setResearchNotes(nextNotes);
+      setReactionState(await api.listContentReactions(resolvedId));
 
       const nextSkills = Object.fromEntries(
         await Promise.all(
@@ -998,6 +1001,7 @@ export function PostDetailPage({ api }: PostDetailPageProps) {
       setThread(null);
       setAnswerSkills({});
       setResearchNotes([]);
+      setReactionState(null);
     } finally {
       setLoading(false);
       setNotesLoading(false);
@@ -1064,11 +1068,44 @@ export function PostDetailPage({ api }: PostDetailPageProps) {
     }
   }
 
+  async function handleToggleLike(): Promise<void> {
+    if (!thread || !auth.session || reactionBusy) {
+      return;
+    }
+
+    const contentId = thread.question.id;
+    const liked = reactionState?.myReactions.includes("like") ?? false;
+    setReactionBusy(true);
+    setError(null);
+
+    try {
+      setReactionState(
+        liked
+          ? await api.removeContentReaction(contentId, "like")
+          : await api.addContentReaction(contentId, "like"),
+      );
+      captureClientEvent(liked ? "taf_content_unliked" : "taf_content_liked", {
+        content_id: contentId,
+      });
+    } catch (cause) {
+      const message = readErrorMessage(cause);
+      setError(message);
+      captureClientEvent("taf_content_reaction_failed", {
+        content_id: contentId,
+        error_message: message,
+      });
+    } finally {
+      setReactionBusy(false);
+    }
+  }
+
   const skillCount = useMemo(
     () => Object.values(answerSkills).reduce((total, skills) => total + skills.length, 0),
     [answerSkills],
   );
   const isArticle = resolvedId?.startsWith("art-") ?? false;
+  const likeCount = reactionState?.reactions.find((reaction) => reaction.type === "like")?.count ?? 0;
+  const likedByMe = reactionState?.myReactions.includes("like") ?? false;
   const contentListPath = isArticle ? "/forum?type=article" : "/forum?type=question";
   const contentListLabel = isArticle ? "articles" : "posts";
   const currentBreadcrumbLabel = thread?.question.title ?? resolvedId ?? "missing";
@@ -1112,9 +1149,22 @@ export function PostDetailPage({ api }: PostDetailPageProps) {
                 <KindBadge kind={thread.question.author.kind} />
                 {isArticle ? <span>{formatDate(thread.question.createdAt)}</span> : <span>{thread.question.status}</span>}
                 <span>{thread.answers.length} comments</span>
+                <span>{likeCount} likes</span>
                 <span>{skillCount} runnable skills linked</span>
               </div>
               <h1>{thread.question.title}</h1>
+              {auth.ready && auth.session ? (
+                <button
+                  type="button"
+                  className="terminal-mini-button"
+                  disabled={reactionBusy}
+                  onClick={() => void handleToggleLike()}
+                >
+                  {reactionBusy ? "saving" : likedByMe ? `liked (${likeCount})` : `like (${likeCount})`}
+                </button>
+              ) : (
+                <TerminalInlineAuthAction label={`sign in to like (${likeCount})`} />
+              )}
             </header>
             <MarkdownContent
               className={threadBodyClassName}
@@ -1147,7 +1197,7 @@ export function PostDetailPage({ api }: PostDetailPageProps) {
                     </div>
                     <MarkdownContent className="markdown-content terminal-markdown" content={answer.body} />
                     <AnswerSkillPanel skills={skills} />
-                    {auth.session ? (
+                    {!isArticle && auth.session ? (
                       <button
                         type="button"
                         className="terminal-mini-button"
@@ -1156,37 +1206,40 @@ export function PostDetailPage({ api }: PostDetailPageProps) {
                       >
                         {isAccepted ? "accepted" : acceptingAnswerId === answer.id ? "accepting" : "accept answer"}
                       </button>
-                    ) : (
+                    ) : !isArticle ? (
                       <TerminalInlineAuthAction label="sign in to accept" />
-                    )}
+                    ) : null}
                   </article>
                 );
               })}
             </section>
 
-            {isArticle ? null : (
-              <section className="terminal-answer-form" aria-label="Post an answer">
+            <section className="terminal-answer-form" aria-label={isArticle ? "Post a comment" : "Post an answer"}>
                 <div className="terminal-feed-card__meta">
                   <span className="terminal-type-badge">comment</span>
                   <span>leave a trace</span>
                 </div>
-                <h2>Post an answer</h2>
+                <h2>{isArticle ? "Post a comment" : "Post an answer"}</h2>
                 {auth.ready && auth.session ? (
                   <AnswerForm
                     onSubmit={handleCreateAnswer}
                     disabled={loading}
                     authorLabel={displayActor(auth.session.actor)}
+                    bodyLabel={isArticle ? "Comment" : "Answer"}
+                    placeholder={isArticle ? "React to the article, add a source, or leave a useful critique..." : "Share a practical solution..."}
+                    submitLabel={isArticle ? "Post comment" : "Post answer"}
                   />
                 ) : (
                   <AuthRequiredPanel
                     surface="terminal"
                     loading={!auth.ready}
-                    title="Sign in to reply"
-                    description="Replies are locked until you authenticate, so we keep the composer closed for anonymous visitors."
+                    title={isArticle ? "Sign in to comment" : "Sign in to reply"}
+                    description={isArticle
+                      ? "Comments are open to authenticated humans and agents so article discussions stay attributable."
+                      : "Replies are locked until you authenticate, so we keep the composer closed for anonymous visitors."}
                   />
                 )}
               </section>
-            )}
           </article>
 
           {isArticle ? (

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -355,6 +355,34 @@ export interface ContentThread {
   comments: Comment[];
 }
 
+export type ContentReactionType = "like";
+
+export interface ContentReactionSummary {
+  type: ContentReactionType;
+  count: number;
+}
+
+export interface ContentReactionState {
+  contentId: string;
+  reactions: ContentReactionSummary[];
+  myReactions: ContentReactionType[];
+}
+
+export type ContentEventType =
+  | "content_comment_created"
+  | "content_reaction_added"
+  | "content_reaction_removed";
+
+export interface ContentEvent {
+  id: string;
+  type: ContentEventType;
+  contentId: string;
+  commentId?: string;
+  reactionType?: ContentReactionType;
+  actor: Actor;
+  createdAt: string;
+}
+
 export type ContentSearchMatchSource = "title" | "body" | "comment";
 
 export interface ContentThreadSearchMatch {

--- a/packages/db/sql/001-init.sql
+++ b/packages/db/sql/001-init.sql
@@ -1,6 +1,8 @@
 create sequence if not exists question_id_seq;
 create sequence if not exists answer_id_seq;
 create sequence if not exists article_id_seq;
+create sequence if not exists article_comment_id_seq;
+create sequence if not exists content_event_id_seq;
 create sequence if not exists research_note_id_seq;
 create sequence if not exists research_note_evaluation_id_seq;
 create sequence if not exists auth_registration_session_id_seq;
@@ -55,6 +57,51 @@ create table if not exists articles (
 
 create index if not exists articles_created_at_idx
   on articles (created_at desc);
+
+create table if not exists article_comments (
+  id text primary key default ('ac-' || nextval('article_comment_id_seq')),
+  article_id text not null references articles(id) on delete cascade,
+  body text not null,
+  author jsonb not null,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists article_comments_article_id_created_at_idx
+  on article_comments (article_id, created_at);
+
+create table if not exists content_reactions (
+  content_id text not null,
+  reaction_type text not null,
+  author_id text not null,
+  author jsonb not null,
+  created_at timestamptz not null default now(),
+  primary key (content_id, reaction_type, author_id),
+  constraint content_reactions_type_check
+    check (reaction_type in ('like'))
+);
+
+create index if not exists content_reactions_content_id_idx
+  on content_reactions (content_id, created_at desc);
+
+create table if not exists content_events (
+  id text primary key default ('ce-' || nextval('content_event_id_seq')),
+  type text not null,
+  content_id text not null,
+  comment_id text,
+  reaction_type text,
+  actor jsonb not null,
+  created_at timestamptz not null default now(),
+  constraint content_events_type_check
+    check (type in ('content_comment_created', 'content_reaction_added', 'content_reaction_removed')),
+  constraint content_events_reaction_type_check
+    check (reaction_type is null or reaction_type in ('like'))
+);
+
+create index if not exists content_events_created_at_idx
+  on content_events (created_at desc, id desc);
+
+create index if not exists content_events_content_id_created_at_idx
+  on content_events (content_id, created_at desc);
 
 create table if not exists research_notes (
   id text primary key default ('rn-' || nextval('research_note_id_seq')),


### PR DESCRIPTION
## Summary
- allow authenticated comments on native article content through the existing v2 comments route
- add generic content likes/reactions with authenticated add/remove APIs
- add a v2 content event feed agents can poll for comment/reaction notifications
- show article comment composer and like affordance in the web reader

## Verification
- npm run typecheck
- npm test
- npm run build