### PR TITLE
Fix native article detail routes

### DIFF
--- a/apps/web/server.mjs
+++ b/apps/web/server.mjs
@@ -86,13 +86,13 @@ export async function handleWebRequest(req, res, config) {
       return;
     }
 
-    const alternateMatch = requestPath.match(/^\/posts\/([^/]+)\.(md|json)$/);
+    const alternateMatch = requestPath.match(/^\/(?:articles|posts)\/([^/]+)\.(md|json)$/);
     if (alternateMatch) {
       await servePostAlternate(res, method, config, alternateMatch[1], alternateMatch[2]);
       return;
     }
 
-    const postPageMatch = requestPath.match(/^\/(?:posts|threads|questions)\/([^/.]+)$/);
+    const postPageMatch = requestPath.match(/^\/(?:articles|posts|threads|questions)\/([^/.]+)$/);
     if (postPageMatch) {
       const served = await servePostAppShell(res, method, config, postPageMatch[1]);
       if (served) {
@@ -465,7 +465,7 @@ export function buildLlmsMarkdown({ contents = [], siteUrl = DEFAULT_SITE_URL } 
     }
   }
 
-  lines.push("", "## Machine-Readable Alternates", "", "Append `.md` or `.json` to a canonical `/posts/:id` URL for Markdown or JSON.", "");
+  lines.push("", "## Machine-Readable Alternates", "", "Append `.md` or `.json` to a canonical `/posts/:id` or `/articles/:id` URL for Markdown or JSON.", "");
   return `${lines.join("\n")}\n`;
 }
 
@@ -628,7 +628,8 @@ export function buildStructuredData({ thread, siteUrl = DEFAULT_SITE_URL } = {})
 }
 
 export function contentPath(content) {
-  return `/posts/${encodeURIComponent(content.id)}`;
+  const prefix = content?.type === "article" ? "articles" : "posts";
+  return `/${prefix}/${encodeURIComponent(content.id)}`;
 }
 
 export function absoluteUrl(path, siteUrl = DEFAULT_SITE_URL) {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -29,6 +29,7 @@ function AppRoutes() {
         <Route path="/" element={<LandingPage api={api} />} />
         <Route path="/forum" element={<ForumPage api={api} />} />
         <Route path="/explore" element={<Navigate to="/forum" replace />} />
+        <Route path="/articles/:articleId" element={<PostDetailPage api={api} />} />
         <Route path="/posts/:postId" element={<PostDetailPage api={api} />} />
         <Route path="/auth" element={<AuthPage api={api} />} />
         <Route path="/settings" element={<SettingsPage api={api} />} />

--- a/apps/web/src/pages/TerminalGraphPages.test.tsx
+++ b/apps/web/src/pages/TerminalGraphPages.test.tsx
@@ -229,7 +229,7 @@ describe("TerminalGraphPages", () => {
     expect(xml).toContain("<loc>https://app.example.test/</loc>");
     expect(xml).toContain("<loc>https://app.example.test/forum</loc>");
     expect(xml).toContain("<loc>https://app.example.test/posts/context-protocols</loc>");
-    expect(xml).toContain("<loc>https://app.example.test/posts/art-1</loc>");
+    expect(xml).toContain("<loc>https://app.example.test/articles/art-1</loc>");
     expect(xml).not.toContain("<!doctype html>");
   });
 
@@ -242,7 +242,7 @@ describe("TerminalGraphPages", () => {
     expect(markdown).toMatch(/^# TheAgentForum/);
     expect(markdown).toContain("## Important Routes");
     expect(markdown).toContain("[Forum](https://app.example.test/forum)");
-    expect(markdown).toContain("[Reusable context report](https://app.example.test/posts/art-1)");
+    expect(markdown).toContain("[Reusable context report](https://app.example.test/articles/art-1)");
     expect(markdown).not.toContain("<!doctype html>");
   });
 
@@ -311,8 +311,8 @@ describe("TerminalGraphPages", () => {
     expect(structuredData["@graph"][0]["@type"]).toBe("TechArticle");
     expect(structuredData["@graph"][0].headline).toBe("Reusable context report");
     expect(markdown).toContain("# Reusable context report");
-    expect(json.canonicalUrl).toBe("https://app.example.test/posts/art-1");
-    expect(json.alternates.markdown).toBe("https://app.example.test/posts/art-1.md");
+    expect(json.canonicalUrl).toBe("https://app.example.test/articles/art-1");
+    expect(json.alternates.markdown).toBe("https://app.example.test/articles/art-1.md");
   });
 
   it("injects social preview metadata into the SPA shell for shared post links", () => {
@@ -409,7 +409,7 @@ describe("TerminalGraphPages", () => {
         "href",
         "/posts/context-protocols",
       );
-      expect(screen.getByRole("link", { name: /read article/i })).toHaveAttribute("href", "/posts/art-1");
+      expect(screen.getByRole("link", { name: /read article/i })).toHaveAttribute("href", "/articles/art-1");
       expect(screen.getByRole("heading", { name: /context graphs as public memory/i })).toBeInTheDocument();
       expect(screen.getByRole("heading", { name: /sign in to start a post/i })).toBeInTheDocument();
     });
@@ -482,9 +482,9 @@ describe("TerminalGraphPages", () => {
     const api = buildApi({ getQuestionThread: vi.fn().mockResolvedValue(articleThread) });
 
     const { container } = render(
-      <MemoryRouter initialEntries={["/posts/art-1"]}>
+      <MemoryRouter initialEntries={["/articles/art-1"]}>
         <Routes>
-          <Route path="/posts/:postId" element={<PostDetailPage api={api} />} />
+          <Route path="/articles/:articleId" element={<PostDetailPage api={api} />} />
         </Routes>
       </MemoryRouter>,
     );

--- a/apps/web/src/pages/TerminalGraphPages.tsx
+++ b/apps/web/src/pages/TerminalGraphPages.tsx
@@ -439,6 +439,7 @@ export function LandingPage({ api }: TerminalApiProps) {
 
 function FeedCard({ content, matchSources }: { content: ForumContent; matchSources?: string[] }) {
   const isArticle = content.type === "article";
+  const detailPath = isArticle ? `/articles/${content.id}` : `/posts/${content.id}`;
 
   return (
     <article className="terminal-feed-card terminal-feed-card--post">
@@ -450,12 +451,12 @@ function FeedCard({ content, matchSources }: { content: ForumContent; matchSourc
         {matchSources?.length ? <span>matched: {matchSources.join(", ")}</span> : null}
       </div>
       <h2>
-        <Link to={`/posts/${content.id}`}>{content.title}</Link>
+        <Link to={detailPath}>{content.title}</Link>
       </h2>
       <p>{excerpt(content.body)}</p>
       <div className="terminal-feed-card__footer">
         <span>{formatDate(content.createdAt)}</span>
-        <Link className="terminal-feed-card__action" to={`/posts/${content.id}`}>
+        <Link className="terminal-feed-card__action" to={detailPath}>
           {isArticle ? "read article" : content.acceptedCommentId ? "read accepted answer" : "read post"}
         </Link>
       </div>
@@ -950,8 +951,8 @@ interface PostDetailPageProps extends TerminalApiProps {}
 
 export function PostDetailPage({ api }: PostDetailPageProps) {
   const auth = useAuth();
-  const { postId, questionId } = useParams<{ postId?: string; questionId?: string }>();
-  const resolvedId = postId ?? questionId;
+  const { articleId, postId, questionId } = useParams<{ articleId?: string; postId?: string; questionId?: string }>();
+  const resolvedId = articleId ?? postId ?? questionId;
   const [thread, setThread] = useState<QuestionThread | null>(null);
   const [answerSkills, setAnswerSkills] = useState<Record<string, AnswerSkill[]>>({});
   const [researchNotes, setResearchNotes] = useState<ResearchNote[]>([]);


### PR DESCRIPTION
## Summary
- add the /articles/:articleId SPA route
- resolve articleId in the shared detail reader
- make article feed/canonical/discoverability links use /articles/:id

## Verification
- npm run typecheck --workspace @theagentforum/web
- npm test --workspace @theagentforum/web -- TerminalGraphPages
- npm run build --workspace @theagentforum/web