### PR TITLE
Fix CLI token actor attribution

### DIFF
--- a/apps/api/src/http.test.ts
+++ b/apps/api/src/http.test.ts
@@ -398,6 +398,7 @@ describe("HTTP API", () => {
 
     assert.equal(inspected.status, 200);
     assert.equal(inspected.body.data.actor.handle, "felix-agent-approval");
+    assert.equal(inspected.body.data.actor.kind, "agent");
     assert.equal(inspected.body.data.deviceLabel, "Codex in browser");
 
     const devices = await requestJson(app, "/auth/devices", {

--- a/apps/api/src/http.v2.test.ts
+++ b/apps/api/src/http.v2.test.ts
@@ -10,7 +10,7 @@ const spoofedHuman = { id: "u-1", kind: "human" as const, handle: "spoofed-human
 const spoofedAgent = { id: "a-1", kind: "agent" as const, handle: "spoofed-agent" };
 
 describe("HTTP API v2 forum", () => {
-  it("accepts paired API bearer tokens for authenticated content writes", async () => {
+  it("accepts paired API bearer tokens as agent actors for authenticated content writes", async () => {
     const authStore = createInMemoryAuthStore();
     const app = createApp(createInMemoryQuestionStore(), authStore);
     const token = await createPairedApiToken(authStore, {
@@ -29,7 +29,25 @@ describe("HTTP API v2 forum", () => {
 
     assert.equal(created.status, 201);
     assert.equal(created.body.data.author.handle, "pixel-bot");
-    assert.equal(created.body.data.author.kind, "human");
+    assert.equal(created.body.data.author.kind, "agent");
+
+    const article = await requestJson(app, "/v2/contents", {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`,
+      },
+      body: {
+        type: "article",
+        title: "Token Article",
+        body: "Created from a paired CLI token.",
+        author: spoofedHuman,
+      },
+    });
+
+    assert.equal(article.status, 201);
+    assert.equal(article.body.data.type, "article");
+    assert.equal(article.body.data.author.handle, "pixel-bot");
+    assert.equal(article.body.data.author.kind, "agent");
   });
 
   it("serves content create->comment->accept flow for questions", async () => {

--- a/apps/api/src/http.webauthn.test.ts
+++ b/apps/api/src/http.webauthn.test.ts
@@ -947,6 +947,7 @@ describe("HTTP API - WebAuthn registration", () => {
     assert.equal(replied.status, 201);
     const commentId = replied.body.data.comments[0].id as string;
     assert.equal(replied.body.data.comments[0].author.handle, "launch-smoke");
+    assert.equal(replied.body.data.comments[0].author.kind, "agent");
 
     const accepted = await requestJson(app, `/v2/contents/${contentId}/accept/${commentId}`, {
       method: "POST",
@@ -966,6 +967,7 @@ describe("HTTP API - WebAuthn registration", () => {
 
     assert.equal(tokenSession.status, 200);
     assert.equal(tokenSession.body.data.actor.handle, "launch-smoke");
+    assert.equal(tokenSession.body.data.actor.kind, "agent");
     assert.equal(tokenSession.body.data.deviceLabel, "launch-smoke-cli");
   });
 

--- a/apps/api/src/memory-auth-store.ts
+++ b/apps/api/src/memory-auth-store.ts
@@ -371,7 +371,7 @@ export function createInMemoryAuthStore(): AuthStore {
     const approvedAt = new Date().toISOString();
     session.status = "paired";
     session.accountId = account.id;
-    session.actor = createStoredActor(account);
+    session.actor = createStoredActor(account, "agent");
     session.deviceLabel = input.deviceLabel?.trim() || session.deviceLabel;
     session.token = createToken();
     session.approvedAt = approvedAt;
@@ -628,7 +628,7 @@ export function createInMemoryAuthStore(): AuthStore {
     });
 
     return {
-      actor: createStoredActor(account),
+      actor: createStoredActor(account, "agent"),
       createdAt: session.pairing.createdAt,
       expiresAt: session.pairing.expiresAt,
       deviceLabel: session.pairing.deviceLabel,
@@ -966,10 +966,10 @@ function isAuthenticatablePasskey(credential: StoredCredential): boolean {
   return !credential.credentialId.startsWith("manual-");
 }
 
-function createStoredActor(account: StoredAccount): Actor {
+function createStoredActor(account: StoredAccount, kind: Actor["kind"] = "human"): Actor {
   return {
     id: account.id,
-    kind: "human",
+    kind,
     handle: account.handle,
     displayName: account.displayName,
   };

--- a/apps/api/src/postgres-auth-store.ts
+++ b/apps/api/src/postgres-auth-store.ts
@@ -1269,7 +1269,7 @@ function apiTokenSessionSelect(pairingAlias: string, accountAlias: string): stri
   return `json_build_object(
     'actor', json_strip_nulls(json_build_object(
       'id', ${accountAlias}.id,
-      'kind', 'human',
+      'kind', 'agent',
       'handle', ${accountAlias}.handle,
       'displayName', ${accountAlias}.display_name
     )),
@@ -1286,7 +1286,7 @@ function agentPairingSessionSelect(
   const actorExpression = accountAlias
     ? `json_strip_nulls(json_build_object(
       'id', ${accountAlias}.id,
-      'kind', 'human',
+      'kind', 'agent',
       'handle', ${accountAlias}.handle,
       'displayName', ${accountAlias}.display_name
     ))`


### PR DESCRIPTION
## Summary
- treat paired API bearer-token sessions as `agent` actors in both memory and Postgres auth stores
- keep browser web sessions as `human` actors
- add regression coverage for bearer-token article creation ignoring spoofed request authors and persisting the token actor as agent

## Tests
- `npm test --workspace @theagentforum/api`
- `npm run typecheck`
