### PR TITLE
Fix article comments in reader

### DIFF
--- a/apps/web/src/pages/TerminalGraphPages.test.tsx
+++ b/apps/web/src/pages/TerminalGraphPages.test.tsx
@@ -477,9 +477,21 @@ describe("TerminalGraphPages", () => {
         createdAt: "2026-04-25T03:00:00.000Z",
         author: questions[0].author,
       },
-      answers: [],
+      answers: [
+        {
+          id: "ac-1",
+          questionId: "art-1",
+          body: "Helpful article note.",
+          createdAt: "2026-04-25T04:00:00.000Z",
+          author: questions[1].author,
+        },
+      ],
     };
-    const api = buildApi({ getQuestionThread: vi.fn().mockResolvedValue(articleThread) });
+    const listAnswerSkills = vi.fn().mockRejectedValue(new Error("Article comments do not have answer skills."));
+    const api = buildApi({
+      getQuestionThread: vi.fn().mockResolvedValue(articleThread),
+      listAnswerSkills,
+    });
 
     const { container } = render(
       <MemoryRouter initialEntries={["/articles/art-1"]}>
@@ -502,6 +514,7 @@ describe("TerminalGraphPages", () => {
       expect(container.querySelector(".katex")).toBeInTheDocument();
       expect(screen.getByRole("complementary", { name: /article tools/i })).toBeInTheDocument();
       expect(screen.getByRole("heading", { name: /post a comment/i })).toBeInTheDocument();
+      expect(screen.getByText("Helpful article note.")).toBeInTheDocument();
       const toc = screen.getByRole("complementary", { name: /article table of contents/i });
       expect(within(toc).getByRole("link", { name: "Abstract" })).toHaveAttribute("href", "#abstract");
       expect(within(toc).getByRole("link", { name: "Introduction" })).toHaveAttribute("href", "#introduction");
@@ -509,6 +522,7 @@ describe("TerminalGraphPages", () => {
       expect(within(toc).getByRole("link", { name: "Conclusion" })).toHaveAttribute("href", "#conclusion");
       expect(within(toc).getByRole("link", { name: "References" })).toHaveAttribute("href", "#references");
       expect(screen.getByRole("heading", { name: "Abstract" })).toHaveAttribute("id", "abstract");
+      expect(listAnswerSkills).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/web/src/pages/TerminalGraphPages.tsx
+++ b/apps/web/src/pages/TerminalGraphPages.tsx
@@ -983,18 +983,21 @@ export function PostDetailPage({ api }: PostDetailPageProps) {
         api.getQuestionThread(resolvedId),
         api.listResearchNotes(resolvedId),
       ]);
+      const isArticleThread = nextThread.question.id.startsWith("art-");
       setThread(nextThread);
       setResearchNotes(nextNotes);
       setReactionState(await api.listContentReactions(resolvedId));
 
-      const nextSkills = Object.fromEntries(
-        await Promise.all(
-          nextThread.answers.map(async (answer) => [
-            answer.id,
-            await api.listAnswerSkills(nextThread.question.id, answer.id),
-          ]),
-        ),
-      );
+      const nextSkills = isArticleThread
+        ? {}
+        : Object.fromEntries(
+          await Promise.all(
+            nextThread.answers.map(async (answer) => [
+              answer.id,
+              await api.listAnswerSkills(nextThread.question.id, answer.id),
+            ]),
+          ),
+        );
 
       setAnswerSkills(nextSkills);
     } catch (cause) {


### PR DESCRIPTION
## Summary
- skip legacy answer-skill loading for article comment threads
- keep Q&A answer skill loading unchanged
- add a regression test for article pages with comments

## Verification
- npm run typecheck --workspace @theagentforum/web
- npm test --workspace @theagentforum/web -- TerminalGraphPages
- npm run build --workspace @theagentforum/web